### PR TITLE
Tweaked XRP increments for Bitstamp & fixed invalid date messages

### DIFF
--- a/extensions/exchanges/bitstamp/exchange.js
+++ b/extensions/exchanges/bitstamp/exchange.js
@@ -298,6 +298,7 @@ module.exports = function container (get, set, clear) {
             // 'In Queue', 'Open', 'Finished'
             body.status = 'done'
           }
+          if(body.datetime) body.done_at = body.created_at = body.datetime;
 
           orders['~' + body.id] = body
           cb(null, body)
@@ -338,7 +339,9 @@ module.exports = function container (get, set, clear) {
         } else if(body.status === 'Finished')
           body.status = 'done';
         
-        if(body.datetime) body.time = body.datetime;
+        if(body.status === 'done'){
+          if(body.transactions && body.transactions[0].datetime) body.done_at = body.transactions[0].datetime;
+        }
         
         cb(null, body)
       })

--- a/extensions/exchanges/bitstamp/products.json
+++ b/extensions/exchanges/bitstamp/products.json
@@ -57,18 +57,18 @@
     "id": "XRPUSD",
     "asset": "XRP",
     "currency": "USD",
-    "min_size": "0.01",
+    "min_size": "5",
     "max_size": "1000000",
-    "increment": "0.01",
+    "increment": "0.00001",
     "label": "XRP/USD"
   },
   {
     "id": "XRPEUR",
     "asset": "XRP",
     "currency": "EUR",
-    "min_size": "0.01",
+    "min_size": "5",
     "max_size": "1000000",
-    "increment": "0.01",
+    "increment": "0.00001",
     "label": "XRP/EUR"
   },
   {


### PR DESCRIPTION
- XRP increments were too big, reduced those. 
- When orders completed on bitstamp, the completion logic couldn't get the datetime properly. This fixed it for me, so I'm sharing it here.