### PR TITLE
Fixed bug where the "stop loss" protection was not triggering

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -598,7 +598,7 @@ module.exports = function container (get, set, clear) {
           delete s.buy_order
           delete s.buy_stop
           delete s.sell_stop
-          if (!s.acted_on_stop && so.sell_stop_pct) {
+          if (so.sell_stop_pct) {
             s.sell_stop = n(price).subtract(n(price).multiply(so.sell_stop_pct / 100)).value()
           }
           delete s.profit_stop
@@ -647,7 +647,7 @@ module.exports = function container (get, set, clear) {
           s.last_sell_price = my_trade.price
           delete s.sell_order
           delete s.buy_stop
-          if (!s.acted_on_stop && so.buy_stop_pct) {
+          if (so.buy_stop_pct) {
             s.buy_stop = n(price).add(n(price).multiply(so.buy_stop_pct / 100)).value()
           }
           delete s.sell_stop


### PR DESCRIPTION
I was simulating. My configuration specifies that:

    c.sell_stop_pct = 1
    c.buy_stop_pct = 1

While simulating I saw this:

![captura de pantalla 2017-12-25 a las 2 26 05](https://user-images.githubusercontent.com/7938671/34328516-78a07fa6-e91b-11e7-8845-8f2c6e8794df.png)

This makes no sense, because the stop loss of 1% (c.sell_stop_pct = 1) should have triggered. This is a bug (I think).

I debugged it, and found that:
- This happens when the buy order is triggered by a "buy stop" protection (c.buy_stop_pct = 1).
- In such a case, when the "buy stop" protection triggers, `s.acted_on_stop` is set to true (line 178). As a consequence, `s.sell_stop` does not get assigned a value (line 601).
- As a result, the stop loss (c.sell_stop_pct = 1) is disabled (in order for the stop loss to work, `s.sell_stop` must have a value (line 157)).

Happy holidays ;P