### PR TITLE
docker-compose: do not expose mongodb by default!

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ server:
 
 mongodb:
   image: mongo:latest
-  ports:
-    - "27017:27017"
   volumes_from:
     - mongodb-data
   command: mongod --smallfiles


### PR DESCRIPTION
This is a pretty important detail for people using docker-compose to deploy their bot on online servers (without default firewall).

There is really no need to expose mongodb at all, since we are internally linking.

I could imagine there are quite a few installations that are currently exposing their mongodb to the outside world, unknowingly.