### PR TITLE
#938, Fixing Error: invalid bucket size spec: undefined

### DIFF
--- a/commands/sim.js
+++ b/commands/sim.js
@@ -49,7 +49,7 @@ module.exports = function container (get, set, clear) {
           }
         })
 
-        so.periodSize = so.period
+        so.periodLength = so.period
 
         if (so.start) {
           so.start = moment(so.start, "YYYYMMDDhhmm").valueOf()
@@ -81,7 +81,7 @@ module.exports = function container (get, set, clear) {
         var engine = get('lib.engine')(s)
         if (!so.min_periods) so.min_periods = 1
         var cursor, reversing, reverse_point
-        var query_start = so.start ? tb(so.start).resize(so.periodSize).subtract(so.min_periods + 2).toMilliseconds() : null
+        var query_start = so.start ? tb(so.start).resize(so.periodLength).subtract(so.min_periods + 2).toMilliseconds() : null
 
         function exitSim () {
           console.log()

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -54,7 +54,7 @@ module.exports = function container (get, set, clear) {
             so[k] = cmd[k]
           }
         })
-        so.periodSize = so.period
+        so.periodLength = so.period
         so.debug = cmd.debug
         so.stats = !cmd.disable_stats
         so.mode = so.paper ? 'paper' : 'live'
@@ -113,7 +113,7 @@ module.exports = function container (get, set, clear) {
           ].join('') + '\n')
           process.stdout.write([
             z(15, (so.mode === 'paper' ? '      ' : (so.mode === 'live' && (so.manual === false || typeof so.manual === 'undefined')) ? '       ' + 'AUTO'.black.bgRed + '    ' : '       ' + 'MANUAL'.black.bgGreen + '  '), ' '),
-            z(13, so.periodSize, ' '),
+            z(13, so.periodLength, ' '),
             z(29, (so.order_type === 'maker' ? so.order_type.toUpperCase().green : so.order_type.toUpperCase().red), ' '),
             z(31, (so.mode === 'paper' ? 'avg. '.grey + so.avg_slippage_pct + '%' : 'max '.grey + so.max_slippage_pct + '%'), ' '),
             z(20, (so.order_type === 'maker' ? so.order_type + ' ' + s.exchange.makerFee : so.order_type + ' ' + s.exchange.takerFee), ' ')
@@ -309,7 +309,7 @@ module.exports = function container (get, set, clear) {
         }
 
         var db_cursor, trade_cursor
-        var query_start = tb().resize(so.periodSize).subtract(so.min_periods * 2).toMilliseconds()
+        var query_start = tb().resize(so.periodLength).subtract(so.min_periods * 2).toMilliseconds()
         var days = Math.ceil((new Date().getTime() - query_start) / 86400000)
         var session = null
         var sessions = get('db.sessions')

--- a/commands/train.js
+++ b/commands/train.js
@@ -83,7 +83,7 @@ module.exports = function container (get, set, clear) {
           }
         })
 
-        so.periodSize = so.period;
+        so.periodLength = so.period;
         
         if (!so.days_test) { so.days_test = 0 }
         so.strategy = 'noop'
