### PR TITLE
Enhance MongoDB authentication logic avoid deprecated Db.prototype.authenticate call.

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -29,12 +29,10 @@ module.exports = function (cb) {
   
   if(c.mongo.username){
     authStr = encodeURIComponent(c.mongo.username)
-      //authStr += ':' + encodeURIComponent(c.mongo.password) + '@'
     
-    if(c.mongo.password)
-      authStr += ':' + encodeURIComponent(c.mongo.password) + '@'
-    else
-      authStr += '@'  
+    if(c.mongo.password) authStr += ':' + encodeURIComponent(c.mongo.password)
+
+    authStr += '@'  
       
     // authMechanism could be a conf.js parameter to support more mongodb authentication methods
     authMechanism = 'DEFAULT'

--- a/boot.js
+++ b/boot.js
@@ -25,26 +25,32 @@ module.exports = function (cb) {
     })
   }
 
-  var u = 'mongodb://' + c.mongo.host + ':' + c.mongo.port + '/' + c.mongo.db + (c.mongo.replicaSet ? '?replicaSet=' + c.mongo.replicaSet : '')
+  var authStr, authMechanismStr, authMechanism;
+  
+  if(c.mongo.username){
+    authStr = encodeURIComponent(c.mongo.username)
+      //authStr += ':' + encodeURIComponent(c.mongo.password) + '@'
+    
+    if(c.mongo.password)
+      authStr += ':' + encodeURIComponent(c.mongo.password) + '@'
+    else
+      authStr += '@'  
+      
+    // authMechanism could be a conf.js parameter to support more mongodb authentication methods
+    authMechanism = 'DEFAULT'
+  }
+  
+  var u = 'mongodb://' + authStr + c.mongo.host + ':' + c.mongo.port + '/' + c.mongo.db + '?' + (c.mongo.replicaSet ? '&replicaSet=' + c.mongo.replicaSet : '' ) + (authMechanism ? '&authMechanism=' + authMechanism : '' )
   require('mongodb').MongoClient.connect(u, function (err, db) {
     if (err) {
       zenbot.set('zenbot:db.mongo', null)
-      console.error('warning: mongodb not accessible. some features (such as backfilling/simulation) may be disabled.')
+      console.error('WARNING: MongoDB Connection Error: ', err)
+      console.error('WARNING: without MongoDB some features (such as backfilling/simulation) may be disabled.')
+      console.error('Attempted authentication string: ' + u);
       return withMongo()
     }
     zenbot.set('zenbot:db.mongo', db)
-    if (c.mongo.username) {
-      db.authenticate(c.mongo.username, c.mongo.password, function (err, result) {
-        if (err) {
-          zenbot.set('zenbot:db.mongo', null)
-          console.error('warning: mongodb auth failed. some features (such as backfilling/simulation) may be disabled.')
-        }
-        withMongo()
-      })
-    }
-    else {
-      withMongo()
-    }
+    withMongo()
   })
 
   function getConfiguration() {


### PR DESCRIPTION
Db.prototype.authenticate is deprecated in the MongoDB module. Authentication is instead done via connection string, as mongodb docs advise:
http://mongodb.github.io/node-mongodb-native/3.0/tutorials/connect/authenticating/

Fixes #521 and that annoying deprecation warning on every launch.