### PR TITLE
Fix for "post only error" not handled and fix for "balance on hold == 0"

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -286,7 +286,7 @@ module.exports = function container (get, set, clear) {
                   cb(null, order)
                 })
               }
-              if (order.status === 'rejected' && order.reject_reason === 'post only') {
+              if (order.status === 'rejected' && (order.reject_reason === 'post only' || api_order.reject_reason === 'post only')) {
                 msg('post-only ' + type + ' failed, re-ordering')
                 return cancelOrder(true)
               }
@@ -416,7 +416,7 @@ module.exports = function container (get, set, clear) {
                   return cb(err)
                 }
               }
-              if (n(s.balance.currency).subtract(s.balance.currency_hold || 0).value() < n(price).multiply(size).value()) {
+              if (n(s.balance.currency).subtract(s.balance.currency_hold || 0).value() < n(price).multiply(size).value() && s.balance.currency_hold > 0) {
                 msg('buy delayed: ' + pct(n(s.balance.currency_hold || 0).divide(s.balance.currency).value()) + ' of funds (' + fc(s.balance.currency_hold) + ') on hold')
                 return setTimeout(function () {
                   if (s.last_signal === signal) {


### PR DESCRIPTION
- Bitfinex and Kraken API throw the "post only" error only on checkOrder(), check for it in engine.js
- Sometimes I would get "0% funds on hold (0.000000)". New check if balance on hold is > 0