### PR TITLE
For #1002 - while start was fixed, 'end' was still not passing right

### DIFF
--- a/scripts/genetic_backtester/darwin.js
+++ b/scripts/genetic_backtester/darwin.js
@@ -120,7 +120,7 @@ let processOutput = output => {
   let errorRate     = errMatch !== null ? parseInt(errMatch[1]) : 0;
   let days = parseInt(params.days);
   let start = parseInt(params.start);
-  let end = parseInt(params.start);
+  let end = parseInt(params.end);
 
   let roi = roundp(
     ((endBalance - params.currency_capital) / params.currency_capital) * 100,


### PR DESCRIPTION
Basically a typo fix:
```
  let start = parseInt(params.start);
  let end = parseInt(params.start);
```

Becomes:
```
  let start = parseInt(params.start);
  let end = parseInt(params.end);
```

I was happy to have finally fixed the start param not passing and overlooked that the end param was still not right.