### PR TITLE
Add two commands to output live HTML chart without killing zenbot. Either on demand or automatically.

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -86,6 +86,8 @@ module.exports = function container (get, set, clear) {
         keyMap.set('O', 'show current trade options in a dirty view (full list)'.grey)
         keyMap.set('P', 'print statistical output'.grey)
         keyMap.set('X', 'exit program with statistical output'.grey)
+        keyMap.set('d', 'dump statistical output to HTML file'.grey)
+        keyMap.set('D', 'toggle automatic HTML dump to file'.grey)
 
         function listKeys() {
           console.log('\nAvailable command keys:')
@@ -131,7 +133,7 @@ module.exports = function container (get, set, clear) {
         }              
 
         /* Implementing statistical Exit */
-        function printTrade (quit) {
+        function printTrade (quit, dump) {
           console.log()
           var output_lines = []
           var tmp_balance = n(s.balance.currency).add(n(s.period.close).multiply(s.balance.asset)).format('0.00000000')
@@ -175,7 +177,7 @@ module.exports = function container (get, set, clear) {
           output_lines.forEach(function (line) {
             console.log(line)
           })
-          if (quit) {
+          if (quit || dump) {
             var html_output = output_lines.map(function (line) {
               return colors.stripColors(line)
             }).join('\n')
@@ -198,12 +200,108 @@ module.exports = function container (get, set, clear) {
               .replace('{{output}}', html_output)
               .replace(/\{\{symbol\}\}/g,  so.selector + ' - zenbot ' + require('../package.json').version)
             if (so.filename !== 'none') {
-              var out_target = so.filename || 'simulations/trade_result_' + so.selector +'_' + new Date().toISOString().replace(/T/, '_').replace(/\..+/, '').replace(/-/g, '').replace(/:/g, '').replace(/20/, '') + '_UTC.html'
+              var out_target
+              
+              if(dump){
+                var dt = new Date().toISOString();
+                
+                //ymd
+                var today = dt.slice(2, 4) + dt.slice(5, 7) + dt.slice(8, 10);
+                out_target = so.filename || 'simulations/trade_result_' + so.selector +'_' + today + '_UTC.html'
+              fs.writeFileSync(out_target, out)
+              }else
+                out_target = so.filename || 'simulations/trade_result_' + so.selector +'_' + new Date().toISOString().replace(/T/, '_').replace(/\..+/, '').replace(/-/g, '').replace(/:/g, '').replace(/20/, '') + '_UTC.html'
+              
               fs.writeFileSync(out_target, out)
               console.log('\nwrote'.grey, out_target)
             }
-            process.exit(0)
+            if(quit) process.exit(0)
           }
+        }
+        /* The end of printTrade */
+        
+        /* Implementing statistical status dump every 10 secs */
+        var shouldSaveStats = false;
+        function toggleStats(){
+          shouldSaveStats = !shouldSaveStats;
+          if(shouldSaveStats)
+            console.log("Auto stats dump enabled")
+          else
+            console.log("Auto stats dump disabled")
+        }
+        
+        function saveStatsLoop(){
+          saveStats()
+          setTimeout(function () {
+            saveStatsLoop()
+          }, 10000)
+        }
+        saveStatsLoop()
+        
+        function saveStats () {
+          if(!shouldSaveStats) return;
+          
+          var output_lines = []
+          var tmp_balance = n(s.balance.currency).add(n(s.period.close).multiply(s.balance.asset)).format('0.00000000')
+          
+          var profit = s.start_capital ? n(tmp_balance).subtract(s.start_capital).divide(s.start_capital) : n(0)
+          output_lines.push('last balance: ' + n(tmp_balance).format('0.00000000').yellow + ' (' + profit.format('0.00%') + ')')
+          var buy_hold = s.start_price ? n(s.period.close).multiply(n(s.start_capital).divide(s.start_price)) : n(tmp_balance)
+          var buy_hold_profit = s.start_capital ? n(buy_hold).subtract(s.start_capital).divide(s.start_capital) : n(0)
+          output_lines.push('buy hold: ' + buy_hold.format('0.00000000').yellow + ' (' + n(buy_hold_profit).format('0.00%') + ')')
+          output_lines.push('vs. buy hold: ' + n(tmp_balance).subtract(buy_hold).divide(buy_hold).format('0.00%').yellow)
+          output_lines.push(s.my_trades.length + ' trades over ' + s.day_count + ' days (avg ' + n(s.my_trades.length / s.day_count).format('0.00') + ' trades/day)')
+          var last_buy
+          var losses = 0, sells = 0
+          s.my_trades.forEach(function (trade) {
+            if (trade.type === 'buy') {
+              last_buy = trade.price
+            }
+            else {
+              if (last_buy && trade.price < last_buy) {
+                losses++
+              }
+              sells++
+            }
+          })
+          if (s.my_trades.length && sells > 0) {
+            output_lines.push('win/loss: ' + (sells - losses) + '/' + losses)
+            output_lines.push('error rate: ' + (sells ? n(losses).divide(sells).format('0.00%') : '0.00%').yellow)
+          }
+          
+          var html_output = output_lines.map(function (line) {
+            return colors.stripColors(line)
+          }).join('\n')
+          var data = s.lookback.slice(0, s.lookback.length - so.min_periods).map(function (period) {
+            return {
+              time: period.time,
+              open: period.open,
+              high: period.high,
+              low: period.low,
+              close: period.close,
+              volume: period.volume
+            }
+          })
+          var code = 'var data = ' + JSON.stringify(data) + ';\n'
+          code += 'var trades = ' + JSON.stringify(s.my_trades) + ';\n'
+          var tpl = fs.readFileSync(path.resolve(__dirname, '..', 'templates', 'sim_result.html.tpl'), {encoding: 'utf8'})
+          var out = tpl
+            .replace('{{code}}', code)
+            .replace('{{trend_ema_period}}', so.trend_ema || 36)
+            .replace('{{output}}', html_output)
+            .replace(/\{\{symbol\}\}/g,  so.selector + ' - zenbot ' + require('../package.json').version)
+          if (so.filename !== 'none') {
+            var out_target
+            var dt = new Date().toISOString();
+            
+            //ymd
+            var today = dt.slice(2, 4) + dt.slice(5, 7) + dt.slice(8, 10);
+            out_target = so.filename || 'simulations/trade_result_' + so.selector +'_' + today + '_UTC.html'
+
+            fs.writeFileSync(out_target, out)
+            //console.log('\nwrote'.grey, out_target)
+          }
+
         }
         /* The end of printTrade */
 
@@ -336,6 +434,13 @@ module.exports = function container (get, set, clear) {
                         } else if (key === 'X' && !info.ctrl) {
                           console.log('\nExiting... ' + '\nWriting statistics...'.grey)
                           printTrade(true)
+                        } else if (key === 'd' && !info.ctrl) {
+                          console.log('\nDumping statistics...'.grey)
+                          printTrade(false, true)
+                        } else if (key === 'D' && !info.ctrl) {
+                          
+                          console.log('\nDumping statistics...'.grey)
+                          toggleStats()
                         } else if (info.name === 'c' && info.ctrl) {
                           // @todo: cancel open orders before exit
                           console.log()


### PR DESCRIPTION
• Add command to write html chart of trades so far, without needing to kill bot via X command. (lower-case d)
• Add command to enable saving/dumping live charts to file every X seconds (defaulted at 10 seconds), relative to selector & year + month + date. (upper-case D to toggle on/off)