### PR TITLE
Fixed VMA indicator calculation

### DIFF
--- a/lib/vma.js
+++ b/lib/vma.js
@@ -1,4 +1,5 @@
 // Variable Moving Average, by Tushar S. Chande
+// VMA automatically adjusts its smoothing constant on the basis of Market Volatility
 module.exports = function container (get, set, clear) {
   return function vma (s, key, length, source_key) {
     if (!source_key) source_key = 'close'
@@ -16,17 +17,18 @@ module.exports = function container (get, set, clear) {
         let mdiS = s.period['mdiS'] = k * mdi + ((s.lookback[0]['mdiS'] != undefined) ? s.lookback[0]['mdiS'] * (1 - k) : 0);
         let d = Math.abs(pdiS - mdiS);
         let s1 = pdiS + mdiS;
-        let iS = s.period['iS'] = k * d / s1 + ((s.lookback[0]['iS'] != undefined) ? s.lookback[0]['iS'] * (1 - k) : 0);
+        var iS = s.period['iS'] = k * d / s1 + ((s.lookback[0]['iS'] != undefined) ? s.lookback[0]['iS'] * (1 - k) : 0);
     }
     if (s.lookback.length > length) {
-        let hhv = 0, llv = 0;
-        for (var i=length-1; i>=0; i--) {
-            let iS = s.lookback[i]['iS'];
-            hhv = Math.max(hhv, iS);
-            llv = Math.min(llv, iS);
-        }
+        let hhv, llv;
+        s.lookback.slice(0, length).forEach(function (period) {
+            hhv = (hhv != undefined) ? Math.max(hhv, period['iS']) : period['iS'];
+            llv = (llv != undefined) ? Math.min(llv, period['iS']) : period['iS'];
+        })
+        hhv = Math.max(hhv, iS);
+        llv = Math.min(llv, iS);
         let d1 = hhv - llv;
-        let vI = (s.period['iS'] - llv) / d1;
+        let vI = (iS - llv) / d1;
         let vma = s.period['vma'] = k * vI * s.period[source_key] + 
             ((s.lookback[0]['vma'] != undefined) ? s.lookback[0]['vma'] * (1 - k * vI) : 0)
         s.period[key] = vma;


### PR DESCRIPTION
VMA indicator calculated moving average incorrectly. llv = Math.min(llv, iS) always returned 0, because llv was initialized to 0 on line 22. Reworked.