### PR TITLE
Revert #990. Cannot assume every kraken currency has the same prefix

### DIFF
--- a/extensions/exchanges/kraken/exchange.js
+++ b/extensions/exchanges/kraken/exchange.js
@@ -48,7 +48,7 @@ module.exports = function container(get, set, clear) {
     if (assetsToFix.indexOf(asset) >= 0 && currency.length > 3) {
       currency = currency.substring(1)
     }
-    return `X${asset}X${currency}`
+    return asset + currency;
   }
 
   function retry(method, args, error) {


### PR DESCRIPTION
Can we revert PR #990 ?

This breaks API calls for fiat currencies, see comments here: https://github.com/carlos8f/zenbot/commit/70e7bbc93224a0bada2beff90bfe1b5db2d88a1f 