### PR TITLE
fix exchange response key

### DIFF
--- a/extensions/exchanges/kraken/exchange.js
+++ b/extensions/exchanges/kraken/exchange.js
@@ -48,14 +48,15 @@ module.exports = function container(get, set, clear) {
     if (assetsToFix.indexOf(asset) >= 0 && currency.length > 3) {
       currency = currency.substring(1)
     }
-    return asset + currency;
+    return `X${asset}X${currency}`
   }
 
   function retry(method, args, error) {
+    let timeout, errorMsg
     if (error.message.match(/API:Rate limit exceeded/)) {
-      var timeout = 10000
+      timeout = 10000
     } else {
-      var timeout = 150
+      timeout = 150
     }
 
     // silence common timeout errors


### PR DESCRIPTION
The key in the response from Kraken had X as the prefix for each currency. So i have fixed that in code to remove the error when tried to perform a
`zenbot backfill kraken.LTC-XBT --days 30`
command