### PR TITLE
Improve XMPP reliability

### DIFF
--- a/extensions/notifiers/xmpp.js
+++ b/extensions/notifiers/xmpp.js
@@ -3,16 +3,17 @@ var simplexmpp = require('simple-xmpp')
 module.exports = function container (get, set, clear) {
   var xmpp = {
     pushMessage: function(config, title, message) {
-      simplexmpp.connect({
-        jid      : config.jid,
-        password : config.password,
-        host     : config.host,
-        port     : config.port
-      })
+      if (!simplexmpp.conn) {
+        simplexmpp.connect({
+          jid       : config.jid,
+          password  : config.password,
+          host      : config.host,
+          port      : config.port,
+          reconnect : true
+        })
+      }
 
       simplexmpp.send(config.to, title + ': ' + message)
-
-      simplexmpp.disconnect()
     }
   }
   return xmpp


### PR DESCRIPTION
The XMPP notifier is awfully unreliable, at least for me, due to the connect/disconnect at every notification, especially if the bot is happily doing what he is supposed to do - trade.

At some point my XMPP server will start rate-limiting the connection causing a whole lot of notifications to never get delivered.

This will make the notifier act more like a real XMPP client by only connecting once, keeping the connection open and reconnecting if necessary.