### PR TITLE
Parabolic SAR strategy

### DIFF
--- a/extensions/strategies/sar/_codemap.js
+++ b/extensions/strategies/sar/_codemap.js
@@ -1,0 +1,6 @@
+module.exports = {
+  _ns: 'zenbot',
+
+  'strategies.sar': require('./strategy'),
+  'strategies.list[]': '#strategies.sar'
+}

--- a/extensions/strategies/sar/strategy.js
+++ b/extensions/strategies/sar/strategy.js
@@ -1,0 +1,94 @@
+var z = require('zero-fill')
+  , n = require('numbro')
+
+module.exports = function container (get, set, clear) {
+  return {
+    name: 'sar',
+    description: 'Buy when (EMA - last(EMA) > 0) and sell when (EMA - last(EMA) < 0). Optional buy on low RSI.',
+
+    getOptions: function () {
+      this.option('period', 'period length', String, '5m')
+      this.option('min_periods', 'min. number of history periods', Number, 52)
+      this.option('sar_af', 'acceleration factor for parabolic SAR', Number, 0.025)
+      this.option('sar_max_af', 'max acceleration factor for parabolic SAR', Number, 0.55)
+    },
+
+    calculate: function (s) {
+      if (s.lookback.length >= s.options.min_periods) {
+        if (!s.trend) {
+          if (s.period.high > s.lookback[s.lookback.length - 1].high) {
+            // start with uptrend
+            s.trend = 'up'
+            s.sar = Math.min(s.lookback[1].low, s.lookback[0].low)
+            s.sar_ep = s.period.high
+            s.sar_af = s.options.sar_af
+            for (var idx = 0; idx < s.lookback.length; idx++) {
+              s.sar_ep = Math.max(s.sar_ep, s.lookback[idx].high)
+            }
+          }
+          else {
+            s.trend = 'down'
+            s.sar = Math.max(s.lookback[1].high, s.lookback[0].high)
+            s.sar_ep = s.period.low
+            s.sar_af = s.options.sar_af
+            for (var idx = 0; idx < s.lookback.length; idx++) {
+              s.sar_ep = Math.min(s.sar_ep, s.lookback[idx].low)
+            }
+          }
+        }
+      }
+    },
+
+    onPeriod: function (s, cb) {
+      if (typeof s.sar === 'number') {
+        if (s.trend === 'up') {
+          s.sar = Math.min(s.lookback[1].low, s.lookback[0].low, s.sar + (s.sar_af * (s.sar_ep - s.sar)))
+        }
+        else {
+          s.sar = Math.max(s.lookback[1].high, s.lookback[0].high, s.sar - (s.sar_af * (s.sar - s.sar_ep)))
+        }
+        if (s.trend === 'down') {
+          if (s.period.high >= s.sar) {
+            s.trend = 'up'
+            s.signal = 'buy'
+            s.sar_ep = s.period.low
+            s.sar_af = s.options.sar_af
+          }
+          else if (s.period.low < s.sar_ep && s.sar_af < s.options.sar_max_af) {
+            s.sar_ep = s.period.low
+            s.sar_af += s.options.sar_af
+          }
+        }
+        else if (s.trend === 'up') {
+          if (s.period.low <= s.sar) {
+            s.trend = 'down'
+            s.signal = 'sell'
+            s.sar_ep = s.period.high
+            s.sar_af = s.options.sar_af
+          }
+          else if (s.period.high > s.sar_ep && s.sar_af < s.options.sar_max_af) {
+            s.sar_ep = s.period.high
+            s.sar_af += s.options.sar_af
+          }
+        }
+      }
+      cb()
+    },
+
+    onReport: function (s) {
+      var cols = []
+      if (typeof s.sar === 'number') {
+        if (s.trend === 'up') {
+          cols.push(z(8, n(s.sar).subtract(s.period.close).divide(s.period.close).format('0.00%'), ' ').green)
+        }
+        else {
+          cols.push(z(8, n(s.sar).subtract(s.period.close).divide(s.period.close).format('0.00%'), ' ').red)
+        }
+      }
+      else {
+        cols.push('                  ')
+      }
+      return cols
+    }
+  }
+}

--- a/extensions/strategies/sar/strategy.js
+++ b/extensions/strategies/sar/strategy.js
@@ -7,7 +7,7 @@ module.exports = function container (get, set, clear) {
     description: 'Parabolic SAR',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '5m')
