### PR TITLE
CEXIO api update to version 1.0.8 - solves Nonce increment error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -399,9 +399,9 @@
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
     },
     "ccxt": {
-      "version": "1.10.420",
-      "resolved": "https://registry.npmjs.org/ccxt/-/ccxt-1.10.420.tgz",
-      "integrity": "sha512-kwqBXX0b4bdBb/CqoPv36pkYMza4sm6CiCb9tdNZ6jWoC5Y5v52PYAFxp4FB/Z0knPA35ww7y0iLyC6vnniLmw==",
+      "version": "1.10.429",
+      "resolved": "https://registry.npmjs.org/ccxt/-/ccxt-1.10.429.tgz",
+      "integrity": "sha512-GtN2bkzrUiQQyC+GCLzcQGiuSIYgeGXuYXC2mk2zm6yOJSYWSs8kC3tLJBsVbrL04L04JIz6mFNmAd8zMiDVNQ==",
       "requires": {
         "crypto-js": "3.1.9-1",
         "fetch-ponyfill": "4.1.0",
@@ -416,9 +416,9 @@
       }
     },
     "cexio-api-node": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cexio-api-node/-/cexio-api-node-1.0.7.tgz",
-      "integrity": "sha512-9GTbEW2W9nPyM7wqX23yyZAvkvtsXtnuDUFJZWXb296VeyuJPVOLiYaKCLhf8+nEkILno/a9xq/edpTX2rfp/A==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/cexio-api-node/-/cexio-api-node-1.0.8.tgz",
+      "integrity": "sha512-vmv090Y7noSohend7XTBMGtXQcOIb5ouLKk/CYfnWr+4deiTv8ie7+sSgszvgGSE689iLDPSFIkrhzeL9CO5yg==",
       "requires": {
         "crypto": "1.0.1",
         "moment": "2.20.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bitfinex-api-node": "^1.2.0",
     "bitstamp": "^1.0.4",
     "bl": "^1.2.1",
-    "cexio-api-node": "^1.0.7",
+    "cexio-api-node": "^1.0.8",
     "cliff": "^0.1.10",
     "codemap": "^1.3.1",
     "colors": "^1.1.2",


### PR DESCRIPTION
`npm install` after `git pull` and generate new API keys on exchange!