### PR TITLE
Small fixes for drops in objectify-selector changes

### DIFF
--- a/commands/balance.js
+++ b/commands/balance.js
@@ -29,6 +29,7 @@ module.exports = function container (get, set, clear) {
             so[k] = cmd[k]
           }
         })
+        so.selector = s.selector
         so.debug = cmd.debug
         var engine = get('lib.engine')(s)
         function balance () {

--- a/commands/buy.js
+++ b/commands/buy.js
@@ -28,6 +28,7 @@ module.exports = function container (get, set, clear) {
         })
         so.debug = cmd.debug
         so.buy_pct = cmd.pct
+        so.selector = get('lib.objectify-selector')(selector || c.selector)
         var order_types = ['maker', 'taker']
         if (!so.order_type in order_types || !so.order_type) {
           so.order_type = 'maker'

--- a/commands/sell.js
+++ b/commands/sell.js
@@ -28,6 +28,7 @@ module.exports = function container (get, set, clear) {
         })
         so.debug = cmd.debug
         so.sell_pct = cmd.pct
+        so.selector = get('lib.objectify-selector')(selector || c.selector)
         var order_types = ['maker', 'taker']
         if (!so.order_type in order_types || !so.order_type) {
           so.order_type = 'maker'


### PR DESCRIPTION
#906 lost some codelines that broke the CLI commands balance, buy, and sell.  This patch adds them back so these commands will work again.