### PR TITLE
Fix market order actual price

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -293,6 +293,7 @@ module.exports = function container (get, set, clear) {
               msg('order status: ' + order.status)
               if (api_order.status === 'done') {
                 order.time = new Date(api_order.done_at).getTime()
+                order.price = api_order.price || order.price // Use actual price if possibile. In market order the actual price (api_order.price) should be very different from trade price
                 executeOrder(order)
                 return syncBalance(function () {
                   cb(null, order)

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -293,7 +293,7 @@ module.exports = function container (get, set, clear) {
               msg('order status: ' + order.status)
               if (api_order.status === 'done') {
                 order.time = new Date(api_order.done_at).getTime()
-                order.price = api_order.price || order.price // Use actual price if possibile. In market order the actual price (api_order.price) should be very different from trade price
+                order.price = api_order.price || order.price // Use actual price if possible. In market order the actual price (api_order.price) could be very different from trade price
                 executeOrder(order)
                 return syncBalance(function () {
                   cb(null, order)


### PR DESCRIPTION
In market order the actual price (api_order.price) should be very different from trade price
Use actual price if possible.
This should fix issue #800 