### PR TITLE
rename so period to so period size

### DIFF
--- a/commands/backfill.js
+++ b/commands/backfill.js
@@ -154,7 +154,7 @@ module.exports = function container (get, set, clear) {
                     if (err) throw err
                     trade_counter += trades.length
                     day_trade_counter += trades.length
-                    var current_days_left = Math.ceil((mode === 'backward' ? marker.oldest_time - target_time : target_time - marker.newest_time) / 86400000)
+                    var current_days_left = 1 + (mode === 'backward' ? tb(marker.oldest_time - target_time).resize('1d').value : tb(target_time - marker.newest_time).resize('1d').value)
                     if (current_days_left >= 0 && current_days_left != days_left) {
                       console.log('\n' + selector, 'saved', day_trade_counter, 'trades', current_days_left, 'days left')
                       day_trade_counter = 0
@@ -175,6 +175,7 @@ module.exports = function container (get, set, clear) {
                   })
                 })
               }
+
               runTasks()
             })
           }

--- a/commands/sim.js
+++ b/commands/sim.js
@@ -48,6 +48,9 @@ module.exports = function container (get, set, clear) {
             so[k] = cmd[k]
           }
         })
+
+        so.periodSize = so.period
+
         if (so.start) {
           so.start = moment(so.start, "YYYYMMDDhhmm").valueOf()
           if (so.days && !so.end) {
@@ -78,7 +81,7 @@ module.exports = function container (get, set, clear) {
         var engine = get('lib.engine')(s)
         if (!so.min_periods) so.min_periods = 1
         var cursor, reversing, reverse_point
-        var query_start = so.start ? tb(so.start).resize(so.period).subtract(so.min_periods + 2).toMilliseconds() : null
+        var query_start = so.start ? tb(so.start).resize(so.periodSize).subtract(so.min_periods + 2).toMilliseconds() : null
 
         function exitSim () {
           console.log()

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -54,6 +54,7 @@ module.exports = function container (get, set, clear) {
             so[k] = cmd[k]
           }
         })
+        so.periodSize = so.period
         so.debug = cmd.debug
         so.stats = !cmd.disable_stats
         so.mode = so.paper ? 'paper' : 'live'
@@ -112,7 +113,7 @@ module.exports = function container (get, set, clear) {
           ].join('') + '\n')
           process.stdout.write([
             z(15, (so.mode === 'paper' ? '      ' : (so.mode === 'live' && (so.manual === false || typeof so.manual === 'undefined')) ? '       ' + 'AUTO'.black.bgRed + '    ' : '       ' + 'MANUAL'.black.bgGreen + '  '), ' '),
-            z(13, so.period, ' '),
+            z(13, so.periodSize, ' '),
             z(29, (so.order_type === 'maker' ? so.order_type.toUpperCase().green : so.order_type.toUpperCase().red), ' '),
             z(31, (so.mode === 'paper' ? 'avg. '.grey + so.avg_slippage_pct + '%' : 'max '.grey + so.max_slippage_pct + '%'), ' '),
             z(20, (so.order_type === 'maker' ? so.order_type + ' ' + s.exchange.makerFee : so.order_type + ' ' + s.exchange.takerFee), ' ')
@@ -308,7 +309,7 @@ module.exports = function container (get, set, clear) {
         }
 
         var db_cursor, trade_cursor
-        var query_start = tb().resize(so.period).subtract(so.min_periods * 2).toMilliseconds()
+        var query_start = tb().resize(so.periodSize).subtract(so.min_periods * 2).toMilliseconds()
         var days = Math.ceil((new Date().getTime() - query_start) / 86400000)
         var session = null
         var sessions = get('db.sessions')

--- a/commands/train.js
+++ b/commands/train.js
@@ -82,6 +82,8 @@ module.exports = function container (get, set, clear) {
             so[k] = cmd[k]
           }
         })
+
+        so.periodSize = so.period;
         
         if (!so.days_test) { so.days_test = 0 }
         so.strategy = 'noop'
@@ -131,13 +133,13 @@ module.exports = function container (get, set, clear) {
 
         if (!so.min_periods) so.min_periods = 1
         var cursor, reversing, reverse_point
-        var query_start = so.start_training ? tb(so.start_training).resize(so.period).subtract(so.min_periods + 2).toMilliseconds() : null
+        var query_start = so.start_training ? tb(so.start_training).resize(so.periodSize).subtract(so.min_periods + 2).toMilliseconds() : null
         
         function writeTempModel (strategy) {
           var tempModelString = JSON.stringify(
             {
               "selector": so.selector,
-              "period": so.period,
+              "period": so.periodSize,
               "start_training": moment(so.start_training),
               "end_training": moment(so.end_training),
               "options": fa_getTrainOptions(so),
@@ -159,7 +161,7 @@ module.exports = function container (get, set, clear) {
           var finalModelString = JSON.stringify(
             {
               "selector": so.selector,
-              "period": so.period,
+              "period": so.periodSize,
               "start_training": moment(so.start_training).utc(),
               "end_training": moment(end_training).utc(),
               "result_training": trainingResult,
@@ -172,7 +174,7 @@ module.exports = function container (get, set, clear) {
           var testVsBuyHold = typeof(testResult) !== "undefined" ? testResult.vsBuyHold : 'noTest'
 
           var finalModelFile = 'models/forex.model_' + so.selector
-            + '_period=' + so.period
+            + '_period=' + so.periodSize
             + '_from=' + moment(so.start_training).utc().format('YYYYMMDD_HHmmssZZ')
             + '_to=' + moment(end_training).utc().format('YYYYMMDD_HHmmssZZ')
             + '_trainingVsBuyHold=' + trainingResult.vsBuyHold
@@ -234,7 +236,7 @@ module.exports = function container (get, set, clear) {
             '--modelfile', path.resolve(__dirname, '..', tempModelFile),
             '--start', so.start_training,
             '--end', so.end_training,
-            '--period', so.period,
+            '--period', so.periodSize,
             '--filename', path.resolve(__dirname, '..', tempModelFile) + '-simTrainingResult.html'
           ]
           var trainingSimulation = spawn(path.resolve(__dirname, '..', zenbot_cmd), trainingArgs, { stdio: 'inherit' })
@@ -260,7 +262,7 @@ module.exports = function container (get, set, clear) {
                 '--disable_options',
                 '--modelfile', path.resolve(__dirname, '..', tempModelFile),
                 '--start', so.end_training,
-                '--period', so.period,
+                '--period', so.periodSize,
                 '--filename', path.resolve(__dirname, '..', tempModelFile) + '-simTestResult.html',
               ]
               var testSimulation = spawn(path.resolve(__dirname, '..', zenbot_cmd), testArgs, { stdio: 'inherit' })

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -14,6 +14,7 @@ module.exports = function container (get, set, clear) {
   var notify = get('lib.notify')
   return function (s) {
     var so = s.options
+    so.periodSize = so.period
     s.selector = get('lib.normalize-selector')(so.selector)
     var selector_parts = s.selector.split('.')
     s.exchange = get('exchanges.' + selector_parts[0])
@@ -119,10 +120,10 @@ module.exports = function container (get, set, clear) {
     }
 
     function initBuffer (trade) {
-      var d = tb(trade.time).resize(so.period)
+      var d = tb(trade.time).resize(so.periodSize)
       s.period = {
         period_id: d.toString(),
-        size: so.period,
+        size: so.periodSize,
         time: d.toMilliseconds(),
         open: trade.price,
         high: trade.price,
@@ -684,7 +685,7 @@ module.exports = function container (get, set, clear) {
       }
       readline.clearLine(process.stdout)
       readline.cursorTo(process.stdout, 0)
-      process.stdout.write(moment(is_progress ? s.period.close_time : tb(s.period.time).resize(so.period).add(1).toMilliseconds()).format('YYYY-MM-DD HH:mm:ss')[is_progress && !blink_off ? 'bgBlue' : 'grey'])
+      process.stdout.write(moment(is_progress ? s.period.close_time : tb(s.period.time).resize(so.periodSize).add(1).toMilliseconds()).format('YYYY-MM-DD HH:mm:ss')[is_progress && !blink_off ? 'bgBlue' : 'grey'])
       process.stdout.write('  ' + fc(s.period.close, true, true, true) + ' ' + s.product_id.grey)
       if (s.lookback[0]) {
         var diff = (s.period.close - s.lookback[0].close) / s.lookback[0].close
@@ -796,7 +797,7 @@ module.exports = function container (get, set, clear) {
             if (s.period && trade.time < s.period.time) {
               return done()
             }
-            var period_id = tb(trade.time).resize(so.period).toString()
+            var period_id = tb(trade.time).resize(so.periodSize).toString()
             var day = tb(trade.time).resize('1d')
             if (s.last_day && s.last_day.toString() && day.toString() !== s.last_day.toString()) {
               s.day_count++


### PR DESCRIPTION
This leaves the command line parameter --period in place, but deals with the value for it within the code as 'periodSize'. This name more accurately describes what is in the variable. This is especially true in light of the s.period object created in engine.js. That object describes high and low values over a period of time.

I'm not stuck on the name periodSize.. periodLength I think is appropriate, too. The phrase 'period length' is used in the description for the command line variable 'period'.