### PR TITLE
Bittrex: extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Zenbot is a hobby project for me and I'm sorry that I can't devote myself full-t
 Zenbot is a command-line cryptocurrency trading bot using Node.js and MongoDB. It features:
 
 - Fully-automated [technical-analysis](http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:introduction_to_technical_indicators_and_oscillators)-based trading approach
-- Full support for [GDAX](https://gdax.com/), [Poloniex](https://poloniex.com) and [Kraken](https://kraken.com/), work on further exchange support is ongoing.
+- Full support for [GDAX](https://gdax.com/), [Poloniex](https://poloniex.com), [Kraken](https://kraken.com/) and [Bittrex](https://bittrex.com/), work on further exchange support is ongoing.
 - Plugin architecture for implementing exchange support, or writing new strategies
 - Simulator for [Backtesting strategies](https://gist.github.com/carlos8f/b09a734cf626ffb9bb3bcb1ca35f3db4) against historical data
 - "Paper" trading mode, operates on a simulated balance while watching the live market

--- a/commands/backfill.js
+++ b/commands/backfill.js
@@ -113,7 +113,7 @@ module.exports = function container (get, set, clear) {
                 console.error('\nerror: getTrades() returned duplicate results')
                 console.error(opts)
                 console.error(last_batch_opts)
-                process.exit(1)
+                process.exit(0)
               }
               last_batch_id = trades[0].trade_id
               var tasks = trades.map(function (trade) {

--- a/conf-sample.js
+++ b/conf-sample.js
@@ -35,6 +35,15 @@ c.kraken.secret = 'YOUR-SECRET'
 // Please read API TOS on https://www.kraken.com/u/settings/api
 c.kraken.tosagree = 'disagree'
 
+// to enable Bittrex trading, enter your API credentials:
+c.bittrex = {}
+c.bittrex.key = 'YOUR-API-KEY'
+c.bittrex.secret = 'YOUR-SECRET'
+// make sure to give your API key access to only: "Trade Limit" and "Read Info",
+// please note that this might change in the future.
+// please note that bittrex API is limited, you cannot use backfills or sims (paper/live trading only)
+
+
 // Optional stop-order triggers:
 
 // sell if price drops below this % of bought price (0 to disable)

--- a/extensions/exchanges/bittrex/_codemap.js
+++ b/extensions/exchanges/bittrex/_codemap.js
@@ -1,0 +1,6 @@
+module.exports = {
+  _ns: 'zenbot',
+
+  'exchanges.bittrex': require('./exchange'),
+  'exchanges.list[]': '#exchanges.bittrex'
+}

--- a/extensions/exchanges/bittrex/exchange.js
+++ b/extensions/exchanges/bittrex/exchange.js
@@ -1,0 +1,289 @@
+var bittrex_authed = require('node.bittrex.api'),
+    bittrex_public = require('node.bittrex.api'),
+    path = require('path'),
+    moment = require('moment'),
+    n = require('numbro'),
+    colors = require('colors')
+
+
+/**
+ ** Bittrex API
+ ** 
+ ** please note: unfortunately getmarkethistory does not work based on time
+ ** this means that we cannot do any backfilles, but paper trading should be fine
+ ** https://github.com/n0mad01/node.bittrex.api/issues/17
+ **
+ **/
+module.exports = function container(get, set, clear) {
+  var c = get('conf')
+  var recoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|Invalid nonce|Rate limit exceeded)/)
+  var shownWarning = false
+
+  bittrex_authed.options({
+    'apikey' : c.bittrex.key.trim(),
+    'apisecret' : c.bittrex.secret.trim()
+  })
+
+  function joinProduct(product_id) {
+    return product_id.split('-')[0] + '-' + product_id.split('-')[1]
+  }
+
+  function retry(method, args, error) {
+    if (error.message.match(/Rate limit exceeded/)) {
+      var timeout = 10000
+    } else {
+      var timeout = 2500
+    }
+
+    console.error(('\Bittrex API error - unable to call ' + method + ' (' + error + '), retrying in ' + timeout / 1000 + 's').red)
+    setTimeout(function () {
+      exchange[method].apply(exchange, args)
+    }, timeout)
+  }
+
+  var orders = {}
+
+  var exchange = {
+    name: 'bittrex',
+    historyScan: 'forward',
+    makerFee: 0.25,
+
+    getProducts: function () {
+      return require('./products.json')
+    },
+
+    getTrades: function (opts, cb) {
+      var func_args = [].slice.call(arguments)
+      var args = {
+        market: joinProduct(opts.product_id)
+      }
+
+      bittrex_public.getmarkethistory(args, function( data ) {
+        if (!shownWarning) {
+          console.log('please note: do not be alarmed if you see an error "returned duplicate results"')
+          console.log('please note: the bittrex api does not support backfilling (trade/paper only).')
+          console.log('please note: make sure to set the --period=1m to make sure data for trade/paper is fetched.')
+          shownWarning = true
+        }
+        if (typeof data !== 'object') {
+          console.log('bittrex API (getmarkethistory) had an abnormal response, quitting.')
+          return cb(null, [])
+        }
+
+        if(!data.success) {
+          if (data.message.match(recoverableErrors)) {
+            return retry('getTrades', func_args, data.message)
+          }
+          console.log(data.message)
+          return cb(null, [])
+        }
+
+        var trades = []
+        Object.keys(data.result).forEach(function (i) {
+          var trade = data.result[i]
+          trades.push({
+            trade_id: trade.Id,
+            time: moment(trade.TimeStamp).valueOf(),
+            size: parseFloat(trade.Quantity),
+            price: parseFloat(trade.Price),
+            side: trade.OrderType == 'BUY' ? 'buy' : 'sell'
+          })
+        })
+        cb(null, trades)
+      })
+    },
+
+    getBalance: function (opts, cb) {
+      var args = [].slice.call(arguments)
+
+      bittrex_authed.getbalances(function( data ) {
+        if (typeof data !== 'object') {
+          console.log('bittrex API (getbalances) had an abnormal response, quitting.')
+          return cb(null, [])
+        }
+
+        if(!data.success) {
+          if (data.message.match(recoverableErrors)) {
+            return retry('getBalance', args, data.message)
+          }
+          console.log(data.message)
+          return cb(null, [])
+        }
+
+        var balance = {
+          asset: 0,
+          currency: 0
+        }
+        Object.keys(data.result).forEach(function (i) {
+          var _balance = data.result[i]
+          if (_balance['Currency'] === opts.currency.toUpperCase()) {
+            balance.currency = n(_balance.Available).format('0.00000000'),
+              balance.currency_hold = 0
+          }
+          if (_balance['Currency'] === opts.asset.toUpperCase()) {
+            balance.asset = n(_balance.Available).format('0.00000000'),
+              balance.asset_hold = 0
+          }
+        })
+        cb(null, balance)
+      })
+    },
+
+    getQuote: function (opts, cb) {
+      var args = {
+        market: joinProduct(opts.product_id)
+      }
+      bittrex_public.getticker(args, function( data ) {
+        if (typeof data !== 'object') {
+          console.log('bittrex API (getticker) had an abnormal response, quitting.')
+          return cb(null, [])
+        }
+
+        if(!data.success) {
+          if (data.message.match(recoverableErrors)) {
+            return retry('getQuote', args, data.message)
+          }
+          console.log(data.message)
+          return cb(null, [])
+        }
+
+        cb(null, {
+          bid: data.result.Bid,
+          ask: data.result.Ask
+        })
+      })
+    },
+
+    cancelOrder: function (opts, cb) {
+      var args = [].slice.call(arguments)
+      bittrex_authed.cancel({
+        uuid: opts.order_id
+      }, function( data ) {
+        if (typeof data !== 'object') {
+          console.log('bittrex API (cancel) had an abnormal response, quitting.')
+          return cb(null, [])
+        }
+
+        if('error' in data || !data.success) {
+          console.log(data.error)
+          console.log(data.message)
+          return cb(null, [])
+        }
+
+        cb(null)
+      })
+    },
+
+    trade: function (type, opts, cb) {
+      var args = [].slice.call(arguments)
+
+      var params = {
+        market: joinProduct(opts.product_id),
+        quantity: opts.size,
+        rate: opts.price
+      }
+
+      if(!'order_type' in opts) {
+        opts.order_type = 'limit'
+      }
+
+      var fn = function(data) {
+        if (typeof data !== 'object') {
+          console.log('bittrex API (trade) had an abnormal response, quitting.')
+          return cb(null, [])
+        }
+
+        if(!data.success) {
+          if (data.message.match(recoverableErrors)) {
+            return retry('trade', args, data.message)
+          }
+          console.log(data.message)
+          return cb(null, [])
+        }
+
+        var order = {
+          id: data && data.result ? data.result.uuid : null,
+          status: 'open',
+          price: opts.price,
+          size: opts.size,
+          post_only: !!opts.post_only,
+          created_at: new Date().getTime(),
+          filled_size: '0',
+          ordertype: opts.order_type
+        }
+
+        orders['~' + data.result.uuid] = order
+        cb(null, order)
+      }
+
+      if (type === 'buy') {
+        if (opts.order_type === 'limit') {
+          bittrex_authed.buylimit(params, fn)
+        }
+        if (opts.order_type === 'market') {
+          bittrex_authed.buymarket(params, fn)
+        }
+      } 
+      if (type === 'sell') {
+        if (opts.order_type === 'limit') {
+          bittrex_authed.selllimit(params, fn)
+        }
+        if (opts.order_type === 'market') {
+          bittrex_authed.sellmarket(params, fn)
+        }
+      }
+    },
+
+    buy: function (opts, cb) {
+      exchange.trade('buy', opts, cb)
+    },
+
+    sell: function (opts, cb) {
+      exchange.trade('sell', opts, cb)
+    },
+
+    getOrder: function (opts, cb) {
+      var args = [].slice.call(arguments)
+      var order = orders['~' + opts.order_id]
+      if (!order) return cb(new Error('order not found in cache'))
+      var params = {
+        uuid: opts.order_id
+      }
+      bittrex_authed.getorder(params, function (data) {
+        if (typeof data !== 'object') {
+          console.log('bittrex API (getorder) had an abnormal response, quitting.')
+          return cb(null, [])
+        }
+
+        if(!data.success) {
+          if (data.message.match(recoverableErrors)) {
+            return retry('getOrder', args, data.message)
+          }
+          console.log(data.message)
+          return cb(null, [])
+        }
+
+        var orderData = data.result
+
+        if (!orderData) {
+          return cb('Order not found')
+        }
+
+        if (orderData.IsOpen === false) {
+          order.status = 'done'
+          order.done_at = new Date().getTime()
+          order.filled_size = parseFloat(orderData.Quantity) - parseFloat(orderData.QuantityRemaining)
+          return cb(null, order)
+        }
+
+        cb(null, order)
+      })
+    },
+
+    // return the property used for range querying.
+    getCursor: function (trade) {
+      return Math.floor((trade.time || trade) / 1000)
+    }
+  }
+  return exchange
+}

--- a/extensions/exchanges/bittrex/products.json
+++ b/extensions/exchanges/bittrex/products.json
@@ -1,0 +1,1381 @@
+[
+  {
+    "asset": "BTC",
+    "currency": "LTC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/LTC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "DOGE",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/DOGE"
+  },
+  {
+    "asset": "BTC",
+    "currency": "VTC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/VTC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "PPC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/PPC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "FTC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/FTC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "RDD",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/RDD"
+  },
+  {
+    "asset": "BTC",
+    "currency": "NXT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/NXT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "DASH",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/DASH"
+  },
+  {
+    "asset": "BTC",
+    "currency": "POT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/POT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BLK",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BLK"
+  },
+  {
+    "asset": "BTC",
+    "currency": "EMC2",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/EMC2"
+  },
+  {
+    "asset": "BTC",
+    "currency": "MYR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/MYR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "AUR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/AUR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "EFL",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/EFL"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GLD",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GLD"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SLR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SLR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "PTC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/PTC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GRS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GRS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "NLG",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/NLG"
+  },
+  {
+    "asset": "BTC",
+    "currency": "RBY",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/RBY"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XWC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XWC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "MONA",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/MONA"
+  },
+  {
+    "asset": "BTC",
+    "currency": "THC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/THC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ENRG",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ENRG"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ERC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ERC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "NAUT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/NAUT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "VRC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/VRC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "CURE",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/CURE"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XBB",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XBB"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XMR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XMR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "CLOAK",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/CLOAK"
+  },
+  {
+    "asset": "BTC",
+    "currency": "START",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/START"
+  },
+  {
+    "asset": "BTC",
+    "currency": "KORE",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/KORE"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XDN",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XDN"
+  },
+  {
+    "asset": "BTC",
+    "currency": "QTL",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/QTL"
+  },
+  {
+    "asset": "BTC",
+    "currency": "TRUST",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/TRUST"
+  },
+  {
+    "asset": "BTC",
+    "currency": "NAV",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/NAV"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XST",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XST"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BTCD",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BTCD"
+  },
+  {
+    "asset": "BTC",
+    "currency": "VIA",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/VIA"
+  },
+  {
+    "asset": "BTC",
+    "currency": "UNO",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/UNO"
+  },
+  {
+    "asset": "BTC",
+    "currency": "PINK",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/PINK"
+  },
+  {
+    "asset": "BTC",
+    "currency": "IOC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/IOC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "CANN",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/CANN"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SYS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SYS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "NEOS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/NEOS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "DGB",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/DGB"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BURST",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BURST"
+  },
+  {
+    "asset": "BTC",
+    "currency": "EXCL",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/EXCL"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SWIFT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SWIFT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "DOPE",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/DOPE"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BLOCK",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BLOCK"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ABY",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ABY"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BYC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BYC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XMG",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XMG"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BLITZ",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BLITZ"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BAY",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BAY"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BTS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BTS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "FAIR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/FAIR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SPR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SPR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "VTR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/VTR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XRP",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XRP"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GAME",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GAME"
+  },
+  {
+    "asset": "BTC",
+    "currency": "COVAL",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/COVAL"
+  },
+  {
+    "asset": "BTC",
+    "currency": "NXS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/NXS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XCP",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XCP"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SJCX",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SJCX"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BITB",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BITB"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GEO",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GEO"
+  },
+  {
+    "asset": "BTC",
+    "currency": "FLDC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/FLDC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "WBB",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/WBB"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GRC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GRC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "FLO",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/FLO"
+  },
+  {
+    "asset": "BTC",
+    "currency": "NBT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/NBT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "MUE",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/MUE"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XEM",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XEM"
+  },
+  {
+    "asset": "BTC",
+    "currency": "8BIT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/8BIT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "CLAM",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/CLAM"
+  },
+  {
+    "asset": "BTC",
+    "currency": "DMD",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/DMD"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GAM",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GAM"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SPHR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SPHR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "OK",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/OK"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SNRG",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SNRG"
+  },
+  {
+    "asset": "BTC",
+    "currency": "PKB",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/PKB"
+  },
+  {
+    "asset": "BTC",
+    "currency": "CPC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/CPC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "AEON",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/AEON"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ETH",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ETH"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GCR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GCR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "TX",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/TX"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BCY",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BCY"
+  },
+  {
+    "asset": "BTC",
+    "currency": "EXP",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/EXP"
+  },
+  {
+    "asset": "BTC",
+    "currency": "INFX",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/INFX"
+  },
+  {
+    "asset": "BTC",
+    "currency": "OMNI",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/OMNI"
+  },
+  {
+    "asset": "BTC",
+    "currency": "AMP",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/AMP"
+  },
+  {
+    "asset": "BTC",
+    "currency": "AGRS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/AGRS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XLM",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XLM"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BTA",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BTA"
+  },
+  {
+    "asset": "USDT",
+    "currency": "BTC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "USDT/BTC"
+  },
+  {
+    "asset": "BITCNY",
+    "currency": "BTC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BITCNY/BTC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "CLUB",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/CLUB"
+  },
+  {
+    "asset": "BTC",
+    "currency": "VOX",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/VOX"
+  },
+  {
+    "asset": "BTC",
+    "currency": "EMC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/EMC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "FCT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/FCT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "MAID",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/MAID"
+  },
+  {
+    "asset": "BTC",
+    "currency": "EGC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/EGC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SLS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SLS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "RADS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/RADS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "DCR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/DCR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SEC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SEC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BSD",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BSD"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XVG",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XVG"
+  },
+  {
+    "asset": "BTC",
+    "currency": "PIVX",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/PIVX"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XVC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XVC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "MEME",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/MEME"
+  },
+  {
+    "asset": "BTC",
+    "currency": "STEEM",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/STEEM"
+  },
+  {
+    "asset": "BTC",
+    "currency": "2GIVE",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/2GIVE"
+  },
+  {
+    "asset": "BTC",
+    "currency": "LSK",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/LSK"
+  },
+  {
+    "asset": "BTC",
+    "currency": "PDC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/PDC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BRK",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BRK"
+  },
+  {
+    "asset": "BTC",
+    "currency": "DGD",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/DGD"
+  },
+  {
+    "asset": "ETH",
+    "currency": "DGD",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/DGD"
+  },
+  {
+    "asset": "BTC",
+    "currency": "WAVES",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/WAVES"
+  },
+  {
+    "asset": "BTC",
+    "currency": "RISE",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/RISE"
+  },
+  {
+    "asset": "BTC",
+    "currency": "LBC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/LBC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SBD",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SBD"
+  },
+  {
+    "asset": "BTC",
+    "currency": "BRX",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/BRX"
+  },
+  {
+    "asset": "BTC",
+    "currency": "DRACO",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/DRACO"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ETC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ETC"
+  },
+  {
+    "asset": "ETH",
+    "currency": "ETC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/ETC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "STRAT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/STRAT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "UNB",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/UNB"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SYNX",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SYNX"
+  },
+  {
+    "asset": "BTC",
+    "currency": "TRIG",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/TRIG"
+  },
+  {
+    "asset": "BTC",
+    "currency": "EBST",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/EBST"
+  },
+  {
+    "asset": "BTC",
+    "currency": "VRM",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/VRM"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SEQ",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SEQ"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XAUR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XAUR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SNGLS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SNGLS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "JWL",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/JWL"
+  },
+  {
+    "asset": "BTC",
+    "currency": "REP",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/REP"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SHIFT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SHIFT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ARDR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ARDR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "XZC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/XZC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ANS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ANS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ZEC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ZEC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ZCL",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ZCL"
+  },
+  {
+    "asset": "BTC",
+    "currency": "IOP",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/IOP"
+  },
+  {
+    "asset": "BTC",
+    "currency": "DAR",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/DAR"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GOLOS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GOLOS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "HKG",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/HKG"
+  },
+  {
+    "asset": "BTC",
+    "currency": "UBQ",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/UBQ"
+  },
+  {
+    "asset": "BTC",
+    "currency": "KMD",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/KMD"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GBG",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GBG"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SIB",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SIB"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ION",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ION"
+  },
+  {
+    "asset": "BTC",
+    "currency": "LMC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/LMC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "QWARK",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/QWARK"
+  },
+  {
+    "asset": "BTC",
+    "currency": "CRW",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/CRW"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SWT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SWT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "TIME",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/TIME"
+  },
+  {
+    "asset": "BTC",
+    "currency": "MLN",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/MLN"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ARK",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ARK"
+  },
+  {
+    "asset": "BTC",
+    "currency": "DYN",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/DYN"
+  },
+  {
+    "asset": "BTC",
+    "currency": "TKS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/TKS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "MUSIC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/MUSIC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "DTB",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/DTB"
+  },
+  {
+    "asset": "BTC",
+    "currency": "INCNT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/INCNT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GBYTE",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GBYTE"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GNT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GNT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "NXC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/NXC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "EDG",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/EDG"
+  },
+  {
+    "asset": "BTC",
+    "currency": "LGD",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/LGD"
+  },
+  {
+    "asset": "BTC",
+    "currency": "TRST",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/TRST"
+  },
+  {
+    "asset": "ETH",
+    "currency": "GNT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/GNT"
+  },
+  {
+    "asset": "ETH",
+    "currency": "REP",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/REP"
+  },
+  {
+    "asset": "USDT",
+    "currency": "ETH",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "USDT/ETH"
+  },
+  {
+    "asset": "ETH",
+    "currency": "WINGS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/WINGS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "WINGS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/WINGS"
+  },
+  {
+    "asset": "BTC",
+    "currency": "RLC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/RLC"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GNO",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GNO"
+  },
+  {
+    "asset": "BTC",
+    "currency": "GUP",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/GUP"
+  },
+  {
+    "asset": "BTC",
+    "currency": "LUN",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/LUN"
+  },
+  {
+    "asset": "ETH",
+    "currency": "GUP",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/GUP"
+  },
+  {
+    "asset": "ETH",
+    "currency": "RLC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/RLC"
+  },
+  {
+    "asset": "ETH",
+    "currency": "LUN",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/LUN"
+  },
+  {
+    "asset": "ETH",
+    "currency": "SNGLS",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/SNGLS"
+  },
+  {
+    "asset": "ETH",
+    "currency": "GNO",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/GNO"
+  },
+  {
+    "asset": "BTC",
+    "currency": "APX",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/APX"
+  },
+  {
+    "asset": "UBQ",
+    "currency": "APX",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "UBQ/APX"
+  },
+  {
+    "asset": "BTC",
+    "currency": "TKN",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/TKN"
+  },
+  {
+    "asset": "ETH",
+    "currency": "TKN",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/TKN"
+  },
+  {
+    "asset": "BTC",
+    "currency": "HMQ",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/HMQ"
+  },
+  {
+    "asset": "ETH",
+    "currency": "HMQ",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/HMQ"
+  },
+  {
+    "asset": "BTC",
+    "currency": "ANT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/ANT"
+  },
+  {
+    "asset": "ETH",
+    "currency": "TRST",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/TRST"
+  },
+  {
+    "asset": "ETH",
+    "currency": "ANT",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "ETH/ANT"
+  },
+  {
+    "asset": "BTC",
+    "currency": "SC",
+    "min_size": "0.01",
+    "increment": "0.00000001",
+    "label": "BTC/SC"
+  }
+]

--- a/extensions/exchanges/bittrex/update-products.sh
+++ b/extensions/exchanges/bittrex/update-products.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+var bittrex = require('node.bittrex.api')
+
+var mapping
+var products = []
+
+function addProduct(base, quote, altname) {
+    products.push({
+        asset: base,
+        currency: quote,
+        min_size: '0.01',
+        increment: '0.00000001',
+        label: base + '/' + quote
+    })
+}
+
+bittrex.getmarkets(function (data) {
+    if(typeof data !== 'object') {
+        console.log('bittrex API had an abnormal response, quitting.')
+        process.exit(1)
+    }
+    if('error' in data || !data.success) {
+        console.log(data.error)
+        console.log(data.message)
+        process.exit(1)
+    }
+    else {
+        mapping = data.result
+
+        mapping = data.result
+
+        Object.keys(data.result).forEach(function (result) {
+            addProduct(data.result[result].BaseCurrency, data.result[result].MarketCurrency, data.result[result].altname)
+        })
+        var target = require('path').resolve(__dirname, 'products.json')
+        require('fs').writeFileSync(target, JSON.stringify(products, null, 2))
+        console.log('wrote', target)
+        process.exit()
+    }
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,789 @@
+{
+  "name": "zenbot4",
+  "version": "4.0.5",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "asn1": {
+      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+    },
+    "assertion-error": {
+      "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+    },
+    "async": {
+      "version": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+      "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM="
+    },
+    "aws-sign2": {
+      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+    },
+    "aws4": {
+      "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "balanced-match": {
+      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+    },
+    "bcrypt-pbkdf": {
+      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true
+    },
+    "bintrees": {
+      "version": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.0.tgz",
+      "integrity": "sha1-nqCaZnLBE0tejEMToT5HzKloxyA="
+    },
+    "bl": {
+      "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g="
+    },
+    "boom": {
+      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+    },
+    "brace-expansion": {
+      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+    },
+    "bson": {
+      "version": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
+      "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
+    },
+    "buffer-shims": {
+      "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
+    "caseless": {
+      "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+    },
+    "chai": {
+      "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc="
+    },
+    "chalk": {
+      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+    },
+    "codemap": {
+      "version": "https://registry.npmjs.org/codemap/-/codemap-1.3.1.tgz",
+      "integrity": "sha1-00p9ul87UQS2WkUQ4jGPqWbP3rk="
+    },
+    "colors": {
+      "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+    },
+    "combined-stream": {
+      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+    },
+    "commander": {
+      "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
+    },
+    "concat-map": {
+      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "core-util-is": {
+      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+    },
+    "ctype": {
+      "version": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+      "optional": true
+    },
+    "dashdash": {
+      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "debug": {
+      "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+    },
+    "deep-eql": {
+      "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dependencies": {
+        "type-detect": {
+          "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+        }
+      }
+    },
+    "deep-equal": {
+      "version": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "delayed-stream": {
+      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
+    "ecc-jsbn": {
+      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true
+    },
+    "es6-promise": {
+      "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
+    },
+    "escape-string-regexp": {
+      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE="
+    },
+    "extend": {
+      "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+    },
+    "forever-agent": {
+      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+      "dependencies": {
+        "async": {
+          "version": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
+          "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c="
+        },
+        "lodash": {
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
+      }
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
+    "fs.realpath": {
+      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "gdax": {
+      "version": "https://registry.npmjs.org/gdax/-/gdax-0.4.2.tgz",
+      "integrity": "sha1-jo0GIi7Zfl40l11W9R6/SaVvqHI="
+    },
+    "generate-function": {
+      "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+    },
+    "generate-object-property": {
+      "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
+    },
+    "getpass": {
+      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "glob": {
+      "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU="
+    },
+    "graceful-readlink": {
+      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "har-validator": {
+      "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0="
+    },
+    "has-ansi": {
+      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+    },
+    "hawk": {
+      "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+    },
+    "hoek": {
+      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "http-signature": {
+      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+    },
+    "idgen": {
+      "version": "https://registry.npmjs.org/idgen/-/idgen-2.0.2.tgz",
+      "integrity": "sha1-ZFpO6n7bUz2UH1jt2UMVVUWPwqg="
+    },
+    "inflight": {
+      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+    },
+    "inherits": {
+      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "int": {
+      "version": "https://registry.npmjs.org/int/-/int-0.1.1.tgz",
+      "integrity": "sha1-18efL4PP9QXTXoaYD4H6FPM4ekw="
+    },
+    "is-my-json-valid": {
+      "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM="
+    },
+    "is-property": {
+      "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-typedarray": {
+      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isstream": {
+      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jodid25519": {
+      "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+      "optional": true
+    },
+    "jsbn": {
+      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-stringify-safe": {
+      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    },
+    "jsonpointer": {
+      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o="
+    },
+    "jsprim": {
+      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "kraken-api": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/kraken-api/-/kraken-api-0.1.7.tgz",
+      "integrity": "sha1-t1JDXmkXunHZ5zSl/tP6WWFiLeg="
+    },
+    "lodash": {
+      "version": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+      "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA="
+    },
+    "lodash._arrayeach": {
+      "version": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
+    },
+    "lodash._baseassign": {
+      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4="
+    },
+    "lodash._basecopy": {
+      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._baseeach": {
+      "version": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+      "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM="
+    },
+    "lodash._baseslice": {
+      "version": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-3.0.3.tgz",
+      "integrity": "sha1-qkrj3FPu1TsI3i4zYrOTV7XIfXU="
+    },
+    "lodash._bindcallback": {
+      "version": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+    },
+    "lodash._createassigner": {
+      "version": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE="
+    },
+    "lodash._createwrapper": {
+      "version": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.2.0.tgz",
+      "integrity": "sha1-30U+ZkFjIXuJWkVAZa8cR6DqPE0="
+    },
+    "lodash._getnative": {
+      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash._replaceholders": {
+      "version": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz",
+      "integrity": "sha1-iru3EmxDH37XRPe6rznwi8m9nVg="
+    },
+    "lodash._root": {
+      "version": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+    },
+    "lodash.assign": {
+      "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
+      "integrity": "sha1-93SdFYCkEgJzo3H1SmaxTJ1yJvo="
+    },
+    "lodash.foreach": {
+      "version": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.0.tgz",
+      "integrity": "sha1-HbUp13oExYxS8YbxTeMucEPog6Q="
+    },
+    "lodash.isarguments": {
+      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
+    },
+    "lodash.partial": {
+      "version": "https://registry.npmjs.org/lodash.partial/-/lodash.partial-3.0.0.tgz",
+      "integrity": "sha1-H6mgMweqKDu41PFave4PL0AJCpY="
+    },
+    "lodash.restparam": {
+      "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+    },
+    "micro-request": {
+      "version": "https://registry.npmjs.org/micro-request/-/micro-request-666.0.10.tgz",
+      "integrity": "sha1-oannMhcBT01AGqH+Vp6NdReB1yY="
+    },
+    "mime": {
+      "version": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+    },
+    "mime-db": {
+      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+    },
+    "mime-types": {
+      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+    },
+    "minimatch": {
+      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM="
+    },
+    "minimist": {
+      "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mkdirp": {
+      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dependencies": {
+        "minimist": {
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "moment": {
+      "version": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+    },
+    "mongodb": {
+      "version": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.27.tgz",
+      "integrity": "sha1-NBIgNNtm2YO89qta2yaiSnD+9uY=",
+      "dependencies": {
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE="
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg="
+        }
+      }
+    },
+    "mongodb-core": {
+      "version": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.11.tgz",
+      "integrity": "sha1-HDh3bOsXSZepnCiGDu2QKNqbPho="
+    },
+    "ms": {
+      "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nock": {
+      "version": "https://registry.npmjs.org/nock/-/nock-3.6.0.tgz",
+      "integrity": "sha1-0mxAAEs0SaZVuRt0rjxW/ALIRSU="
+    },
+    "node-uuid": {
+      "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "node.bittrex.api": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/node.bittrex.api/-/node.bittrex.api-0.2.5.tgz",
+      "integrity": "sha1-rtkKEr/U9kgYQbScXA+e7MC5RtE="
+    },
+    "nonce": {
+      "version": "https://registry.npmjs.org/nonce/-/nonce-1.0.4.tgz",
+      "integrity": "sha1-7nMCrejBvvR28wG4yR9cxRpIdhI="
+    },
+    "num": {
+      "version": "https://registry.npmjs.org/num/-/num-0.2.1.tgz",
+      "integrity": "sha1-Agqy79KldZ5VA5HivFoEwnifWNo="
+    },
+    "number-abbreviate": {
+      "version": "https://registry.npmjs.org/number-abbreviate/-/number-abbreviate-2.0.0.tgz",
+      "integrity": "sha1-6cstGNuADhU88HKClVPEr+DfeJg="
+    },
+    "numbro": {
+      "version": "git+https://github.com/carlos8f/numbro.git#e6e9a0d5f4c32939a7c19cf1546c7766b38cd31f",
+      "integrity": "sha1-SQHFyg42RNFIir4rPQE2lJT9e6I="
+    },
+    "oauth-sign": {
+      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "once": {
+      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+    },
+    "options": {
+      "version": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "path-is-absolute": {
+      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU="
+    },
+    "pinkie": {
+      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+    },
+    "poloniex.js": {
+      "version": "https://registry.npmjs.org/poloniex.js/-/poloniex.js-0.0.7.tgz",
+      "integrity": "sha1-B0crcBZtztjjaI0eqI7+3ZBrKeU=",
+      "dependencies": {
+        "asn1": {
+          "version": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+          "optional": true
+        },
+        "async": {
+          "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+          "optional": true
+        },
+        "boom": {
+          "version": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+          "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs="
+        },
+        "combined-stream": {
+          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+          "optional": true
+        },
+        "cryptiles": {
+          "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+          "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+          "optional": true
+        },
+        "forever-agent": {
+          "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+          "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+        },
+        "form-data": {
+          "version": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+          "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+          "optional": true
+        },
+        "hawk": {
+          "version": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+          "integrity": "sha1-uQuxaYByhUEdp//LjdJZhQLTtS0=",
+          "optional": true
+        },
+        "hoek": {
+          "version": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+        },
+        "http-signature": {
+          "version": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+          "optional": true
+        },
+        "oauth-sign": {
+          "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+          "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
+          "optional": true
+        },
+        "qs": {
+          "version": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+          "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
+        },
+        "request": {
+          "version": "https://registry.npmjs.org/request/-/request-2.33.0.tgz",
+          "integrity": "sha1-UWeHgTFyYHDsYzdS6iMKI3ncZf8="
+        },
+        "sntp": {
+          "version": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+          "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
+          "integrity": "sha1-rWgbaPUyGtKCfEz7G31d8s/pQu4=",
+          "optional": true
+        }
+      }
+    },
+    "process-nextick-args": {
+      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "propagate": {
+      "version": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
+      "integrity": "sha1-46hEBKfs6CDda76p9tkk4xNa4Jw="
+    },
+    "punycode": {
+      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+      "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "readable-stream": {
+      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44="
+    },
+    "request": {
+      "version": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+      "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs="
+    },
+    "require_optional": {
+      "version": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+      "integrity": "sha1-UqhhN6hJco62ClVTNhf4+RT1mr8="
+    },
+    "resolve-from": {
+      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+    },
+    "run-parallel": {
+      "version": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
+      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk="
+    },
+    "run-series": {
+      "version": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
+      "integrity": "sha1-iac93F51ye+KtjIMChYA1qQRebk="
+    },
+    "safe-buffer": {
+      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+    },
+    "semver": {
+      "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+    },
+    "sntp": {
+      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+    },
+    "sosa": {
+      "version": "https://registry.npmjs.org/sosa/-/sosa-1.1.3.tgz",
+      "integrity": "sha1-iCLCvrXbzwl/w2NQpC5k09tdE4k="
+    },
+    "sosa_mongo": {
+      "version": "https://registry.npmjs.org/sosa_mongo/-/sosa_mongo-1.0.3.tgz",
+      "integrity": "sha1-zSy6BNSpZXJ1vQfcAKuCmeAm7VE="
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8="
+    },
+    "sshpk": {
+      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ="
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringstream": {
+      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+    },
+    "supports-color": {
+      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "timebucket": {
+      "version": "https://registry.npmjs.org/timebucket/-/timebucket-0.4.0.tgz",
+      "integrity": "sha1-2H9xqMhrjqq95zX3qcSzJc6ZhXw="
+    },
+    "tough-cookie": {
+      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+    },
+    "tunnel-agent": {
+      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+    },
+    "tweetnacl": {
+      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-detect": {
+      "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+    },
+    "ultron": {
+      "version": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "util-deprecate": {
+      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "verror": {
+      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+    },
+    "wrappy": {
+      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+      "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg="
+    },
+    "xtend": {
+      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "zero-fill": {
+      "version": "https://registry.npmjs.org/zero-fill/-/zero-fill-2.2.3.tgz",
+      "integrity": "sha1-o97wa6XjmuZEhQu0yirUEStIVek="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "minimist": "^1.2.0",
     "moment": "^2.18.1",
     "mongodb": "^2.2.25",
+    "node.bittrex.api": "^0.2.5",
     "number-abbreviate": "^2.0.0",
     "numbro": "git+https://github.com/carlos8f/numbro.git",
     "poloniex.js": "0.0.7",


### PR DESCRIPTION
This PR adds support for the bittrex api:
https://bittrex.com/home/api

There's a big limitation in how their API has been adjusted recently, it means we cannot get historical data. I've attempted to make it as clear as possible everywhere that paper/live trading is the only option for now (with bittrex).


![screenshot_2017-06-03_09-32-00](https://cloud.githubusercontent.com/assets/777823/26751693/ce6c34ac-483f-11e7-8fd2-4fa3b20d6e1f.png)