### PR TITLE
Don't default to live trading

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -106,7 +106,7 @@ module.exports = function container (get, set, clear) {
                 if (so.mode === 'paper') {
                   console.log('!!! Paper mode enabled. No real trades are performed until you remove --paper from the startup command.')
                 }
-		engine.syncBalance(function (err) {
+                engine.syncBalance(function (err) {
                   if (err) {
                     if (err.desc) console.error(err.desc)
                     if (err.body) console.error(err.body)

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -103,7 +103,10 @@ module.exports = function container (get, set, clear) {
               if (err) throw err
               if (!trades.length) {
                 console.log('---------------------------- STARTING ' + so.mode.toUpperCase() + ' TRADING ----------------------------')
-                engine.syncBalance(function (err) {
+                if (so.mode === 'paper') {
+                  console.log('!!! Paper mode enabled. No real trades are performed until you remove --paper from the startup command.')
+                }
+		engine.syncBalance(function (err) {
                   if (err) {
                     if (err.desc) console.error(err.desc)
                     if (err.body) console.error(err.body)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ server:
     - /app/node_modules
   links:
     - mongodb
-  command: ./zenbot.sh trade
+  command: ./zenbot.sh trade --paper
   restart: always
 
 mongodb:


### PR DESCRIPTION
Following the README instructions getting started it is not clear that running docker-compose up will fire up the bot in live trading mode and could be a real surprise to new users starting things up for the first time.

This PR defaults it to start in paper mode.

Fixes #232 