### PR TITLE
More accurate simulation

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -551,7 +551,6 @@ module.exports = function container (get, set, clear) {
         if (so.mode === 'live' || trade.price <= Number(s.buy_order.price)) {
           price = s.buy_order.price
           if (so.mode !== 'live') {
-            price = n(s.buy_order.orig_price).add(n(s.buy_order.orig_price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
             s.balance.asset = n(s.balance.asset).add(s.buy_order.size).format('0.00000000')
             var total = n(price).multiply(s.buy_order.size)
             s.balance.currency = n(s.balance.currency).subtract(total).format('0.00000000')
@@ -562,6 +561,7 @@ module.exports = function container (get, set, clear) {
               }
             }
             if (so.order_type === 'taker') {
+              price = n(s.buy_order.price).add(n(s.buy_order.price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
               if (s.exchange.takerFee) {
                 fee = n(s.buy_order.size).multiply(s.exchange.takerFee / 100).value()
                 s.balance.asset = n(s.balance.asset).subtract(fee).format('0.00000000')
@@ -604,7 +604,6 @@ module.exports = function container (get, set, clear) {
         if (so.mode === 'live' || trade.price >= s.sell_order.price) {
           price = s.sell_order.price
           if (so.mode !== 'live') {
-            price = n(s.sell_order.orig_price).subtract(n(s.sell_order.orig_price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
             s.balance.asset = n(s.balance.asset).subtract(s.sell_order.size).value()
             var total = n(price).multiply(s.sell_order.size)
             s.balance.currency = n(s.balance.currency).add(total).value()
@@ -615,6 +614,7 @@ module.exports = function container (get, set, clear) {
               }
             }
             if (so.order_type === 'taker') {
+              price = n(s.sell_order.price).subtract(n(s.sell_order.price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
               if (s.exchange.takerFee) {
                 fee = n(s.sell_order.size).multiply(s.exchange.takerFee / 100).multiply(price).value()
                 s.balance.currency = n(s.balance.currency).subtract(fee).format('0.00000000')


### PR DESCRIPTION
I think the changes below make the simulation more accurate
- "order.price" instead or "orig_price" to compute sim price
- slippage only for taker order

Try and tell me