### PR TITLE
Fix bug where fitness function assigned higher fitness to worse results.

### DIFF
--- a/scripts/genetic_backtester/phenotype.js
+++ b/scripts/genetic_backtester/phenotype.js
@@ -68,7 +68,8 @@ module.exports = {
     if (typeof phenotype.sim === 'undefined') return 0;
     
     var vsBuyHoldRate = (phenotype.sim.vsBuyHold / 50);
-    var wlRatioRate = 1.0 / (1.0 + Math.pow(2.71828, -(phenotype.sim.wins - phenotype.sim.losses)));
+    var wlRatio = phenotype.sim.wins - phenotype.sim.losses
+    var wlRatioRate = 1.0 / (1.0 + Math.pow(2.71828, wlRatio < 0 ? wlRatio:-(wlRatio)));
     var rate = vsBuyHoldRate * (wlRatioRate);
     return rate;
   },


### PR DESCRIPTION
The fitness calculation does not appear to work correctly when win < loss AND buyvsHold value is negative. It results in a higher fitness value being assigned to worse results. In generation runs where ONLY negative results are returned, each subsequent generation gets progressively worse, not better. To test this I ran trend_ema, 60 days on cexio.ETH_USD and the results now assign the best fitness to the best result correctly, where it was incorrect before.