+      this.option('period', 'period length', String, '1m')
       this.option('min_periods', 'min. number of history periods', Number, 52)
       this.option('sar_af', 'acceleration factor for parabolic SAR', Number, 0.025)
       this.option('sar_max_af', 'max acceleration factor for parabolic SAR', Number, 0.55)

--- a/extensions/strategies/sar/strategy.js
+++ b/extensions/strategies/sar/strategy.js
@@ -4,7 +4,7 @@ var z = require('zero-fill')
 module.exports = function container (get, set, clear) {
   return {
     name: 'sar',
-    description: 'Buy when (EMA - last(EMA) > 0) and sell when (EMA - last(EMA) < 0). Optional buy on low RSI.',
+    description: 'Parabolic SAR',
 
     getOptions: function () {
       this.option('period', 'period length', String, '5m')

--- a/extensions/strategies/sar/strategy.js
+++ b/extensions/strategies/sar/strategy.js
@@ -78,15 +78,7 @@ module.exports = function container (get, set, clear) {
     onReport: function (s) {
       var cols = []
       if (typeof s.sar === 'number') {
-        if (s.trend === 'up') {
-          cols.push(z(8, n(s.sar).subtract(s.period.close).divide(s.period.close).format('0.00%'), ' ').green)
-        }
-        else {
-          cols.push(z(8, n(s.sar).subtract(s.period.close).divide(s.period.close).format('0.00%'), ' ').red)
-        }
-      }
-      else {
-        cols.push('                  ')
+        cols.push(z(8, n(s.sar).subtract(s.period.close).divide(s.period.close).format('0.00%'), ' ').grey)
       }
       return cols
     }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -295,8 +295,8 @@ module.exports = function container (get, set, clear) {
                   var mid_price = n(quote.ask).add(quote.bid).divide(2)
                   if (type === 'buy') {
                     marked_price = n(mid_price).subtract(n(mid_price).multiply(so.markup_pct / 100)).format(s.product.increment, Math.floor)
-                    msg(marked_price + ' vs our ' + order.price)
                     if (n(order.price).value() < marked_price) {
+                      msg(marked_price + ' vs our ' + order.price)
                       cancelOrder(true)
                     }
                     else {
@@ -306,8 +306,8 @@ module.exports = function container (get, set, clear) {
                   }
                   else {
                     marked_price = n(mid_price).add(n(mid_price).multiply(so.markup_pct / 100)).format(s.product.increment, Math.ceil)
-                    msg(marked_price + ' vs our ' + order.price)
                     if (n(order.price).value() > marked_price) {
+                      msg(marked_price + ' vs our ' + order.price)
                       cancelOrder(true)
                     }
                     else {


### PR DESCRIPTION
@DeviaVir adding back the SAR strat, tweaked the settings a bit and getting good sim results:

```
the-batcomp:zenbot morpheus.5250$ zenbot sim gdax.eth-usd --days 10 --strategy=sar --period=1m
2017-06-08 12:11:28  253.73 ETH-USD   -0.1%       14    --        -0.06%   bought  9.79 ETH    24.84 USD  +150.9%  +73.5%
{
  "asset_capital": 0,
  "buy_pct": 99,
  "buy_stop_pct": 0,
  "currency_capital": 1000,
  "days": 10,
  "markup_pct": 0,
  "max_sell_loss_pct": 25,
  "max_slippage_pct": 5,
  "min_periods": 52,
  "mode": "sim",
  "order_adjust_time": 10000,
  "period": "1m",
  "profit_stop_enable_pct": 0,
  "profit_stop_pct": 1,
  "rsi_periods": 14,
  "sar_af": 0.025,
  "sar_max_af": 0.55,
  "selector": "gdax.ETH-USD",
  "sell_pct": 99,
  "sell_stop_pct": 0,
  "start": 1496016000000,
  "stats": false,
  "strategy": "sar",
  "verbose": false
}
end balance: 2511.68408604 (151.17%)
buy hold: 1447.50940385 (44.75%)
vs. buy hold: 73.52%
2011 trades over 11 days (avg 182.82 trades/day)
win/loss: 966/1045
error rate: 51.96%
```

It seems to work best with aggressive trading, so would probably only be an option for 0% fee exchanges.... currently testing this on GDAX with parallel paper trading to see if 1m period is practical.