### PR TITLE
Fix for buy_pct (#724)

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -418,7 +418,7 @@ module.exports = function container (get, set, clear) {
                   size = n(s.balance.currency).multiply(so.buy_pct).divide(100).multiply(s.exchange.makerFee / 100).format('0.00000000');
                 else
                   size = n(s.balance.currency).multiply(so.buy_pct).divide(100).multiply(s.exchange.takerFee / 100).format('0.00000000');
-                size = n(s.balance.currency - size).divide(price).format('0.00000000')
+                size = n(s.balance.currency).multiply(so.buy_pct).divide(100).subtract(size).divide(price).format('0.00000000')
               } else {
                 size = n(s.balance.currency).multiply(so.buy_pct).divide(100).divide(price).format('0.00000000')
               }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -414,10 +414,11 @@ module.exports = function container (get, set, clear) {
             price = n(quote.bid).subtract(n(quote.bid).multiply(so.markdown_buy_pct / 100)).format(s.product.increment, Math.floor)
             if (!size) {
               if (so.mode === 'live') {
-                if (so.order_type === 'maker')
+                if (so.order_type === 'maker') {
                   size = n(s.balance.currency).multiply(so.buy_pct).divide(100).multiply(s.exchange.makerFee / 100).format('0.00000000');
-                else
+                } else {
                   size = n(s.balance.currency).multiply(so.buy_pct).divide(100).multiply(s.exchange.takerFee / 100).format('0.00000000');
+                }
                 size = n(s.balance.currency).multiply(so.buy_pct).divide(100).subtract(size).divide(price).format('0.00000000')
               } else {
                 size = n(s.balance.currency).multiply(so.buy_pct).divide(100).divide(price).format('0.00000000')


### PR DESCRIPTION
This is a fix to address #724.  This was related to commit b53abcc not taking the buy_pct into account during the final calculation of the size.  It was taking it into account when calculating the impact of the fee on the asset purchase, but not the overall purchase of the asset itself.