### PR TITLE
Enhance backtester: support peroid, min_peroids param and rsi_macd strategy

### DIFF
--- a/scripts/auto_backtester/backtester.js
+++ b/scripts/auto_backtester/backtester.js
@@ -72,6 +72,7 @@ let objectProduct = obj => {
 let runCommand = (strategy, cb) => {
   countArr.push(1);
   let strategyArgs = {
+    rsi_macd: `--rsi_periods=${strategy.rsi_periods} --srsi_periods=${strategy.srsi_periods} --srsi_k=${strategy.srsi_k} --srsi_d=${strategy.srsi_d} --oversold_rsi=${strategy.oversold_rsi} --overbought_rsi=${strategy.overbought_rsi} --ema_short_period=${strategy.ema_short_period} --ema_long_period=${strategy.ema_long_period} --signal_period=${strategy.signal_period} --up_trend_threshold=${strategy.up_trend_threshold} --down_trend_threshold=${strategy.down_trend_threshold}`,
     macd: `--ema_short_period=${strategy.ema_short_period} --ema_long_period=${strategy.ema_long_period} --signal_period=${strategy.signal_period} --up_trend_threshold=${strategy.up_trend_threshold} --down_trend_threshold=${strategy.down_trend_threshold} --overbought_rsi_periods=${strategy.overbought_rsi_periods} --overbought_rsi=${strategy.overbought_rsi}`,
     rsi: `--rsi_periods=${strategy.rsi_periods} --oversold_rsi=${strategy.oversold_rsi} --overbought_rsi=${strategy.overbought_rsi} --rsi_recover=${strategy.rsi_recover} --rsi_drop=${strategy.rsi_drop} --rsi_divisor=${strategy.rsi_divisor}`,
     sar: `--sar_af=${strategy.sar_af} --sar_max_af=${strategy.sar_max_af}`,
@@ -126,6 +127,19 @@ let processOutput = output => {
     losses:             losses,
     errorRate:          parseFloat(errorRate),
 
+    // rsi_macd
+    rsiPeriods:         params.rsi_periods,
+    srsiPeriods:        params.srsi_periods,
+    srsiK:              params.srsi_k,
+    srsiD:              params.srsi_d,
+    oversoldRsi:        params.oversold_rsi,
+    overboughtRsi:      params.overbought_rsi,
+    emaShortPeriod:     params.ema_short_period,
+    emaLongPeriod:      params.ema_long_period,
+    signalPeriod:       params.signal_period,
+    upTrendThreshold:   params.up_trend_threshold,
+    downTrendThreshold: params.down_trend_threshold,
+
     // macd
     emaShortPeriod:     params.ema_short_period,
     emaLongPeriod:      params.ema_long_period,
@@ -167,6 +181,21 @@ let processOutput = output => {
 };
 
 let strategies = {
+  rsi_macd: objectProduct({
+    period: ['30m'],
+    min_periods: [52, 200],
+    rsi_periods: [14, 20],
+    srsi_periods: [14, 20],
+    srsi_k: [3, 9],
+    srsi_d: [3, 9],
+    oversold_rsi: [18],
+    overbought_rsi: [82],
+    ema_short_period: [12, 24],
+    ema_long_period: [26, 200],
+    signal_period: [9, 14],
+    up_trend_threshold: [0],
+    down_trend_threshold: [0]
+  }),
   macd: objectProduct({
     period: ['1h'],
     min_periods: [52],
@@ -240,6 +269,7 @@ parallel(tasks, PARALLEL_LIMIT, (err, results) => {
   let filedsGeneral = ['roi', 'vsBuyHold', 'errorRate', 'wlRatio', 'frequency', 'endBalance', 'buyHold', 'wins', 'losses', 'period', 'min_periods', 'days'];
   let filedNamesGeneral = ['ROI (%)', 'VS Buy Hold (%)', 'Error Rate (%)', 'Win/Loss Ratio', '# Trades/Day', 'Ending Balance ($)', 'Buy Hold ($)', '# Wins', '# Losses', 'Period', 'Min Periods', '# Days'];
   let fields = {
+    rsi_macd: filedsGeneral.concat(['rsiPeriods', 'srsiPeriods', 'srsiK', 'srsiD', 'oversoldRsi', 'overboughtRsi', 'emaShortPeriod', 'emaLongPeriod', 'signalPeriod', 'upTrendThreshold', 'downTrendThreshold', 'params']),
     macd: filedsGeneral.concat([ 'emaShortPeriod', 'emaLongPeriod', 'signalPeriod', 'upTrendThreshold', 'downTrendThreshold', 'overboughtRsiPeriods', 'overboughtRsi', 'params']),
     rsi: filedsGeneral.concat(['rsiPeriods', 'oversoldRsi', 'overboughtRsi', 'rsiRecover', 'rsiDrop', 'rsiDivsor', 'params']),
     sar: filedsGeneral.concat(['sarAf', 'sarMaxAf', 'params']),
@@ -247,6 +277,7 @@ parallel(tasks, PARALLEL_LIMIT, (err, results) => {
     trend_ema: filedsGeneral.concat(['trendEma', 'neutralRate', 'oversoldRsiPeriods', 'oversoldRsi', 'params'])
   };
   let fieldNames = {
+    rsi_macd: filedNamesGeneral.concat(['RSI Periods', 'SRSI Periods', 'SRSI K', 'SRSI D', 'Oversold RSI', 'Overbought RSI', 'EMA Short Period', 'EMA Long Period', 'Signal Period', 'Up Trend Threshold', 'Down Trend Threshold', 'Full Parameters']),
     macd: filedNamesGeneral.concat(['EMA Short Period', 'EMA Long Period', 'Signal Period', 'Up Trend Threshold', 'Down Trend Threshold', 'Overbought Rsi Periods', 'Overbought Rsi', 'Full Parameters']),
     rsi: filedNamesGeneral.concat(['RSI Periods', 'Oversold RSI', 'Overbought RSI', 'RSI Recover', 'RSI Drop', 'RSI Divisor', 'Full Parameters']),
     sar: filedNamesGeneral.concat(['SAR AF', 'SAR MAX AF', 'Full Parameters']),


### PR DESCRIPTION
The new added `rsi_macd` strategy set `min_peroids` to 200 as default value which is different than others, so I support it in backtester firstly.

BTW, looks `srsi_macd` is a better name than `rsi_macd` for it use Stochastic RSI in fact...