### PR TITLE
docker-compose: Restart node

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ server:
   links:
     - mongodb
   command: ./zenbot.sh trade
+  restart: always
 
 mongodb:
   image: mongo:latest


### PR DESCRIPTION
I didn't keep an eye on my bot for a few days only to discover it died a painful death (503 by GDAX being down) without restarting.
Adding `restart: always` should tell docker(-compose) to restart the docker if it stopped for whatever reason.

There might be a case to be made to have `restart: on-failure` but I couldn't think of one.