### PR TITLE
xmpp for trading alarms

### DIFF
--- a/conf-sample.js
+++ b/conf-sample.js
@@ -101,3 +101,18 @@ c.rsi_periods = 14
 c.balance_snapshot_period = '15m'
 // avg. amount of slippage to apply to sim trades
 c.avg_slippage_pct = 0.045
+
+//xmpp configs
+
+c.xmpp = require('simple-xmpp');
+
+c.xmpp.connect({
+                jid                    : 'trader@domain.com', //xmpp account trader bot
+                password               : 'Password',          //xmpp password
+                host                   : 'domain.com',        //xmpp domain
+                port                   : 5222                 //xmpp port
+});
+
+c.xmppto="MeMyselfAndI@domain.com" //xmpp alert to friend
+//end xmpp configs
+

--- a/conf-sample.js
+++ b/conf-sample.js
@@ -104,15 +104,20 @@ c.avg_slippage_pct = 0.045
 
 //xmpp configs
 
-c.xmpp = require('simple-xmpp');
+c.xmppon=0  // 0 xmpp disabled; 1 xmpp enabled (credentials should be correct)
 
-c.xmpp.connect({
+if (c.xmppon) {
+
+  c.xmpp = require('simple-xmpp');
+
+  c.xmpp.connect({
                 jid                    : 'trader@domain.com', //xmpp account trader bot
                 password               : 'Password',          //xmpp password
                 host                   : 'domain.com',        //xmpp domain
                 port                   : 5222                 //xmpp port
-});
+  });
 
-c.xmppto="MeMyselfAndI@domain.com" //xmpp alert to friend
+  c.xmppto="MeMyselfAndI@domain.com" //xmpp alert to friend
+}
 //end xmpp configs
 

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -180,6 +180,9 @@ module.exports = function container (get, set, clear) {
             if (err) return cb(err)
             s.start_price = n(quote.ask).value()
             s.start_capital = n(s.balance.currency).add(n(s.balance.asset).multiply(quote.ask)).value()
+            
+            c.xmpp.send(c.xmppto,'Balance: ' + s.start_capital + '\n') // xmpp
+            
             cb()
           })
         }
@@ -423,6 +426,9 @@ module.exports = function container (get, set, clear) {
               }
               else {
                 //console.log('\nplacing buy order at ' + fc(price) + ', ' + fc(quote.bid - Number(price)) + ' under best bid\n')
+                
+                c.xmpp.send(c.xmppto,'placing buy order at ' + fc(price) + ', ' + fc(quote.bid - Number(price)) + ' under best bid\n')
+                
                 doOrder()
               }
             }
@@ -464,6 +470,8 @@ module.exports = function container (get, set, clear) {
                 }
                 else {
                   //console.log('\nplacing sell order at ' + fc(price) + ', ' + fc(Number(price) - quote.bid) + ' over best ask\n')
+                  c.xmpp.send(c.xmppto,'placing sell order at ' + fc(price) + ', ' + fc(Number(price) - quote.bid) + ' over best ask\n')
+                  
                   doOrder()
                 }
               }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -181,7 +181,7 @@ module.exports = function container (get, set, clear) {
             s.start_price = n(quote.ask).value()
             s.start_capital = n(s.balance.currency).add(n(s.balance.asset).multiply(quote.ask)).value()
             
-            c.xmpp.send(c.xmppto,'Balance: ' + s.start_capital + '\n') // xmpp
+            if (c.xmppon) c.xmpp.send(c.xmppto,'Balance: ' + s.start_capital + '\n') // xmpp
             
             cb()
           })
@@ -427,7 +427,7 @@ module.exports = function container (get, set, clear) {
               else {
                 //console.log('\nplacing buy order at ' + fc(price) + ', ' + fc(quote.bid - Number(price)) + ' under best bid\n')
                 
-                c.xmpp.send(c.xmppto,'placing buy order at ' + fc(price) + ', ' + fc(quote.bid - Number(price)) + ' under best bid\n')
+                if (c.xmppon) c.xmpp.send(c.xmppto,'placing buy order at ' + fc(price) + ', ' + fc(quote.bid - Number(price)) + ' under best bid\n')
                 
                 doOrder()
               }
@@ -470,7 +470,7 @@ module.exports = function container (get, set, clear) {
                 }
                 else {
                   //console.log('\nplacing sell order at ' + fc(price) + ', ' + fc(Number(price) - quote.bid) + ' over best ask\n')
-                  c.xmpp.send(c.xmppto,'placing sell order at ' + fc(price) + ', ' + fc(Number(price) - quote.bid) + ' over best ask\n')
+                  if (c.xmppon) c.xmpp.send(c.xmppto,'placing sell order at ' + fc(price) + ', ' + fc(Number(price) - quote.bid) + ' over best ask\n')
                   
                   doOrder()
                 }


### PR DESCRIPTION
Added optional account set-up and buy/sell alarms with XMPP. Needs simple-xmpp and 2 XMPP server accounts: one for sending the trader messages and one for receiving them.

Considering two way functionality to disable/reenable live trading while running