### PR TITLE
Extension to PR #972, in case mongo user is blank in conf.js

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -25,7 +25,7 @@ module.exports = function (cb) {
     })
   }
 
-  var authStr, authMechanismStr, authMechanism;
+  var authStr = '', authMechanismStr, authMechanism;
   
   if(c.mongo.username){
     authStr = encodeURIComponent(c.mongo.username)


### PR DESCRIPTION
Prevents connection err when username is blank/undefined in conf by initialising the authStr.