### PR TITLE
Console Output adjustment

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -386,9 +386,11 @@ module.exports = function container (get, set, clear) {
             get('db.trades').select(opts, function (err, trades) {
               if (err) throw err
               if (!trades.length) {
-                console.log('------------------------------------------ INITIALIZE  OUTPUT ------------------------------------------')
+                var head = '------------------------------------------ INITIALIZE  OUTPUT ------------------------------------------';
+                console.log(head)
                 get('lib.output').initializeOutput(s)
-                console.log('---------------------------- STARTING ' + so.mode.toUpperCase() + ' TRADING ----------------------------')
+                var minuses = Math.floor((head.length - so.mode.length - 19) / 2)
+                console.log('-'.repeat(minuses) + ' STARTING ' + so.mode.toUpperCase() + ' TRADING ' + '-'.repeat(minuses + (minuses % 2 == 0 ? 0 : 1)))
                 if (so.mode === 'paper') {
                   console.log('!!! Paper mode enabled. No real trades are performed until you remove --paper from the startup command.')
                 }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -698,7 +698,7 @@ module.exports = function container (get, set, clear) {
         process.stdout.write(z(8, pct(diff), ' ')[diff >= 0 ? 'green' : 'red'])
       }
       else {
-        process.stdout.write(z(8, '', ' '))
+        process.stdout.write(z(9, '', ' '))
       }
       var volume_display = s.period.volume > 99999 ? abbreviate(s.period.volume, 2) : n(s.period.volume).format('0')
       volume_display = z(8, volume_display, ' ')
@@ -781,8 +781,8 @@ module.exports = function container (get, set, clear) {
           z(19, 'DATE', ' ').grey,
           z(17, 'PRICE', ' ').grey,
           z(9, 'DIFF', ' ').grey,
-          z(15, 'VOL', ' ').grey,
-          z(12, 'RSI', ' ').grey,
+          z(10, 'VOL', ' ').grey,
+          z(8, 'RSI', ' ').grey,
           z(32, 'ACTIONS', ' ').grey,
           z(25, 'BAL', ' ').grey,
           z(22, 'PROFIT', ' ').grey


### PR DESCRIPTION
Just two adjustments for the console output which annoyed myself.

* adjusted the length of minuses in the starting header to match each other
* moved the header lines to match the report output (until custom output of the strategy)

