### PR TITLE
Fix live trading for GDAX (and others) add a message to improve low volume pre-roll

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -114,11 +114,10 @@ module.exports = function container (get, set, clear) {
               limit: 1000
             }
             if (db_cursor) {
-              trade_cursor = db_cursor
               opts.query.time = {$gt: db_cursor}
             }
             else {
-              trade_cursor = query_start
+              trade_cursor = s.exchange.getCursor(query_start) 
               opts.query.time = {$gte: query_start}
             }
             get('db.trades').select(opts, function (err, trades) {

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -261,6 +261,10 @@ module.exports = function container (get, set, clear) {
                 }
                 if (s.period) {
                   engine.writeReport(true)
+                } else {
+                  readline.clearLine(process.stdout)
+                  readline.cursorTo(process.stdout, 0)
+                  process.stdout.write('Waiting on first live trade to display reports, could be a few minutes ...')
                 }
               })
             })


### PR DESCRIPTION
This is an improvement to the previous low volume fix. In low volume markets there may not be any trades during the pre_roll or initial live trading periods, it is not possible to show reports in that case which gives the impression that the bot it broken. Now we will at least show a message indicating that we are waiting for data before reporting starts.

Also provide a fix for broken trading GDAX. The exchange doesn't use timestamps so it is necessary to call getCursor when setting the trade_cursor.