### PR TITLE
percentage format fix

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -108,7 +108,7 @@ module.exports = function container (get, set, clear) {
     }
 
     function pct (ratio) {
-      return (ratio >= 0 ? '+' : '') + n(ratio).format('0.0%')
+      return (ratio >= 0 ? '+' : '') + n(ratio).format('0.0000%')
     }
 
     function initBuffer (trade) {


### PR DESCRIPTION
is ```slippage protection: refusing to buy at 616.310 USD, slippage of +0.0%```
should be ```slippage protection: refusing to buy at 616.310 USD, slippage of +0.0150%```