### PR TITLE
GDAX now supports Bitcoin Cash (BCH)

### DIFF
--- a/extensions/exchanges/gdax/products.json
+++ b/extensions/exchanges/gdax/products.json
@@ -70,5 +70,29 @@
     "max_size": "250",
     "increment": "0.01",
     "label": "BTC/GBP"
+  },
+  {
+    "asset": "BCH",
+    "currency": "USD",
+    "min_size": "0.0001",
+    "max_size": "250",
+    "increment": "0.01",
+    "label": "BCH/USD"
+  },
+  {
+    "asset": "BCH",
+    "currency": "EUR",
+    "min_size": "0.0001",
+    "max_size": "250",
+    "increment": "0.01",
+    "label": "BCH/EUR"
+  },
+  {
+    "asset": "BCH",
+    "currency": "BTC",
+    "min_size": "0.0001",
+    "max_size": "250",
+    "increment": "0.01",
+    "label": "BCH/BTC"
   }
 ]


### PR DESCRIPTION
Numbers taken from https://api.gdax.com/products