### PR TITLE
Adjusted glob (more structure in extensions possible)

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -18,14 +18,12 @@ module.exports = function (cb) {
   zenbot.set('@zenbot:conf', c)
 
   function withMongo () {
-    glob('extensions/*', {cwd: __dirname, absolute: true}, function (err, results) {
+    //searches all directorys in {workingdir}/extensions/ for files called '_codemap.js'
+    glob('extensions/**/_codemap.js', {cwd: __dirname, absolute: true}, function (err, results) {
       if (err) return cb(err)
       results.forEach(function (result) {
-        if (path.basename(result) === 'README.md') {
-          return
-        }
-        var ext = require(path.join(result, '_codemap'))
-        zenbot.use(ext)
+        var ext = require(result) //load the _codemap for the extension
+        zenbot.use(ext)           //load the extension into zenbot
       })
       cb(null, zenbot)
     })


### PR DESCRIPTION
Adjusted the glob pattern to search recursive and already search for the _codemap.js file.

This made the following function a lot simpler as glob does al the work for us.

With this change the structure inside the \extensions\ folder does not matter anymore.

please note: I did not include the structure change in the extensions folder yet. as it might mess up the git if they are changed before this goes through.
i would recommend one of the maintainers change the file structure after this is merged. 
This solution does not break the current structure.