### PR TITLE
Expansion on PR #854, missed this hardcoded section in the auto-dump (shift + D).

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -272,14 +272,12 @@ module.exports = function container (get, set, clear) {
             return colors.stripColors(line)
           }).join('\n')
           var data = s.lookback.slice(0, s.lookback.length - so.min_periods).map(function (period) {
-            return {
-              time: period.time,
-              open: period.open,
-              high: period.high,
-              low: period.low,
-              close: period.close,
-              volume: period.volume
+            var data = {};
+            var keys = Object.keys(period);
+            for(i = 0;i < keys.length;i++){
+              data[keys[i]] = period[keys[i]];
             }
+            return data;
           })
           var code = 'var data = ' + JSON.stringify(data) + ';\n'
           code += 'var trades = ' + JSON.stringify(s.my_trades) + ';\n'


### PR DESCRIPTION
Expansion on PR #854, missed this hardcoded section in the auto-dump (shift + D).

> Instead of hardcoding which values are included in the export, include all values in the export. Allows for further enhancement of the graphs. #854