### PR TITLE
Added All Poloniex USDT Pairs

### DIFF
--- a/plugins/poloniex/exchange.json
+++ b/plugins/poloniex/exchange.json
@@ -9,7 +9,7 @@
       "min_size":0.01,
       "max_size":10000,
       "increment":0.01,
-      "label":"BTC/USDT"
+      "label":"USDT/BTC"
     },
     {
       "id":"USDT_DASH",

--- a/plugins/poloniex/exchange.json
+++ b/plugins/poloniex/exchange.json
@@ -3,6 +3,87 @@
   "rest_url": "https://poloniex.com/public",
   "products": [
     {
+      "id":"USDT_BTC",
+      "asset":"BTC",
+      "currency":"USDT",
+      "min_size":0.01,
+      "max_size":10000,
+      "increment":0.01,
+      "label":"BTC/USDT"
+    },
+    {
+      "id":"USDT_DASH",
+      "asset":"DASH",
+      "currency":"USDT",
+      "min_size":0.01,
+      "max_size":10000,
+      "increment":0.01,
+      "label":"USDT/DASH"
+    },
+    {
+      "id":"USDT_ETC",
+      "asset":"ETC",
+      "currency":"USDT",
+      "min_size":0.01,
+      "max_size":10000,
+      "increment":0.01,
+      "label":"USDT/ETC"
+    },
+    {
+      "id":"USDT_ETH",
+      "asset":"ETH",
+      "currency":"USDT",
+      "min_size":0.01,
+      "max_size":100000,
+      "increment":0.01,
+      "label":"USDT/ETH"
+    },
+    {
+      "id":"USDT_LTC",
+      "asset":"LTC",
+      "currency":"USD",
+      "min_size":0.01,
+      "max_size":10000,
+      "increment":0.01,
+      "label":"USDT/LTC"
+    },
+    {
+      "id":"USDT_NXT",
+      "asset":"NXT",
+      "currency":"USDT",
+      "min_size":0.01,
+      "max_size":100000,
+      "increment":0.01,
+      "label":"USDT/NXT"
+    },
+    {
+      "id":"USDT_STR",
+      "asset":"STR",
+      "currency":"USDT",
+      "min_size":0.01,
+      "max_size":100000,
+      "increment":0.01,
+      "label":"USDT/STR"
+    },
+    {
+      "id":"USDT_XMR",
+      "asset":"XMR",
+      "currency":"USDT",
+      "min_size":0.01,
+      "max_size":100000,
+      "increment":0.01,
+      "label":"USDT/XMR"
+    },
+    {
+      "id":"USDT_XRP",
+      "asset":"XRP",
+      "currency":"USDT",
+      "min_size":0.01,
+      "max_size":100000,
+      "increment":0.01,
+      "label":"USDT/XRP"
+    },
+    {
       "id":"BTC_1CR",
       "asset":"1CR",
       "currency":"BTC",
@@ -2084,15 +2165,6 @@
       "max_size":10000,
       "increment":0.01,
       "label":"BTC/USDE"
-    },
-    {
-      "id":"USDT_BTC",
-      "asset":"BTC",
-      "currency":"USDT",
-      "min_size":0.01,
-      "max_size":10000,
-      "increment":0.01,
-      "label":"BTC/USDT"
     },
     {
       "id":"BTC_UTC",


### PR DESCRIPTION
I've added all the USDT pairs for Poloniex. I'm working on getting Poloniex live trading implemented but it still needs a lot of testing since there is no 'market' price option in the Poloniex API and while I've been able to connect and place orders I am running into trouble getting the orders to actually fill instead of just placing an order and hoping it gets filled. If the buy/sell query doesn't completely fill orders and just sits there it will cause zenbot to only see the remaining balance (5% of total balance with zenbot's 95% trade defaults or whatever balance is remaining). I will probably end up having to tweak some things and have the trade logic look at the orderbooks and modify sitting orders.

I'm currently testing the 'fillOrKill', 'immediateOrCancel', and 'postOnly' parameters to figure out the most reliable method. I am also running into some errors with the nonce value (probably due to async) that Poloniex API requires but I should be able to figure that out.

Any suggestions would be much appreciated :)
