### PR TITLE
Fix Volume in Bittrex Adapter

### DIFF
--- a/extensions/exchanges/bittrex/exchange.js
+++ b/extensions/exchanges/bittrex/exchange.js
@@ -38,7 +38,7 @@ module.exports = function container(get, set, clear) {
       var timeout = 2500
     }
 
-    console.error(('\Bittrex API error - unable to call ' + method + ' (' + error + '), retrying in ' + timeout / 1000 + 's').red)
+    console.error(('\Bittrex API error - unable to call ' + method + ' (' + error.message + '), retrying in ' + timeout / 1000 + 's').red)
     setTimeout(function () {
       exchange[method].apply(exchange, args)
     }, timeout)
@@ -95,8 +95,7 @@ module.exports = function container(get, set, clear) {
             }
           })
         } catch (e) {
-          console.log('bittrex API (getmarkethistory). Retry in progress.  Error:' + e);
-          return retry('getTrades', func_args, {message: e.toString()});
+          return retry('getTrades', func_args, {message: 'Error:  ' + e});
         }
         cb(null, trades)
       })


### PR DESCRIPTION
This corrects the volume reporting in the Bittrex adapter.  It also removes the need to have the warning about the duplicate results as that is no longer a problem.

Adjust the wording in the error message so the console.log was removed.  Utilize the retry function's error reporting to show the message instead.

If this is approved, then #717 can be closed.