### PR TITLE
Fix for something i broke

### DIFF
--- a/conf-sample.js
+++ b/conf-sample.js
@@ -186,6 +186,6 @@ c.notifiers.slack.webhook_url = ''
 // discord configs
 c.notifiers.discord = {}
 c.notifiers.discord.on = false // false discord disabled; true discord enabled (key should be correct)
-c.notifiers.discord.webhook.id = 'YOUR-WEBHOOK-ID'
-c.notifiers.discord.webhook.token = 'YOUR-WEBHOOK-TOKEN'
+c.notifiers.discord.id = 'YOUR-WEBHOOK-ID'
+c.notifiers.discord.token = 'YOUR-WEBHOOK-TOKEN'
 // end discord configs

--- a/extensions/notifiers/discord.js
+++ b/extensions/notifiers/discord.js
@@ -23,7 +23,7 @@ module.exports = function container (get, set, clear) {
 
       var options = {
         method: 'POST',
-        url: 'https://discordapp.com/api/webhooks/' + config.webhook.id + '/' + config.webhook.token,
+        url: 'https://discordapp.com/api/webhooks/' + config.id + '/' + config.token,
         json: postData
       }
 


### PR DESCRIPTION
somehow this happened:
```
/var/zenbot/extensions/exchanges/gdax/exchange.js:21
        throw new Error('please configure your GDAX credentials in conf.js')
        ^

Error: please configure your GDAX credentials in conf.js
    at authedClient (/var/zenbot/extensions/exchanges/gdax/exchange.js:21:15)
    at Object.getBalance (/var/zenbot/extensions/exchanges/gdax/exchange.js:91:20)
    at Object.syncBalance (/var/zenbot/lib/engine.js:178:18)
    at Object.<anonymous> (/var/zenbot/commands/trade.js:263:24)
    at Immediate._onImmediate (/var/zenbot/node_modules/sosa/api.js:15:12)
    at runCallback (timers.js:781:20)
    at tryOnImmediate (timers.js:743:5)
    at processImmediate [as _immediateCallback] (timers.js:714:5)
```
but this fixes it :)