### PR TITLE
Add simple crossover_vwap strategy with vwap indicator.

### DIFF
--- a/extensions/strategies/crossover_vwap/_codemap.js
+++ b/extensions/strategies/crossover_vwap/_codemap.js
@@ -1,0 +1,6 @@
+module.exports = {
+  _ns: 'zenbot',
+
+  'strategies.crossover_vwap': require('./strategy'),
+  'strategies.list[]': '#strategies.crossover_vwap'
+}

--- a/extensions/strategies/crossover_vwap/strategy.js
+++ b/extensions/strategies/crossover_vwap/strategy.js
@@ -1,0 +1,112 @@
+var z = require('zero-fill')
+  , n = require('numbro')
+  //, fs = require('fs'), fs_started = false
+;
+
+
+var data = "";
+/*
+if(!fs_started) {
+  fs.appendFile('log.csv', 'pid'+','+'pOpen'+','+'pClose'+','+'emagreen'+','+'smapurple'+','+'smared'+'\n', (err)=>{});
+  fs_started = true;
+}//*/
+module.exports = function container (get, set, clear) {
+  return {
+    name: 'crossover_vwap',
+    description: 'Testing indicator with vwap',
+
+    getOptions: function () {
+      // these are relative to period length. Good tests so far: period=5m or 90m
+      
+      // default start is 30, 108, 60.
+      this.option('emalen1', 'Length of EMA 1', Number, 30 )//green
+      this.option('smalen1', 'Length of SMA 1', Number, 108 )//red
+      this.option('smalen2', 'Length of SMA 2', Number, 60 )//purple
+      this.option('vwap_length', 'Length of vwap', Number, 10 )//gold
+      this.option('vwap_max', 'Max history for vwap. Increasing this makes it more sensitive to short-term changes', Number)//gold
+    },
+    
+    /*
+      zenbot sim kraken.XXRP-ZEUR --period="120m" --strategy=crossover_vwap --currency_capital=700 --asset_capital=0 --max_slippage_pct=100 --days=60 --avg_slippage_pct=0.045 --vwap_max=8000 --markup_sell_pct=0.5 --markdown_buy_pct=0.5 --emalen1=50
+      zenbot sim kraken.XXRP-ZEUR --period="120m" --strategy=crossover_vwap --currency_capital=700 --asset_capital=0 --max_slippage_pct=100 --days=60 --avg_slippage_pct=0.045 --vwap_max=8000 --markup_sell_pct=0.5 --markdown_buy_pct=0.5 --emalen1=30
+    */
+    calculate: function (s) {
+        // compute MACD
+        //get('lib.ti_vwap')(s, 'vwap', s.options.vwap_len)//gold
+        get('lib.vwap')(s, 'vwap', s.options.vwap_length, s.options.vwap_max)//gold
+        
+        get('lib.ema')(s, 'ema1', s.options.emalen1)//green
+        get('lib.sma')(s, 'sma1', s.options.smalen1, 'high')//red
+        get('lib.sma')(s, 'sma2', s.options.smalen2)//purple
+    },
+    
+    onPeriod: function (s, cb) { 
+      let pOpen = s.period.open,
+        pClose = s.period.close;
+        emagreen = s.period.ema1,
+        smared = s.period.sma1,
+        smapurple= s.period.sma2,
+        vwapgold = s.period.vwap;
+    
+     // helper functions
+     var trendUp = function(s, cancel){
+        if (s.trend !== 'up') {
+          s.acted_on_trend = false
+        }
+        s.trend = 'up'
+        s.signal = !s.acted_on_trend ? 'buy' : null
+        s.cancel_down = false
+
+        if(cancel)
+          s.cancel_down = true
+      },
+      trendDown = function(s){
+        if (s.trend !== 'down') {
+          s.acted_on_trend = false
+        }
+        s.trend = 'down'
+        s.signal = !s.acted_on_trend ? 'sell' : null
+      };
+      
+      if(emagreen && smared && smapurple && s.period.vwap){
+        
+        if(vwapgold > emagreen) trendUp(s, true)
+        else trendDown(s)
+          
+      }
+      cb()
+    },
+
+    onReport: function (s) {
+      var cols = []
+      let pOpen = s.period.open,
+        pClose = s.period.open;
+        emaSO = s.period.ema_short_o,
+        emaLO = s.period.ema_long_o,
+        emaSC = s.period.ema_short_c,
+        emaLC = s.period.ema_long_c;
+      
+      
+      if (typeof s.period.vwap != 'undefined' && typeof emaLC != 'undefined') {
+        var color = 'grey'
+        if (emaSC > emaLO)
+          color = 'green'
+        else if (pClose < (pOpen * -1)) 
+          color = 'red'
+        
+        cols.push(z(8, n(s.period.vwap).format('0.00000'), ' ')['gold'])
+        cols.push(z(8, n(emaLC).format('0.00000'), ' ')['blue'])
+ 
+      }
+      else {
+        if (s.period.trend_ema_stddev) {
+          cols.push('                  ')
+        }
+        else {
+          cols.push('        ')
+        }
+      }
+      return cols
+    }
+  }
+}

