### PR TITLE
Fix up/downtrend thresholds MACD

### DIFF
--- a/extensions/macd/strategy.js
+++ b/extensions/macd/strategy.js
@@ -52,9 +52,9 @@ module.exports = function container (get, set, clear) {
       }
 
       if (typeof s.period.macd_histogram === 'number' && typeof s.lookback[0].macd_histogram === 'number') {
-        if (s.period.macd_histogram > s.options.up_trend_threshold && s.lookback[0].macd_histogram <= 0) {
+        if (s.period.macd_histogram > s.options.up_trend_threshold && (s.lookback[0].macd_histogram - s.options.up_trend_threshold) <= 0) {
           s.signal = 'buy';
-        } else if (s.period.macd_histogram < -s.options.down_trend_threshold && s.lookback[0].macd_histogram >= 0) {
+        } else if (s.period.macd_histogram < -s.options.down_trend_threshold && (s.lookback[0].macd_histogram + s.options.down_trend_threshold) >= 0) {
           s.signal = 'sell';
         } else {
           s.signal = null;  // hold

--- a/extensions/macd/strategy.js
+++ b/extensions/macd/strategy.js
@@ -52,9 +52,9 @@ module.exports = function container (get, set, clear) {
       }
 
       if (typeof s.period.macd_histogram === 'number' && typeof s.lookback[0].macd_histogram === 'number') {
-        if (s.period.macd_histogram > s.options.up_trend_threshold && (s.lookback[0].macd_histogram - s.options.up_trend_threshold) <= 0) {
+        if ((s.period.macd_histogram - s.options.up_trend_threshold) > 0 && (s.lookback[0].macd_histogram - s.options.up_trend_threshold) <= 0) {
           s.signal = 'buy';
-        } else if (s.period.macd_histogram < -s.options.down_trend_threshold && (s.lookback[0].macd_histogram + s.options.down_trend_threshold) >= 0) {
+        } else if ((s.period.macd_histogram + s.options.down_trend_threshold) < 0 && (s.lookback[0].macd_histogram + s.options.down_trend_threshold) >= 0) {
           s.signal = 'sell';
         } else {
           s.signal = null;  // hold


### PR DESCRIPTION
The thresholds were only reacting on the first period of the MACD trend. After this they did not respond as the last period was already positive or negative.

With this it will take the threshold in consideration as well.