### PR TITLE
[Bitstamp] Fix order completion detection & balance reading during open order.

### DIFF
--- a/extensions/exchanges/bitstamp/exchange.js
+++ b/extensions/exchanges/bitstamp/exchange.js
@@ -242,14 +242,21 @@ module.exports = function container (get, set, clear) {
         if (body.status === 'error') {
 	        return retry('getBalance', args)
         }
-        var balance = {asset: 0, currency: 0}
+        var balance = {
+          asset: '0',
+          asset_hold: '0',
+          currency: '0',
+          currency_hold: '0'
+        }
+                
         // Dirty hack to avoid engine.js bailing out when balance has 0 value
         // The added amount is small enough to not have any significant effect
-        balance.currency = n(body[opts.currency.toLowerCase() + '_available']) + 0.000001
-        balance.asset = n(body[opts.asset.toLowerCase() + '_available']) + 0.000001
-        balance.currency_hold = 0
-        balance.asset_hold = 0
-				if (typeof balance.asset == undefined || typeof balance.currency == undefined ) {
+        balance.currency = n(body[opts.currency.toLowerCase() + '_balance']) + 0.000001
+        balance.asset = n(body[opts.asset.toLowerCase() + '_balance']) + 0.000001
+        balance.currency_hold = n(body[opts.currency.toLowerCase() + '_reserved']) + 0.000001
+        balance.asset_hold = n(body[opts.asset.toLowerCase() + '_reserved']) + 0.000001
+
+				if (typeof balance.asset == undefined || typeof balance.currency == undefined) {
           console.log('Communication delay, fallback to previous balance')
 					balance = lastBalance
 				} else {
@@ -263,6 +270,7 @@ module.exports = function container (get, set, clear) {
       var func_args = [].slice.call(arguments)
       var client = authedClient()
       client.cancel_order(opts.order_id, function (err, body) {
+
         body = statusErr(err,body)
         if (body.status === 'error') {
 	        return retry('cancelOrder', func_args, err)
@@ -290,6 +298,7 @@ module.exports = function container (get, set, clear) {
             // 'In Queue', 'Open', 'Finished'
             body.status = 'done'
           }
+
           orders['~' + body.id] = body
           cb(null, body)
         })
@@ -320,6 +329,7 @@ module.exports = function container (get, set, clear) {
       var func_args = [].slice.call(arguments)
       var client = authedClient()
       client.order_status(opts.order_id, function (err, body) {
+
         body = statusErr(err,body)
         if (body.status === 'error') {
           body = orders['~' + opts.order_id]
@@ -327,6 +337,8 @@ module.exports = function container (get, set, clear) {
           body.done_reason = 'canceled'
         } else if(body.status === 'Finished')
           body.status = 'done';
+        
+        if(body.datetime) body.time = body.datetime;
         
         cb(null, body)
       })

--- a/extensions/exchanges/bitstamp/exchange.js
+++ b/extensions/exchanges/bitstamp/exchange.js
@@ -325,7 +325,9 @@ module.exports = function container (get, set, clear) {
           body = orders['~' + opts.order_id]
           body.status = 'done'
           body.done_reason = 'canceled'
-        } 
+        } else if(body.status === 'Finished')
+          body.status = 'done';
+        
         cb(null, body)
       })
     },


### PR DESCRIPTION
The key fix is for issue #901. Zenbot places an order on bitstamp and doesn't realise it's completed when the order status comes back as "Finished". I've added some logic to change it to "done" when that happens.

When an order completed, the message from zenbot couldn't read the date returned from the API:
`sell order completed at Invalid date:`

Added a bit of logic to map datetime to date, so the engine.js logic can read it properly. Lastly, while an order is open/placed with bitstamp, the current logic read the current balance as 0 and the balance on hold was hardcoded as 0. I've mapped that correctly to x_balance and x_reserved from the bitstamp API response.