### PR TITLE
WIP: docker-compose based command interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY package.json /app/
 RUN npm install -g node-gyp && npm install --unsafe-perm
 
 COPY . /app
+RUN ln -s /app/zenbot.sh /usr/local/bin/zenbot
 
 ENV NODE_ENV production
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ docker-compose --file=docker-compose-windows.yml up
 If you wish to run commands (e.g. backfills, list-selectors), you can run this separate command after a successful `docker-compose up -d`:
 
 ```
-docker run --rm --link zenbot_mongodb_1:mongodb -it zenbot_server list-selectors
-docker run --rm --link zenbot_mongodb_1:mongodb -it zenbot_server backfill <selector> --days <days>
+docker-compose exec server zenbot list-selectors
+docker-compose exec server zenbot backfill <selector> --days <days>
 ```
 
 ## Selectors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ server:
   volumes:
     - ./conf.js:/app/conf.js
     - ./extensions:/app/extensions
+    - ./simulations:/app/simulations
   links:
     - mongodb
   command: [ "trade", "--paper" ]


### PR DESCRIPTION
Instead of using `docker` with linking and naming specific containers, we just execute the command through `docker-compose` itself.