@@ -133,13 +133,13 @@ module.exports = function container (get, set, clear) {
 
         if (!so.min_periods) so.min_periods = 1
         var cursor, reversing, reverse_point
-        var query_start = so.start_training ? tb(so.start_training).resize(so.periodSize).subtract(so.min_periods + 2).toMilliseconds() : null
+        var query_start = so.start_training ? tb(so.start_training).resize(so.periodLength).subtract(so.min_periods + 2).toMilliseconds() : null
         
         function writeTempModel (strategy) {
           var tempModelString = JSON.stringify(
             {
               "selector": so.selector,
-              "period": so.periodSize,
+              "period": so.periodLength,
               "start_training": moment(so.start_training),
               "end_training": moment(so.end_training),
               "options": fa_getTrainOptions(so),
@@ -161,7 +161,7 @@ module.exports = function container (get, set, clear) {
           var finalModelString = JSON.stringify(
             {
               "selector": so.selector,
-              "period": so.periodSize,
+              "period": so.periodLength,
               "start_training": moment(so.start_training).utc(),
               "end_training": moment(end_training).utc(),
               "result_training": trainingResult,
@@ -174,7 +174,7 @@ module.exports = function container (get, set, clear) {
           var testVsBuyHold = typeof(testResult) !== "undefined" ? testResult.vsBuyHold : 'noTest'
 
           var finalModelFile = 'models/forex.model_' + so.selector
-            + '_period=' + so.periodSize
+            + '_period=' + so.periodLength
             + '_from=' + moment(so.start_training).utc().format('YYYYMMDD_HHmmssZZ')
             + '_to=' + moment(end_training).utc().format('YYYYMMDD_HHmmssZZ')
             + '_trainingVsBuyHold=' + trainingResult.vsBuyHold
@@ -236,7 +236,7 @@ module.exports = function container (get, set, clear) {
             '--modelfile', path.resolve(__dirname, '..', tempModelFile),
             '--start', so.start_training,
             '--end', so.end_training,
-            '--period', so.periodSize,
+            '--period', so.periodLength,
             '--filename', path.resolve(__dirname, '..', tempModelFile) + '-simTrainingResult.html'
           ]
           var trainingSimulation = spawn(path.resolve(__dirname, '..', zenbot_cmd), trainingArgs, { stdio: 'inherit' })
@@ -262,7 +262,7 @@ module.exports = function container (get, set, clear) {
                 '--disable_options',
                 '--modelfile', path.resolve(__dirname, '..', tempModelFile),
                 '--start', so.end_training,
-                '--period', so.periodSize,
+                '--period', so.periodLength,
                 '--filename', path.resolve(__dirname, '..', tempModelFile) + '-simTestResult.html',
               ]
               var testSimulation = spawn(path.resolve(__dirname, '..', zenbot_cmd), testArgs, { stdio: 'inherit' })

--- a/extensions/strategies/cci_srsi/strategy.js
+++ b/extensions/strategies/cci_srsi/strategy.js
@@ -7,7 +7,8 @@ module.exports = function container (get, set, clear) {
     description: 'Stochastic CCI Strategy',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '20m')
+      this.option('period', 'period length, same as --periodLength', String, '20m')
+      this.option('periodLength', 'period length, same as --period', String, '20m')
       this.option('min_periods', 'min. number of history periods', Number, 30)
       this.option('ema_acc', 'sideways threshold (0.2-0.4)', Number, 0.03)
       this.option('cci_periods', 'number of RSI periods', Number, 14)

--- a/extensions/strategies/macd/strategy.js
+++ b/extensions/strategies/macd/strategy.js
@@ -7,7 +7,8 @@ module.exports = function container (get, set, clear) {
     description: 'Buy when (MACD - Signal > 0) and sell when (MACD - Signal < 0).',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '1h')
+      this.option('period', 'period length, same as --periodLength', String, '1h')
+      this.option('periodLength', 'period length, same as --period', String, '1h')
       this.option('min_periods', 'min. number of history periods', Number, 52)
       this.option('ema_short_period', 'number of periods for the shorter EMA', Number, 12)
       this.option('ema_long_period', 'number of periods for the longer EMA', Number, 26)

--- a/extensions/strategies/noop/strategy.js
+++ b/extensions/strategies/noop/strategy.js
@@ -4,7 +4,8 @@ module.exports = function container (get, set, clear) {
     description: 'Just do nothing. Can be used to e.g. generate candlesticks for training the genetic forex strategy.',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '30m')
+      this.option('period', 'period length, same as --periodLength', String, '30m')
+      this.option('periodLength', 'period length, same as --period', String, '30m')
     },
 
     calculate: function (s) {

--- a/extensions/strategies/rsi/strategy.js
+++ b/extensions/strategies/rsi/strategy.js
@@ -7,7 +7,8 @@ module.exports = function container (get, set, clear) {
     description: 'Attempts to buy low and sell high by tracking RSI high-water readings.',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '2m')
+      this.option('period', 'period length, same as --periodLength', String, '2m')
+      this.option('periodLength', 'period length, same as --period', String, '2m')
       this.option('min_periods', 'min. number of history periods', Number, 52)
       this.option('rsi_periods', 'number of RSI periods', 14)
       this.option('oversold_rsi', 'buy when RSI reaches or drops below this value', Number, 30)

--- a/extensions/strategies/sar/strategy.js
+++ b/extensions/strategies/sar/strategy.js
@@ -7,7 +7,8 @@ module.exports = function container (get, set, clear) {
     description: 'Parabolic SAR',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '2m')
+      this.option('period', 'period length, same as --periodLength', String, '2m')
+      this.option('periodLength', 'period length, same as --period', String, '2m')
       this.option('min_periods', 'min. number of history periods', Number, 52)
       this.option('sar_af', 'acceleration factor for parabolic SAR', Number, 0.015)
       this.option('sar_max_af', 'max acceleration factor for parabolic SAR', Number, 0.3)

--- a/extensions/strategies/speed/strategy.js
+++ b/extensions/strategies/speed/strategy.js
@@ -7,7 +7,8 @@ module.exports = function container (get, set, clear) {
     description: 'Trade when % change from last two 1m periods is higher than average.',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '1m')
+      this.option('period', 'period length, same as --periodLength', String, '1m')
+      this.option('periodLength', 'period length, same as --period', String, '1m')
       this.option('min_periods', 'min. number of history periods', Number, 3000)
       this.option('baseline_periods', 'lookback periods for volatility baseline', Number, 3000)
       this.option('trigger_factor', 'multiply with volatility baseline EMA to get trigger value', Number, 1.6)

--- a/extensions/strategies/srsi_macd/strategy.js
+++ b/extensions/strategies/srsi_macd/strategy.js
@@ -7,7 +7,8 @@ module.exports = function container (get, set, clear) {
     description: 'Stochastic MACD Strategy',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '30m')
+      this.option('period', 'period length, same as --periodLength', String, '30m')
+      this.option('periodLength', 'period length, same as --period', String, '30m')
       this.option('min_periods', 'min. number of history periods', Number, 200)
       this.option('rsi_periods', 'number of RSI periods', 14)
       this.option('srsi_periods', 'number of RSI periods', Number, 9)

--- a/extensions/strategies/ta_ema/strategy.js
+++ b/extensions/strategies/ta_ema/strategy.js
@@ -7,7 +7,8 @@ module.exports = function container (get, set, clear) {
     description: 'Buy when (EMA - last(EMA) > 0) and sell when (EMA - last(EMA) < 0). Optional buy on low RSI.',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '10m')
+      this.option('period', 'period length, same as --periodLength', String, '10m')
+      this.option('periodLength', 'period length, same as --period', String, '10m')
       this.option('min_periods', 'min. number of history periods', Number, 52)
       this.option('trend_ema', 'number of periods for trend EMA', Number, 20)
       this.option('neutral_rate', 'avoid trades if abs(trend_ema) under this float (0 to disable, "auto" for a variable filter)', Number, 0.06)

--- a/extensions/strategies/ta_macd/strategy.js
+++ b/extensions/strategies/ta_macd/strategy.js
@@ -7,7 +7,8 @@ module.exports = function container (get, set, clear) {
     description: 'Buy when (MACD - Signal > 0) and sell when (MACD - Signal < 0).',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '1h')
+      this.option('period', 'period length, same as --periodLength', String, '1h')
+      this.option('periodLength', 'period length, same as --period', String, '1h')
       this.option('min_periods', 'min. number of history periods', Number, 52)
       this.option('ema_short_period', 'number of periods for the shorter EMA', Number, 12)
       this.option('ema_long_period', 'number of periods for the longer EMA', Number, 26)

--- a/extensions/strategies/trend_ema/strategy.js
+++ b/extensions/strategies/trend_ema/strategy.js
@@ -7,7 +7,8 @@ module.exports = function container (get, set, clear) {
     description: 'Buy when (EMA - last(EMA) > 0) and sell when (EMA - last(EMA) < 0). Optional buy on low RSI.',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '2m')
+      this.option('period', 'period length, same as --periodLength', String, '2m')
+      this.option('periodLength', 'period length, same as --period', String, '2m')
       this.option('min_periods', 'min. number of history periods', Number, 52)
       this.option('trend_ema', 'number of periods for trend EMA', Number, 26)
       this.option('neutral_rate', 'avoid trades if abs(trend_ema) under this float (0 to disable, "auto" for a variable filter)', Number, 'auto')

--- a/extensions/strategies/trendline/strategy.js
+++ b/extensions/strategies/trendline/strategy.js
@@ -8,7 +8,8 @@ module.exports = function container (get, set, clear) {
     name: 'trendline',
     description: 'Calculate a trendline and trade when trend is positive vs negative.',
     getOptions: function () {
-      this.option('period', 'period length', String, '1s')
+      this.option('period', 'period length, same as --periodLength', String, '1s')
+      this.option('periodLength', 'period length, same as --period', String, '1s')
       this.option('lastpoints', "Number of trades for short trend average", Number, 100)
       this.option('avgpoints', "Number of trades for long trend average", Number, 1000)
       this.option('lastpoints2', "Number of trades for short trend average", Number, 10)

--- a/extensions/strategies/trust_distrust/strategy.js
+++ b/extensions/strategies/trust_distrust/strategy.js
@@ -7,7 +7,8 @@ module.exports = function container (get, set, clear) {
     description: 'Sell when price higher than $sell_min% and highest point - $sell_threshold% is reached. Buy when lowest price point + $buy_threshold% reached.',
 
     getOptions: function () {
-      this.option('period', 'period length', String, '30m')
+      this.option('period', 'period length, same as --periodLength', String, '30m')
+      this.option('periodLength', 'period length, same as --period', String, '30m')
       this.option('min_periods', 'min. number of history periods', Number, 52)
       this.option('sell_threshold', 'sell when the top drops at least below this percentage', Number, 2)
       this.option('sell_threshold_max', 'sell when the top drops lower than this max, regardless of sell_min (panic sell, 0 to disable)', Number, 0)

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -14,7 +14,7 @@ module.exports = function container (get, set, clear) {
   var notify = get('lib.notify')
   return function (s) {
     var so = s.options
-    so.periodSize = so.period
+    so.periodLength = so.period
     s.selector = get('lib.normalize-selector')(so.selector)
     var selector_parts = s.selector.split('.')
     s.exchange = get('exchanges.' + selector_parts[0])
@@ -120,10 +120,10 @@ module.exports = function container (get, set, clear) {
     }
 
     function initBuffer (trade) {
-      var d = tb(trade.time).resize(so.periodSize)
+      var d = tb(trade.time).resize(so.periodLength)
       s.period = {
         period_id: d.toString(),
-        size: so.periodSize,
+        size: so.periodLength,
         time: d.toMilliseconds(),
         open: trade.price,
         high: trade.price,
@@ -685,7 +685,7 @@ module.exports = function container (get, set, clear) {
       }
       readline.clearLine(process.stdout)
       readline.cursorTo(process.stdout, 0)
-      process.stdout.write(moment(is_progress ? s.period.close_time : tb(s.period.time).resize(so.periodSize).add(1).toMilliseconds()).format('YYYY-MM-DD HH:mm:ss')[is_progress && !blink_off ? 'bgBlue' : 'grey'])
+      process.stdout.write(moment(is_progress ? s.period.close_time : tb(s.period.time).resize(so.periodLength).add(1).toMilliseconds()).format('YYYY-MM-DD HH:mm:ss')[is_progress && !blink_off ? 'bgBlue' : 'grey'])
       process.stdout.write('  ' + fc(s.period.close, true, true, true) + ' ' + s.product_id.grey)
       if (s.lookback[0]) {
         var diff = (s.period.close - s.lookback[0].close) / s.lookback[0].close
@@ -797,7 +797,7 @@ module.exports = function container (get, set, clear) {
             if (s.period && trade.time < s.period.time) {
               return done()
             }
-            var period_id = tb(trade.time).resize(so.periodSize).toString()
+            var period_id = tb(trade.time).resize(so.periodLength).toString()
             var day = tb(trade.time).resize('1d')
             if (s.last_day && s.last_day.toString() && day.toString() !== s.last_day.toString()) {
               s.day_count++


### PR DESCRIPTION
In addition to the options on a command, there are options on 
strategies. There is a callback function in engine.js which sets the
options as defined in a strategy. The strategy objects were not
updated to have a periodSize option, only a period option. So,
the periodSize attribute was not being set. This caused the
execption in this bug.

This commit adds a second option, named 'periodLength'. The name
'periodLength' was chosen, rather than the previous 'periodSize' for
consistency; the description for the --period option already said
'period length', so it made sense that the additional variable be named
that as well.

Each reference to *.periodSize has been changed to *.periodLength.

This commit continues PR #926.