### PR TITLE
Bittrex and Insufficient Funds (#708)

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -413,7 +413,15 @@ module.exports = function container (get, set, clear) {
           if (signal === 'buy') {
             price = n(quote.bid).subtract(n(quote.bid).multiply(so.markup_pct / 100)).format(s.product.increment, Math.floor)
             if (!size) {
-              size = n(s.balance.currency).multiply(so.buy_pct).divide(100).divide(price).format('0.00000000')
+              if (so.mode === 'live') {
+                if (so.order_type === 'maker')
+                  size = n(s.balance.currency).multiply(so.buy_pct).divide(100).multiply(s.exchange.makerFee / 100).format('0.00000000');
+                else
+                  size = n(s.balance.currency).multiply(so.buy_pct).divide(100).multiply(s.exchange.takerFee / 100).format('0.00000000');
+                size = n(s.balance.currency - size).divide(price).format('0.00000000')
+              } else {
+                size = n(s.balance.currency).multiply(so.buy_pct).divide(100).divide(price).format('0.00000000')
+              }
             }
             if ((s.product.min_size && Number(size) >= Number(s.product.min_size)) || ('min_total' in s.product && s.product.min_total && n(size).multiply(price).value() >= Number(s.product.min_total))) {
               if (s.product.max_size && Number(size) > Number(s.product.max_size)) {


### PR DESCRIPTION
Added if statements so the exchange can have it's cut out of the purchase of the asset.
Most exchanges want their cut in BTC rather than the alt-coin being processed.
This modification allows for the exchange fee to be removed from the overall purchase price allowing for 100% of the currency balance to be spent without an insufficient funds error popping up.