### PR TITLE
HTML report graphs use green arrows when buying

### DIFF
--- a/templates/sim_result.html.tpl
+++ b/templates/sim_result.html.tpl
@@ -200,10 +200,14 @@ path.middle, path.zero {
 }
 
 .tradearrow path.tradearrow {
-    stroke: none;
+    stroke: black;
 }
 
-.tradearrow path.buy, .tradearrow path.sell {
+.tradearrow path.buy {
+    fill: #00ff00;
+}
+
+.tradearrow path.sell {
     fill: #ff0056;
 }
 


### PR DESCRIPTION
It's easier to read the graph, especially for graphs with a lot of buy/sell.