### PR TITLE
Kraken network errors

### DIFF
--- a/extensions/exchanges/kraken/exchange.js
+++ b/extensions/exchanges/kraken/exchange.js
@@ -14,7 +14,7 @@ module.exports = function container(get, set, clear) {
 
   var public_client, authed_client
   // var recoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|API:Invalid nonce|API:Rate limit exceeded|between Cloudflare and the origin web server)/)
-  var recoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|API:Invalid nonce|between Cloudflare and the origin web server|SSL handshake failed|Gateway time-out|Bad gateway|Service:Unavailable)/)
+  var recoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|API:Invalid nonce|between Cloudflare and the origin web server|SSL handshake failed|Gateway time-out|Bad gateway|Service:Unavailable|Service:Busy)/)
   var silencedRecoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|SSL handshake failed|Gateway time-out|Bad gateway)/)
 
   function publicClient() {

--- a/extensions/exchanges/kraken/exchange.js
+++ b/extensions/exchanges/kraken/exchange.js
@@ -14,8 +14,8 @@ module.exports = function container(get, set, clear) {
 
   var public_client, authed_client
   // var recoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|API:Invalid nonce|API:Rate limit exceeded|between Cloudflare and the origin web server)/)
-  var recoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|API:Invalid nonce|between Cloudflare and the origin web server)/)
-  var silencedRecoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT)/)
+  var recoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|API:Invalid nonce|between Cloudflare and the origin web server|SSL handshake failed|Gateway time-out|Bad gateway)/)
+  var silencedRecoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|SSL handshake failed|Gateway time-out|Bad gateway)/)
 
   function publicClient() {
     if (!public_client) {

--- a/extensions/exchanges/kraken/exchange.js
+++ b/extensions/exchanges/kraken/exchange.js
@@ -14,7 +14,7 @@ module.exports = function container(get, set, clear) {
 
   var public_client, authed_client
   // var recoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|API:Invalid nonce|API:Rate limit exceeded|between Cloudflare and the origin web server)/)
-  var recoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|API:Invalid nonce|between Cloudflare and the origin web server|SSL handshake failed|Gateway time-out|Bad gateway)/)
+  var recoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|API:Invalid nonce|between Cloudflare and the origin web server|SSL handshake failed|Gateway time-out|Bad gateway|Service:Unavailable)/)
   var silencedRecoverableErrors = new RegExp(/(ESOCKETTIMEDOUT|ETIMEDOUT|SSL handshake failed|Gateway time-out|Bad gateway)/)
 
   function publicClient() {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "glob": "^7.1.1",
     "har-validator": "^5.0.3",
     "idgen": "^2.0.2",
-    "kraken-api": "^0.1.7",
+    "kraken-api": "github:xma/npm-kraken-api#zenbot",
     "micro-request": "^666.0.10",
     "mime": "^1.4.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
This pull request intend to fix two things, for kraken exchange:
- Errors returned by Kraken (w/ Cloudflare proxy) weren't handled, namely:
   SSL handshake failed
   Gateway time-out
   Bad gateway

It's quite bad as those could occur while doing an order or a cancel
which in this case wouldn't have the 'retry' feature

- Timeout, related to the NPM module "kraken-api"
It's set to 5 sec, which is way too low ( I'm seeing sometime requests completed in around 30s, especially those related to order)

=> I've made a quick fork of the module, setting the default to 60s

