### PR TITLE
Fix poll_trades From Command Line

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -294,7 +294,7 @@ module.exports = function container (get, set, clear) {
                     }
                     lookback_size = s.lookback.length
                     forwardScan()
-                    setInterval(forwardScan, c.poll_trades)
+                    setInterval(forwardScan, so.poll_trades)
                     readline.emitKeypressEvents(process.stdin)
                     if (!so.non_interactive && process.stdin.setRawMode) {
                       process.stdin.setRawMode(true)


### PR DESCRIPTION
When using the poll_trades setting from the command line, Zenbot will ignore it in favor of the currently used conf.js file.  This effectively eliminates the possibility of an override from the command line as dictated in the settings.

This modification will allow the command line option to override the setting in the conf.js file.