### PR TITLE
Fix parsing error in genetic backtesting python script, doesn't remove terminal color.. leads to parse float errors otherwise

### DIFF
--- a/scripts/genetic_algo/evaluation.py
+++ b/scripts/genetic_algo/evaluation.py
@@ -4,6 +4,7 @@ import random
 import shlex
 import subprocess
 import sys
+import re
 from typing import List
 
 from termcolor import colored
@@ -23,10 +24,13 @@ def minutes(x):
 
 
 def runzen(cmdline):
+    ansi_escape = re.compile(b'\x1b[^m]*m')
     with open(os.devnull, 'w') as devnull:
         a = subprocess.check_output(shlex.split(cmdline), stderr=devnull)
-    profit = a.split(b'}')[-1].splitlines()[3].split(b': ')[-1][:-1]
+    profit = a.split(b'}')[-1].splitlines()[3].split(b': ')[-1]
+    profit = ansi_escape.sub(b'', profit)[:-1]
     trades = parse_trades(a.split(b'}')[-1].splitlines()[4])
+    trades = ansi_escape.sub(b'', trades)
     return float(profit), float(trades)
 
 


### PR DESCRIPTION
this is a fix for : 
```
    res = evolve(evaluate, Andividual, popsize)
  File "/root/zenbot/scripts/genetic_algo/evolution/__init__.py", line 18, in evolve
    return algorithm(cls, popsize, futures.map, evaluate, select, breed, mutate, stats, history, hof)
  File "/root/zenbot/scripts/genetic_algo/evolution/core.py", line 17, in algorithm
    evaluate_group(would_be,map,evaluate)
  File "/root/zenbot/scripts/genetic_algo/evolution/core.py", line 38, in evaluate_group
    for ind, fit in zip(invalid_ind, fitnesses):
  File "/usr/local/lib/python3.6/dist-packages/scoop/futures.py", line 102, in _mapGenerator
    for future in _waitAll(*futures):
  File "/usr/local/lib/python3.6/dist-packages/scoop/futures.py", line 358, in _waitAll
    for f in _waitAny(future):
  File "/usr/local/lib/python3.6/dist-packages/scoop/futures.py", line 335, in _waitAny
    raise childFuture.exceptionValue
  File "/usr/local/lib/python3.6/dist-packages/scoop/_control.py", line 127, in runFuture
    future.resultValue = future.callable(*future.args, **future.kargs)
  File "/root/zenbot/scripts/genetic_algo/evaluation.py", line 120, in evaluate_zen
    f,t = runzen(cmd)
  File "/root/zenbot/scripts/genetic_algo/evaluation.py", line 33, in runzen
    return float(profit), float(trades)
ValueError: could not convert string to float: b'\x1b[33m-4.62%\x1b[39'
```


when trying to run the genetic  algo: 

```
~/zenbot/scripts/genetic_algo# python3 -m scoop main.py BTC-JPY 4 10 sar
```
f.e.