### PR TITLE
Remove full memory dump for Loss/slippage protection

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -7,6 +7,8 @@ var tb = require('timebucket')
   , abbreviate = require('number-abbreviate')
   , readline = require('readline')
 
+var nice_errors = new RegExp(/(slippage protection|loss protection)/)
+
 module.exports = function container (get, set, clear) {
   var c = get('conf')
   return function (s) {
@@ -333,7 +335,9 @@ module.exports = function container (get, set, clear) {
           if (_cb) {
             _cb(err)
           }
-          else {
+          else if (err.message.match(nice_errors)) {
+            console.error((err.message + ': ' + err.desc).red)
+          } else {
             memDump()
             console.error('\n')
             console.error(err)


### PR DESCRIPTION
Added Regex filter for 'nice errors'.

only filters slippage and loss protection errors to stop a full memory dump. any other error will still do a full memory dump.

Filtered errors will output 1 line with err.message and err.desc:
slippage protection: refusing to buy at 203.12 ZEUR ZEUR, slippage of +0.0%