### PR TITLE
Chaikin Money Flow oscillator

### DIFF
--- a/lib/_codemap.js
+++ b/lib/_codemap.js
@@ -20,5 +20,6 @@ module.exports = {
   'lrc': require('./lrc'),
   'adx': require('./adx'),
   'vwap': require('./vwap'),
-  'slow_stochastic': require('./slow_stochastic')
+  'slow_stochastic': require('./slow_stochastic'),
+  'cmf': require('./cmf')
 }

--- a/lib/cmf.js
+++ b/lib/cmf.js
@@ -1,0 +1,13 @@
+// Chaikin Money Flow
+module.exports = function container (get, set, clear) {
+  return function cmf (s, key, length) {
+    if (s.lookback.length >= length) {
+      let MFV = 0, SOV = 0;
+      s.lookback.slice(0, length).forEach(function(cur) {
+          MFV += cur.volume * ((cur.close - cur.low) - (cur.high - cur.close)) / (cur.high - cur.low);
+          SOV += cur.volume;
+      });
+      s.period[key] = MFV / SOV;
+    }
+  }
+}


### PR DESCRIPTION
Chaikin Money Flow should not be used as a stand-alone indicator, but it's very useful for trend confirmation by volume. Positive CMF would confirm an uptrend, but negative CMF would call into question the strength behind an uptrend. The reverse holds true for downtrends. I use it with length 20 and threshold 0.05