### PR TITLE
--periodLength value is kept in sim, trade, train commands

### DIFF
--- a/commands/sim.js
+++ b/commands/sim.js
@@ -49,8 +49,6 @@ module.exports = function container (get, set, clear) {
           }
         })
 
-        so.periodLength = so.period
-
         if (so.start) {
           so.start = moment(so.start, "YYYYMMDDhhmm").valueOf()
           if (so.days && !so.end) {

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -54,7 +54,7 @@ module.exports = function container (get, set, clear) {
             so[k] = cmd[k]
           }
         })
-        so.periodLength = so.period
+
         so.debug = cmd.debug
         so.stats = !cmd.disable_stats
         so.mode = so.paper ? 'paper' : 'live'

--- a/commands/train.js
+++ b/commands/train.js
@@ -83,8 +83,6 @@ module.exports = function container (get, set, clear) {
           }
         })
 
-        so.periodLength = so.period;
-        
         if (!so.days_test) { so.days_test = 0 }
         so.strategy = 'noop'
 

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -18,7 +18,11 @@ module.exports = function container (get, set, clear) {
     s.product_id = so.selector.product_id
     s.asset = so.selector.asset
     s.currency = so.selector.currency
-    so.periodLength = so.period
+    
+    if (typeof so.periodLength == 'undefined')
+      so.periodLength = so.period
+    else
+      so.period = so.periodLength
     
     var products = s.exchange.getProducts()
     products.forEach(function (product) {


### PR DESCRIPTION
The value was being overwritten, so defaults were being applied. 

The value you give on the command line is now the value used, for either --period or --periodLength.

This affected the sim, trade, and train commands.