### PR TITLE
Added Product BCH-BTC to Poloniex Exchange

### DIFF
--- a/extensions/exchanges/poloniex/products.json
+++ b/extensions/exchanges/poloniex/products.json
@@ -16,6 +16,14 @@
     "label": "Ardor/Bitcoin"
   },
   {
+    "asset": "BCH",
+    "currency": "BTC",
+    "min_total": "0.0001",
+    "max_size": null,
+    "increment": "0.00000001",
+    "label": "BitcoinCash/Bitcoin"
+  },
+  {
     "asset": "BCN",
     "currency": "BTC",
     "min_total": "0.0001",


### PR DESCRIPTION
The product BCH-BTC was not defined for Poloniex. So I added it to the products definition file.