### PR TITLE
Added bind_ip_all to mongodb.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ mongodb:
   image: mongo:latest
   volumes_from:
     - mongodb-data
-  command: mongod --smallfiles
+  command: mongod --smallfiles --bind_ip_all
 
 mongodb-data:
   image: mongo:latest


### PR DESCRIPTION
On a new install, per warning:
mongodb_1       | 2017-12-11T14:05:29.348+0000 I CONTROL  [initandlisten] ** WARNING: This server is bound to localhost.
mongodb_1       | 2017-12-11T14:05:29.348+0000 I CONTROL  [initandlisten] **          Remote systems will be unable to connect to this server.
mongodb_1       | 2017-12-11T14:05:29.348+0000 I CONTROL  [initandlisten] **          Start the server with --bind_ip <address> to specify which IP
mongodb_1       | 2017-12-11T14:05:29.348+0000 I CONTROL  [initandlisten] **          addresses it should serve responses from, or with --bind_ip_all to
mongodb_1       | 2017-12-11T14:05:29.348+0000 I CONTROL  [initandlisten] **          bind to all interfaces. If this behavior is desired, start the
mongodb_1       | 2017-12-11T14:05:29.348+0000 I CONTROL  [initandlisten] **          server with --bind_ip 127.0.0.1 to disable this warning.

Resolves issue:
server_1        | warning: mongodb not accessible. some features (such as backfilling/simulation) may be disabled.
server_1        | /app/node_modules/sosa_mongo/mongo_backend.js:6
server_1        |   if (!backend_options.db) throw new Error('must pass a node-mongodb-native db with backend_options.db');
server_1        |                            ^
server_1        |
server_1        | Error: must pass a node-mongodb-native db with backend_options.db
server_1        |     at module.exports (/app/node_modules/sosa_mongo/mongo_backend.js:6:34)
server_1        |     at /app/node_modules/sosa/index.js:7:17
server_1        |     at createCollection (/app/db/createCollection.js:5:7)
server_1        |     at Object.container (/app/db/sessions.js:2:36)
server_1        |     at Object.getValue (/app/node_modules/codemap/index.js:298:22)
server_1        |     at /app/node_modules/codemap/index.js:238:23
server_1        |     at Array.forEach (<anonymous>)
server_1        |     at Object.get (/app/node_modules/codemap/index.js:237:13)
server_1        |     at get (/app/node_modules/codemap/index.js:60:22)
server_1        |     at Command.<anonymous> (/app/commands/trade.js:319:24)
server_1        |     at Command.listener (/app/node_modules/commander/index.js:315:8)
server_1        |     at Command.emit (events.js:159:13)
server_1        |     at Command.parseArgs (/app/node_modules/commander/index.js:653:12)
server_1        |     at Command.parse (/app/node_modules/commander/index.js:475:21)
server_1        |     at /app/zenbot.js:39:11
server_1        |     at /app/boot.js:28:7
server_1        |     at f (/app/node_modules/once/once.js:25:25)
server_1        |     at Glob.<anonymous> (/app/node_modules/glob/glob.js:151:7)
server_1        |     at Glob.emit (events.js:159:13)
server_1        |     at Glob._finish (/app/node_modules/glob/glob.js:197:8)
server_1        |     at done (/app/node_modules/glob/glob.js:182:14)
server_1        |     at Glob._processGlobStar2 (/app/node_modules/glob/glob.js:637:12)
zenbot_server_1 exited with code 1