--- a/extensions/strategies/crossover_vwap/strategy.js
+++ b/extensions/strategies/crossover_vwap/strategy.js
@@ -22,8 +22,8 @@ module.exports = function container (get, set, clear) {
       this.option('emalen1', 'Length of EMA 1', Number, 30 )//green
       this.option('smalen1', 'Length of SMA 1', Number, 108 )//red
       this.option('smalen2', 'Length of SMA 2', Number, 60 )//purple
-      this.option('vwap_length', 'Length of vwap', Number, 10 )//gold
-      this.option('vwap_max', 'Max history for vwap. Increasing this makes it more sensitive to short-term changes', Number)//gold
+      this.option('vwap_length', 'Min periods for vwap to start', Number, 10 )//gold
+      this.option('vwap_max', 'Max history for vwap. Increasing this makes it more sensitive to short-term changes', Number, 8000)//gold
     },
     
     /*
@@ -42,7 +42,7 @@ module.exports = function container (get, set, clear) {
     
     onPeriod: function (s, cb) { 
       let pOpen = s.period.open,
-        pClose = s.period.close;
+        pClose = s.period.close,
         emagreen = s.period.ema1,
         smared = s.period.sma1,
         smapurple= s.period.sma2,
@@ -80,31 +80,21 @@ module.exports = function container (get, set, clear) {
     onReport: function (s) {
       var cols = []
       let pOpen = s.period.open,
-        pClose = s.period.open;
-        emaSO = s.period.ema_short_o,
-        emaLO = s.period.ema_long_o,
-        emaSC = s.period.ema_short_c,
-        emaLC = s.period.ema_long_c;
+        pClose = s.period.close,
+        emagreen = s.period.ema1,
+        smared = s.period.sma1,
+        smapurple= s.period.sma2,
+        vwapgold = s.period.vwap
       
-      
-      if (typeof s.period.vwap != 'undefined' && typeof emaLC != 'undefined') {
-        var color = 'grey'
-        if (emaSC > emaLO)
-          color = 'green'
-        else if (pClose < (pOpen * -1)) 
-          color = 'red'
-        
-        cols.push(z(8, n(s.period.vwap).format('0.00000'), ' ')['gold'])
-        cols.push(z(8, n(emaLC).format('0.00000'), ' ')['blue'])
- 
+      if (vwapgold && emagreen) {   
+        var color = "green";
+        if(vwapgold > emagreen) color = "red"
+          
+        cols.push(z(6, n(vwapgold).format('0.00000'), '')['yellow'] + ' ')
+        cols.push(z(6, n(emagreen).format('0.00000'), '')[color] + ' ')
       }
       else {
-        if (s.period.trend_ema_stddev) {
-          cols.push('                  ')
-        }
-        else {
-          cols.push('        ')
-        }
+        cols.push('                ')
       }
       return cols
     }

--- a/lib/_codemap.js
+++ b/lib/_codemap.js
@@ -17,6 +17,6 @@ module.exports = {
   'tcf': require('./tcf'),
   'vma': require('./vma'),
   'lrc': require('./lrc'),
-  'adx': require('./adx')
+  'adx': require('./adx'),
   'vwap': require('./vwap')
 }

--- a/lib/_codemap.js
+++ b/lib/_codemap.js
@@ -18,4 +18,5 @@ module.exports = {
   'vma': require('./vma'),
   'lrc': require('./lrc'),
   'adx': require('./adx')
+  'vwap': require('./vwap')
 }

--- a/lib/vwap.js
+++ b/lib/vwap.js
@@ -1,0 +1,30 @@
+module.exports = function container (get, set, clear) {
+  return function vwap (s, key, length, max_period, source_key) {
+    if (!source_key) source_key = 'close'
+    
+    if (s.lookback.length >= length) {
+      if(!s.vwap){
+        s.vwap = 0, 
+        s.vwapMultiplier = 0, 
+        s.vwapDivider = 0,
+        s.vwapCount = 0;
+      }
+      
+      if(max_period && s.vwapCount > max_period){
+        s.vwap = 0, 
+        s.vwapMultiplier = 0, 
+        s.vwapDivider = 0,
+        s.vwapCount = 0;
+      }
+      
+      s.vwapMultiplier = s.vwapMultiplier + parseFloat(s.period[source_key]) * parseFloat(s.period['volume']);
+      s.vwapDivider = s.vwapDivider + parseFloat(s.period['volume']);
+      
+      
+      s.period[key] = s.vwap = s.vwapMultiplier / s.vwapDivider;
+      
+      s.vwapCount++;
+      
+    }
+  }
+}


### PR DESCRIPTION
I've been playing with a strategy that could possibly anticipate gradual price changes and flow with those changes, reducing losses vs hold and increasing gains vs hold. Here's an example that worked well for me in a sim:
```zenbot sim kraken.XXRP-ZEUR --period="120m" --strategy=crossover_vwap --currency_capital=700 --asset_capital=0 --max_slippage_pct=100 --days=60 --avg_slippage_pct=1  ```
That's even with a relatively high average slippage. Defaults may still need tweaking though, especially on different exchanges & currency combinations:

```2017-12-13 11:59:59  0.383310 XXRP-ZEUR   +3.49%    4.77m   92 +++++0.38272 0.25607   +89.75%  4048.39850742 XXRP    0.08 ZEUR+121.69%  +26.25%
{
  "asset_capital": 0,
  "avg_slippage_pct": 1,
  "buy_pct": 99,
  "buy_stop_pct": 0,
  "currency_capital": 700,
  "days": 60,
  "emalen1": 30,
  "markdown_buy_pct": 0,
  "markup_sell_pct": 0,
  "max_sell_loss_pct": 25,
  "max_slippage_pct": "100",
  "min_periods": 1,
  "mode": "sim",
  "order_adjust_time": 5000,
  "order_type": "maker",
  "period": "120m",
  "profit_stop_enable_pct": 0,
  "profit_stop_pct": 1,
  "rsi_periods": 14,
  "selector": "kraken.XXRP-ZEUR",
  "sell_pct": 99,
  "sell_stop_pct": 0,
  "show_options": true,
  "smalen1": 108,
  "smalen2": 60,
  "start": 1507939200000,
  "stats": false,
  "strategy": "crossover_vwap",
  "verbose": false,
  "vwap_length": 10,
  "vwap_max": 8000
}
end balance: 1538.51299549 (119.78%)
buy hold: 1218.53870819 (74.07%)
vs. buy hold: 26.25%
18 trades over 62 days (avg 0.29 trades/day)
win/loss: 4/4
error rate: 50.00%
```

Assuming lower slippage, e.g taker/instant orders, the results are stronger:
```zenbot sim kraken.XXRP-ZEUR --period="120m" --strategy=crossover_vwap --currency_capital=700 --asset_capital=0 --max_slippage_pct=100 --days=60 --avg_slippage_pct=0.045
2017-12-13 11:59:59  0.383310 XXRP-ZEUR   +3.49%    4.77m   92 +++++0.38272 0.25607   +91.56%  4604.42017895 XXRP    8.81 ZEUR+153.39%  +44.30%
{
  "asset_capital": 0,
  "avg_slippage_pct": 0.045,
  "buy_pct": 99,
  "buy_stop_pct": 0,
  "currency_capital": 700,
  "days": 60,
  "emalen1": 30,
  "markdown_buy_pct": 0,
  "markup_sell_pct": 0,
  "max_sell_loss_pct": 25,
  "max_slippage_pct": "100",
  "min_periods": 1,
  "mode": "sim",
  "order_adjust_time": 5000,
  "order_type": "maker",
  "period": "120m",
  "profit_stop_enable_pct": 0,
  "profit_stop_pct": 1,
  "rsi_periods": 14,
  "selector": "kraken.XXRP-ZEUR",
  "sell_pct": 99,
  "sell_stop_pct": 0,
  "show_options": true,
  "smalen1": 108,
  "smalen2": 60,
  "start": 1507939200000,
  "stats": false,
  "strategy": "crossover_vwap",
  "verbose": false,
  "vwap_length": 10,
  "vwap_max": 8000
}
end balance: 1763.05037236 (151.86%)
buy hold: 1221.68117269 (74.52%)
vs. buy hold: 44.31%
18 trades over 62 days (avg 0.29 trades/day)
win/loss: 4/4
error rate: 50.00%
```

