### PR TITLE
Add post-install to remove .git folder from forex.analytics npm module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "bin": {
     "zenbot": "./zenbot.sh"
   },
+  "scripts": {
+    "postinstall": "rm -rf node_modules/forex.analytics/.git"
+  },
   "dependencies": {
     "@slack/client": "^3.14.0",
     "async": "^2.5.0",


### PR DESCRIPTION
This stops issue #700 from being asked about every week, meaning you can just npm install after a new git pull. No need to manually remove node_modules every update.