### PR TITLE
simple fix for correct asset display

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -79,7 +79,7 @@ module.exports = function container (get, set, clear) {
     }
 
     function isFiat () {
-      return !s.currency.match(/^BTC|ETH|XMR|USDT$/)
+      return !s.currency.match(/^BTC|ETH|XMR|USD|USDT$/)
     }
 
     var max_fc_width = 0


### PR DESCRIPTION
before fix: 
```
zenbot balance --debug bitfinex.xrp-usd
2017-07-09 05:57:33 0.24 XRP-USD Asset: 1190.00000000 Currency: 0.75283021 Total: 285.11523020999994
```
after fix:
```
zenbot balance --debug bitfinex.xrp-usd
2017-07-09 06:08:49 0.23815000 XRP-USD Asset: 1190.00000000 Currency: 0.75283021 Total: 284.15133021
```