### PR TITLE
Different Bittrex error (#659)

### DIFF
--- a/extensions/exchanges/bittrex/exchange.js
+++ b/extensions/exchanges/bittrex/exchange.js
@@ -82,7 +82,7 @@ module.exports = function container(get, set, clear) {
         }
 
         var trades = []
-        if (typeof data.result !== 'undefined') {
+        try {
           Object.keys(data.result).forEach(function (i) {
             var trade = data.result[i]
             trades.push({
@@ -93,6 +93,9 @@ module.exports = function container(get, set, clear) {
               side: trade.OrderType == 'BUY' ? 'buy' : 'sell'
             })
           })
+        } catch (e) {
+          console.log('bittrex API (getmarkethistory). Retry in progress.  Error:' + e);
+          return retry('getTrades', func_args, e.toString());
         }
         cb(null, trades)
       })

--- a/extensions/exchanges/bittrex/exchange.js
+++ b/extensions/exchanges/bittrex/exchange.js
@@ -95,7 +95,7 @@ module.exports = function container(get, set, clear) {
           })
         } catch (e) {
           console.log('bittrex API (getmarkethistory). Retry in progress.  Error:' + e);
-          return retry('getTrades', func_args, e.toString());
+          return retry('getTrades', func_args, {message: e.toString()});
         }
         cb(null, trades)
       })


### PR DESCRIPTION
This fix should handle any error that happens and then fire's off a retry.  I tried the Try .. Catch block on fiddle and it worked flawlessly to capture the error in question.

I'm not sure how to exactly test the retry, but I created the statement similar to the one on line 78.  This technically should be recoverable, because Bittrex is just having some sort of hiccup on their API sending data.

I would say this would close #659, but time will ultimately tell.