### PR TITLE
Fix min_periods for sar strategy in genetic backtesting

### DIFF
--- a/scripts/genetic_backtester/darwin.js
+++ b/scripts/genetic_backtester/darwin.js
@@ -289,7 +289,7 @@ let strategies = {
   sar: {
     // -- common
     period: RangePeriod(1, 120, 'm'),
-    min_periods: Range(1, 100),
+    min_periods: Range(2, 100),
     markup_pct: RangeFloat(0, 5),
     order_type: RangeMakerTaker(),
     sell_stop_pct: Range0(1, 50),


### PR DESCRIPTION
changed min_periods in genetic backtesting for sar strategy because the strategy need a min_periods of 2.

If min_periods set to 1 it throws a error while backtesting or sim.

Example:

zenbot sim kraken.XETC-ZEUR --days=10 --currency_capital=1000 --strategy=sar --period=15m --min_periods=1 --markup_pct=2.078805099136376 --order_type=maker --sar_af=0.806678206572936 --sar_max_af=0.7707578826702995
2017-09-24 01:37:25  8.84800 XETC-ZEUR                5                    /home/moebis/prog/zenbot/extensions/strategies/sar/strategy.js:31
            s.sar = Math.max(s.lookback[1].high, s.lookback[0].high)
                                          ^

TypeError: Cannot read property 'high' of undefined
    at Object.calculate (/home/moebis/prog/zenbot/extensions/strategies/sar/strategy.js:31:43)
    at onTrade (/home/moebis/prog/zenbot/lib/engine.js:135:18)
    at withOnPeriod (/home/moebis/prog/zenbot/lib/engine.js:806:15)
    at /home/moebis/prog/zenbot/lib/engine.js:799:17
    at Object.onPeriod (/home/moebis/prog/zenbot/extensions/strategies/sar/strategy.js:84:7)
    at Array.<anonymous> (/home/moebis/prog/zenbot/lib/engine.js:786:35)
    at Immediate.each (/home/moebis/prog/zenbot/node_modules/run-series/index.js:17:24)
    at runCallback (timers.js:672:20)
    at tryOnImmediate (timers.js:645:5)
    at processImmediate [as _immediateCallback] (timers.js:617:5)
