### PR TITLE
Calculate balance: translate assets/currency to something else

### DIFF
--- a/commands/balance.js
+++ b/commands/balance.js
@@ -10,6 +10,7 @@ module.exports = function container (get, set, clear) {
       .allowUnknownOption()
       .description('get asset and currency balance from the exchange')
       //.option('--all', 'output all balances')
+      .option('-c, --calculate_currency <calculate_currency>', 'show the full balance in another currency')
       .option('--debug', 'output detailed debug info')
       .action(function (selector, cmd) {
         var s = {options: minimist(process.argv)}
@@ -29,15 +30,33 @@ module.exports = function container (get, set, clear) {
         so.debug = cmd.debug
         function balance () {
           s.exchange.getBalance(s, function (err, balance) {
-            if (err) throw err
+            if (err) return cb(err)
             s.exchange.getQuote(s, function (err, quote) {
               if (err) throw err
               var bal = (s.product_id + ' Asset: ').grey + balance.asset.white + ' Currency: '.grey + balance.currency.yellow + ' Total: '.grey + n(balance.asset).multiply(quote.ask).add(balance.currency).value().toString().yellow
               console.log(bal)
-              process.exit()
+
+              if (so.calculate_currency) {
+                s.exchange.getQuote({'product_id': s.asset + '-' + so.calculate_currency}, function (err, asset_quote) {
+                  if (err)  throw err
+
+                  s.exchange.getQuote({'product_id': s.currency + '-' + so.calculate_currency}, function (err, currency_quote) {
+                    if (err)  throw err
+                    var asset_total = balance.asset * asset_quote.bid
+                    var currency_total = balance.currency * currency_quote.bid
+                    console.log((so.calculate_currency + ': ').grey + (asset_total + currency_total))
+
+                    process.exit()
+                  })
+                })
+              }
+              else {
+                process.exit()
+              }
             })
           })
         }
+
         balance()
       })
   }

--- a/extensions/exchanges/gdax/exchange.js
+++ b/extensions/exchanges/gdax/exchange.js
@@ -6,11 +6,13 @@ var Gdax = require('gdax')
 module.exports = function container (get, set, clear) {
   var c = get('conf')
 
-  var public_client, authed_client
+  var public_client = {}, authed_client
 
   function publicClient (product_id) {
-    if (!public_client) public_client = new Gdax.PublicClient(product_id, c.gdax.apiURI)
-    return public_client
+    if (!public_client[product_id]) {
+      public_client[product_id] = new Gdax.PublicClient(product_id, c.gdax.apiURI)
+    }
+    return public_client[product_id]
   }
 
   function authedClient () {


### PR DESCRIPTION
I'm usually trading ETH-BTC, which means I need to do somewhat complex things to translate it into EUR (my fiat). This PR makes that a hell of a lot easier.

sample:

```
$ ./zenbot.sh balance gdax.ETH-BTC --calculate_currency=EUR 
ETH-BTC Asset: 5.4099392900000000 Currency: 0.0048659300700954
EUR: 1494.486289398647
```