### PR TITLE
Remove options key from REST output

### DIFF
--- a/extensions/output/api.js
+++ b/extensions/output/api.js
@@ -16,11 +16,17 @@ module.exports = function container (get) {
     }
   }
 
+  let objectWithoutKey = (object, key) => {
+    const {[key]: deletedKey, ...otherKeys} = object;
+    return otherKeys;
+  }
+
   let startServer = function(port, tradeObject) {
     tradeObject.port = port
 
     app.get('/trades', function (req, res) {
-      res.send(tradeObject)
+      // Remove "options" key because it contains credentials
+      res.send(objectWithoutKey(tradeObject, 'options'))
     })
 
     app.listen(port)


### PR DESCRIPTION
Because it contains credentials.

Maybe someone will want to see some options anyway. If you want to see options, Edit this branch as you wish : https://github.com/storm1er/zenbot/tree/remove-options-key-from-REST-output