### PR TITLE
adjustments to work on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,11 @@
         }
       }
     },
+    "@types/node": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+      "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg=="
+    },
     "@xmpp/jid": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@xmpp/jid/-/jid-0.0.2.tgz",
@@ -319,8 +324,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
       "version": "0.2.3",
@@ -1557,7 +1561,6 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2226,6 +2229,11 @@
       "requires": {
         "repeating": "2.0.1"
       }
+    },
+    "diff": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -3088,795 +3096,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "optional": true,
-      "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.39",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
-    },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
@@ -4279,6 +3498,14 @@
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "requires": {
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -5273,6 +4500,11 @@
         "pify": "3.0.0"
       }
     },
+    "make-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.2.tgz",
+      "integrity": "sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ=="
+    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -5843,6 +5075,3516 @@
         "set-blocking": "2.0.0"
       }
     },
+    "npx": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/npx/-/npx-9.7.1.tgz",
+      "integrity": "sha512-useBT9FsT0o0grqL8zAx4Sht5aHXVoxxKjcKCEA2hpnzAHeoT8NqGFllE85iRI7EbDaQF9lK7CvvJKVLQQrmyQ==",
+      "requires": {
+        "libnpx": "9.7.1",
+        "npm": "5.1.0"
+      },
+      "dependencies": {
+        "ansi-align": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "2.1.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "boxen": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "2.2.0",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.1",
+            "term-size": "1.2.0",
+            "widest-line": "1.0.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "builtins": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "capture-stack-trace": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "color-convert": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "configstore": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "dot-prop": "4.2.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.0.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.3.0",
+            "xdg-basedir": "3.0.0"
+          }
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "capture-stack-trace": "1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "is-obj": "1.0.1"
+          }
+        },
+        "dotenv": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "global-dirs": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "ini": "1.3.4"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "bundled": true,
+          "requires": {
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "bundled": true
+        },
+        "import-lazy": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "global-dirs": "0.1.0",
+            "is-path-inside": "1.0.0"
+          }
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-path-inside": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "1.0.2"
+          }
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "package-json": "4.0.1"
+          }
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "libnpx": {
+          "version": "9.7.1",
+          "bundled": true,
+          "requires": {
+            "dotenv": "4.0.0",
+            "npm-package-arg": "5.1.2",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.1",
+            "update-notifier": "2.3.0",
+            "which": "1.3.0",
+            "y18n": "3.2.1",
+            "yargs": "8.0.2"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "npm": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "JSONStream": "1.3.1",
+            "abbrev": "1.1.0",
+            "ansi-regex": "3.0.0",
+            "ansicolors": "0.3.2",
+            "ansistyles": "0.1.3",
+            "aproba": "1.1.2",
+            "archy": "1.0.0",
+            "bluebird": "3.5.0",
+            "cacache": "9.2.9",
+            "call-limit": "1.1.0",
+            "chownr": "1.0.1",
+            "cmd-shim": "2.0.2",
+            "columnify": "1.5.4",
+            "config-chain": "1.1.11",
+            "debuglog": "1.0.1",
+            "detect-indent": "5.0.0",
+            "dezalgo": "1.0.3",
+            "editor": "1.0.0",
+            "fs-vacuum": "1.2.10",
+            "fs-write-stream-atomic": "1.0.10",
+            "fstream": "1.0.11",
+            "fstream-npm": "1.2.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "has-unicode": "2.0.1",
+            "hosted-git-info": "2.5.0",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "ini": "1.3.4",
+            "init-package-json": "1.10.1",
+            "lazy-property": "1.0.0",
+            "lockfile": "1.0.3",
+            "lodash._baseindexof": "3.1.0",
+            "lodash._baseuniq": "4.6.0",
+            "lodash._bindcallback": "3.0.1",
+            "lodash._cacheindexof": "3.0.2",
+            "lodash._createcache": "3.1.2",
+            "lodash._getnative": "3.9.1",
+            "lodash.clonedeep": "4.5.0",
+            "lodash.restparam": "3.6.1",
+            "lodash.union": "4.6.0",
+            "lodash.uniq": "4.5.0",
+            "lodash.without": "4.4.0",
+            "lru-cache": "4.1.1",
+            "mississippi": "1.3.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "node-gyp": "3.6.2",
+            "nopt": "4.0.1",
+            "normalize-package-data": "2.4.0",
+            "npm-cache-filename": "1.0.2",
+            "npm-install-checks": "3.0.0",
+            "npm-package-arg": "5.1.2",
+            "npm-registry-client": "8.4.0",
+            "npm-user-validate": "1.0.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "opener": "1.4.3",
+            "osenv": "0.1.4",
+            "pacote": "2.7.38",
+            "path-is-inside": "1.0.2",
+            "promise-inflight": "1.0.1",
+            "read": "1.0.7",
+            "read-cmd-shim": "1.0.1",
+            "read-installed": "4.0.3",
+            "read-package-json": "2.0.9",
+            "read-package-tree": "5.1.6",
+            "readable-stream": "2.3.2",
+            "readdir-scoped-modules": "1.0.2",
+            "request": "2.81.0",
+            "retry": "0.10.1",
+            "rimraf": "2.6.1",
+            "safe-buffer": "5.1.1",
+            "semver": "5.3.0",
+            "sha": "2.0.1",
+            "slide": "1.1.6",
+            "sorted-object": "2.0.1",
+            "sorted-union-stream": "2.1.3",
+            "ssri": "4.1.6",
+            "strip-ansi": "4.0.0",
+            "tar": "2.2.1",
+            "text-table": "0.2.0",
+            "uid-number": "0.0.6",
+            "umask": "1.1.0",
+            "unique-filename": "1.1.0",
+            "unpipe": "1.0.0",
+            "update-notifier": "2.2.0",
+            "uuid": "3.1.0",
+            "validate-npm-package-license": "3.0.1",
+            "validate-npm-package-name": "3.0.0",
+            "which": "1.2.14",
+            "worker-farm": "1.3.1",
+            "wrappy": "1.0.2",
+            "write-file-atomic": "2.1.0"
+          },
+          "dependencies": {
+            "JSONStream": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "jsonparse": "1.3.1",
+                "through": "2.3.8"
+              },
+              "dependencies": {
+                "jsonparse": {
+                  "version": "1.3.1",
+                  "bundled": true
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "bundled": true
+                }
+              }
+            },
+            "abbrev": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "ansicolors": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "ansistyles": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "archy": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "bluebird": {
+              "version": "3.5.0",
+              "bundled": true
+            },
+            "cacache": {
+              "version": "9.2.9",
+              "bundled": true,
+              "requires": {
+                "bluebird": "3.5.0",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.1",
+                "mississippi": "1.3.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.1",
+                "ssri": "4.1.6",
+                "unique-filename": "1.1.0",
+                "y18n": "3.2.1"
+              },
+              "dependencies": {
+                "lru-cache": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "pseudomap": "1.0.2",
+                    "yallist": "2.1.2"
+                  },
+                  "dependencies": {
+                    "pseudomap": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "yallist": {
+                      "version": "2.1.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "y18n": {
+                  "version": "3.2.1",
+                  "bundled": true
+                }
+              }
+            },
+            "call-limit": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "cmd-shim": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "mkdirp": "0.5.1"
+              }
+            },
+            "columnify": {
+              "version": "1.5.4",
+              "bundled": true,
+              "requires": {
+                "strip-ansi": "3.0.1",
+                "wcwidth": "1.0.1"
+              },
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "wcwidth": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "defaults": "1.0.3"
+                  },
+                  "dependencies": {
+                    "defaults": {
+                      "version": "1.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "clone": "1.0.2"
+                      },
+                      "dependencies": {
+                        "clone": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "config-chain": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "ini": "1.3.4",
+                "proto-list": "1.2.4"
+              },
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.4",
+                  "bundled": true
+                }
+              }
+            },
+            "debuglog": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "detect-indent": {
+              "version": "5.0.0",
+              "bundled": true
+            },
+            "dezalgo": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "asap": "2.0.5",
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.5",
+                  "bundled": true
+                }
+              }
+            },
+            "editor": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fs-vacuum": {
+              "version": "1.2.10",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "path-is-inside": "1.0.2",
+                "rimraf": "2.6.1"
+              }
+            },
+            "fs-write-stream-atomic": {
+              "version": "1.0.10",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "2.3.2"
+              }
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1"
+              }
+            },
+            "fstream-npm": {
+              "version": "1.2.1",
+              "bundled": true,
+              "requires": {
+                "fstream-ignore": "1.0.5",
+                "inherits": "2.0.3"
+              },
+              "dependencies": {
+                "fstream-ignore": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "requires": {
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4"
+                  },
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "3.0.4",
+                      "bundled": true,
+                      "requires": {
+                        "brace-expansion": "1.1.8"
+                      },
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.8",
+                          "bundled": true,
+                          "requires": {
+                            "balanced-match": "1.0.0",
+                            "concat-map": "0.0.1"
+                          },
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              },
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.8"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "hosted-git-info": {
+              "version": "2.5.0",
+              "bundled": true
+            },
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.4",
+              "bundled": true
+            },
+            "init-package-json": {
+              "version": "1.10.1",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2",
+                "npm-package-arg": "5.1.2",
+                "promzard": "0.3.0",
+                "read": "1.0.7",
+                "read-package-json": "2.0.9",
+                "semver": "5.3.0",
+                "validate-npm-package-license": "3.0.1",
+                "validate-npm-package-name": "3.0.0"
+              },
+              "dependencies": {
+                "promzard": {
+                  "version": "0.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "read": "1.0.7"
+                  }
+                }
+              }
+            },
+            "lazy-property": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "lockfile": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "lodash._baseindexof": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "lodash._baseuniq": {
+              "version": "4.6.0",
+              "bundled": true,
+              "requires": {
+                "lodash._createset": "4.0.3",
+                "lodash._root": "3.0.1"
+              },
+              "dependencies": {
+                "lodash._createset": {
+                  "version": "4.0.3",
+                  "bundled": true
+                },
+                "lodash._root": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "lodash._cacheindexof": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "lodash._createcache": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "lodash._getnative": "3.9.1"
+              }
+            },
+            "lodash._getnative": {
+              "version": "3.9.1",
+              "bundled": true
+            },
+            "lodash.clonedeep": {
+              "version": "4.5.0",
+              "bundled": true
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "bundled": true
+            },
+            "lodash.union": {
+              "version": "4.6.0",
+              "bundled": true
+            },
+            "lodash.uniq": {
+              "version": "4.5.0",
+              "bundled": true
+            },
+            "lodash.without": {
+              "version": "4.4.0",
+              "bundled": true
+            },
+            "lru-cache": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+              },
+              "dependencies": {
+                "pseudomap": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "yallist": {
+                  "version": "2.1.2",
+                  "bundled": true
+                }
+              }
+            },
+            "mississippi": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "concat-stream": "1.6.0",
+                "duplexify": "3.5.0",
+                "end-of-stream": "1.4.0",
+                "flush-write-stream": "1.0.2",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "1.0.2",
+                "pumpify": "1.3.5",
+                "stream-each": "1.2.0",
+                "through2": "2.0.3"
+              },
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2",
+                    "typedarray": "0.0.6"
+                  },
+                  "dependencies": {
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "bundled": true
+                    }
+                  }
+                },
+                "duplexify": {
+                  "version": "3.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.0.0",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2",
+                    "stream-shift": "1.0.0"
+                  },
+                  "dependencies": {
+                    "end-of-stream": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.3.3"
+                      },
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.3",
+                          "bundled": true,
+                          "requires": {
+                            "wrappy": "1.0.2"
+                          }
+                        }
+                      }
+                    },
+                    "stream-shift": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "end-of-stream": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "once": "1.4.0"
+                  }
+                },
+                "flush-write-stream": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2"
+                  }
+                },
+                "from2": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2"
+                  }
+                },
+                "parallel-transform": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "cyclist": "0.2.2",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2"
+                  },
+                  "dependencies": {
+                    "cyclist": {
+                      "version": "0.2.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "pump": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.0",
+                    "once": "1.4.0"
+                  }
+                },
+                "pumpify": {
+                  "version": "1.3.5",
+                  "bundled": true,
+                  "requires": {
+                    "duplexify": "3.5.0",
+                    "inherits": "2.0.3",
+                    "pump": "1.0.2"
+                  }
+                },
+                "stream-each": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.4.0",
+                    "stream-shift": "1.0.0"
+                  },
+                  "dependencies": {
+                    "stream-shift": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "2.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "readable-stream": "2.3.2",
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "xtend": {
+                      "version": "4.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                }
+              }
+            },
+            "move-concurrently": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.1.2",
+                "copy-concurrently": "1.0.3",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1",
+                "run-queue": "1.0.3"
+              },
+              "dependencies": {
+                "copy-concurrently": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "aproba": "1.1.2",
+                    "fs-write-stream-atomic": "1.0.10",
+                    "iferr": "0.1.5",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.1",
+                    "run-queue": "1.0.3"
+                  }
+                },
+                "run-queue": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "aproba": "1.1.2"
+                  }
+                }
+              }
+            },
+            "node-gyp": {
+              "version": "3.6.2",
+              "bundled": true,
+              "requires": {
+                "fstream": "1.0.11",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "npmlog": "4.1.2",
+                "osenv": "0.1.4",
+                "request": "2.81.0",
+                "rimraf": "2.6.1",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "which": "1.2.14"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.8"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.6",
+                  "bundled": true,
+                  "requires": {
+                    "abbrev": "1.1.0"
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.1.0",
+                "osenv": "0.1.4"
+              }
+            },
+            "normalize-package-data": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.3.0",
+                "validate-npm-package-license": "3.0.1"
+              },
+              "dependencies": {
+                "is-builtin-module": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "builtin-modules": "1.1.1"
+                  },
+                  "dependencies": {
+                    "builtin-modules": {
+                      "version": "1.1.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "npm-cache-filename": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "npm-install-checks": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "semver": "5.3.0"
+              }
+            },
+            "npm-package-arg": {
+              "version": "5.1.2",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.4",
+                "semver": "5.3.0",
+                "validate-npm-package-name": "3.0.0"
+              }
+            },
+            "npm-registry-client": {
+              "version": "8.4.0",
+              "bundled": true,
+              "requires": {
+                "concat-stream": "1.6.0",
+                "graceful-fs": "4.1.11",
+                "normalize-package-data": "2.4.0",
+                "npm-package-arg": "5.1.2",
+                "npmlog": "4.1.2",
+                "once": "1.4.0",
+                "request": "2.81.0",
+                "retry": "0.10.1",
+                "semver": "5.3.0",
+                "slide": "1.1.6",
+                "ssri": "4.1.6"
+              },
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2",
+                    "typedarray": "0.0.6"
+                  },
+                  "dependencies": {
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "npm-user-validate": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
+              },
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.3.2"
+                  },
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "gauge": {
+                  "version": "2.7.4",
+                  "bundled": true,
+                  "requires": {
+                    "aproba": "1.1.2",
+                    "console-control-strings": "1.1.0",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.1",
+                    "signal-exit": "3.0.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.2"
+                  },
+                  "dependencies": {
+                    "object-assign": {
+                      "version": "4.1.1",
+                      "bundled": true
+                    },
+                    "signal-exit": {
+                      "version": "3.0.2",
+                      "bundled": true
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            },
+            "opener": {
+              "version": "1.4.3",
+              "bundled": true
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+              },
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "pacote": {
+              "version": "2.7.38",
+              "bundled": true,
+              "requires": {
+                "bluebird": "3.5.0",
+                "cacache": "9.2.9",
+                "glob": "7.1.2",
+                "lru-cache": "4.1.1",
+                "make-fetch-happen": "2.4.13",
+                "minimatch": "3.0.4",
+                "mississippi": "1.3.0",
+                "normalize-package-data": "2.4.0",
+                "npm-package-arg": "5.1.2",
+                "npm-pick-manifest": "1.0.4",
+                "osenv": "0.1.4",
+                "promise-inflight": "1.0.1",
+                "promise-retry": "1.1.1",
+                "protoduck": "4.0.0",
+                "safe-buffer": "5.1.1",
+                "semver": "5.3.0",
+                "ssri": "4.1.6",
+                "tar-fs": "1.15.3",
+                "tar-stream": "1.5.4",
+                "unique-filename": "1.1.0",
+                "which": "1.2.14"
+              },
+              "dependencies": {
+                "make-fetch-happen": {
+                  "version": "2.4.13",
+                  "bundled": true,
+                  "requires": {
+                    "agentkeepalive": "3.3.0",
+                    "cacache": "9.2.9",
+                    "http-cache-semantics": "3.7.3",
+                    "http-proxy-agent": "2.0.0",
+                    "https-proxy-agent": "2.0.0",
+                    "lru-cache": "4.1.1",
+                    "mississippi": "1.3.0",
+                    "node-fetch-npm": "2.0.1",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "3.0.0",
+                    "ssri": "4.1.6"
+                  },
+                  "dependencies": {
+                    "agentkeepalive": {
+                      "version": "3.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "humanize-ms": "1.2.1"
+                      },
+                      "dependencies": {
+                        "humanize-ms": {
+                          "version": "1.2.1",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "http-cache-semantics": {
+                      "version": "3.7.3",
+                      "bundled": true
+                    },
+                    "http-proxy-agent": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.1.0",
+                        "debug": "2.6.8"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.1.1"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.1.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "2.6.8",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "https-proxy-agent": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.1.0",
+                        "debug": "2.6.8"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.1.1"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.1.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "2.6.8",
+                          "bundled": true,
+                          "requires": {
+                            "ms": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "node-fetch-npm": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "encoding": "0.1.12",
+                        "json-parse-helpfulerror": "1.0.3",
+                        "safe-buffer": "5.1.1"
+                      },
+                      "dependencies": {
+                        "encoding": {
+                          "version": "0.1.12",
+                          "bundled": true,
+                          "requires": {
+                            "iconv-lite": "0.4.18"
+                          },
+                          "dependencies": {
+                            "iconv-lite": {
+                              "version": "0.4.18",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "json-parse-helpfulerror": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "jju": "1.3.0"
+                          },
+                          "dependencies": {
+                            "jju": {
+                              "version": "1.3.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "socks-proxy-agent": {
+                      "version": "3.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "agent-base": "4.1.0",
+                        "socks": "1.1.10"
+                      },
+                      "dependencies": {
+                        "agent-base": {
+                          "version": "4.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "es6-promisify": "5.0.0"
+                          },
+                          "dependencies": {
+                            "es6-promisify": {
+                              "version": "5.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "es6-promise": "4.1.1"
+                              },
+                              "dependencies": {
+                                "es6-promise": {
+                                  "version": "4.1.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "socks": {
+                          "version": "1.1.10",
+                          "bundled": true,
+                          "requires": {
+                            "ip": "1.1.5",
+                            "smart-buffer": "1.1.15"
+                          },
+                          "dependencies": {
+                            "ip": {
+                              "version": "1.1.5",
+                              "bundled": true
+                            },
+                            "smart-buffer": {
+                              "version": "1.1.15",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.8"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "npm-pick-manifest": {
+                  "version": "1.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "npm-package-arg": "5.1.2",
+                    "semver": "5.3.0"
+                  }
+                },
+                "promise-retry": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
+                  },
+                  "dependencies": {
+                    "err-code": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "protoduck": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "genfun": "4.0.1"
+                  },
+                  "dependencies": {
+                    "genfun": {
+                      "version": "4.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "tar-fs": {
+                  "version": "1.15.3",
+                  "bundled": true,
+                  "requires": {
+                    "chownr": "1.0.1",
+                    "mkdirp": "0.5.1",
+                    "pump": "1.0.2",
+                    "tar-stream": "1.5.4"
+                  },
+                  "dependencies": {
+                    "pump": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "end-of-stream": "1.4.0",
+                        "once": "1.4.0"
+                      },
+                      "dependencies": {
+                        "end-of-stream": {
+                          "version": "1.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "once": "1.4.0"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "tar-stream": {
+                  "version": "1.5.4",
+                  "bundled": true,
+                  "requires": {
+                    "bl": "1.2.1",
+                    "end-of-stream": "1.4.0",
+                    "readable-stream": "2.3.2",
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "bl": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "readable-stream": "2.3.2"
+                      }
+                    },
+                    "end-of-stream": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0"
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "path-is-inside": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "promise-inflight": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "read": {
+              "version": "1.0.7",
+              "bundled": true,
+              "requires": {
+                "mute-stream": "0.0.7"
+              },
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.7",
+                  "bundled": true
+                }
+              }
+            },
+            "read-cmd-shim": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11"
+              }
+            },
+            "read-installed": {
+              "version": "4.0.3",
+              "bundled": true,
+              "requires": {
+                "debuglog": "1.0.1",
+                "graceful-fs": "4.1.11",
+                "read-package-json": "2.0.9",
+                "readdir-scoped-modules": "1.0.2",
+                "semver": "5.3.0",
+                "slide": "1.1.6",
+                "util-extend": "1.0.3"
+              },
+              "dependencies": {
+                "util-extend": {
+                  "version": "1.0.3",
+                  "bundled": true
+                }
+              }
+            },
+            "read-package-json": {
+              "version": "2.0.9",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "json-parse-helpfulerror": "1.0.3",
+                "normalize-package-data": "2.4.0"
+              },
+              "dependencies": {
+                "json-parse-helpfulerror": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "jju": "1.3.0"
+                  },
+                  "dependencies": {
+                    "jju": {
+                      "version": "1.3.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "read-package-tree": {
+              "version": "5.1.6",
+              "bundled": true,
+              "requires": {
+                "debuglog": "1.0.1",
+                "dezalgo": "1.0.3",
+                "once": "1.4.0",
+                "read-package-json": "2.0.9",
+                "readdir-scoped-modules": "1.0.2"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "bundled": true
+                },
+                "string_decoder": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.1"
+                  }
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "readdir-scoped-modules": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "debuglog": "1.0.1",
+                "dezalgo": "1.0.3",
+                "graceful-fs": "4.1.11",
+                "once": "1.4.0"
+              }
+            },
+            "request": {
+              "version": "2.81.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+              },
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "bundled": true
+                },
+                "aws4": {
+                  "version": "1.6.0",
+                  "bundled": true
+                },
+                "caseless": {
+                  "version": "0.12.0",
+                  "bundled": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "bundled": true
+                },
+                "form-data": {
+                  "version": "2.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.15"
+                  },
+                  "dependencies": {
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "4.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "ajv": "4.11.8",
+                    "har-schema": "1.0.5"
+                  },
+                  "dependencies": {
+                    "ajv": {
+                      "version": "4.11.8",
+                      "bundled": true,
+                      "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                      },
+                      "dependencies": {
+                        "co": {
+                          "version": "4.6.0",
+                          "bundled": true
+                        },
+                        "json-stable-stringify": {
+                          "version": "1.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "jsonify": "0.0.0"
+                          },
+                          "dependencies": {
+                            "jsonify": {
+                              "version": "0.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "har-schema": {
+                      "version": "1.0.5",
+                      "bundled": true
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "bundled": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "bundled": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.4.0",
+                    "sshpk": "1.13.1"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "bundled": true
+                    },
+                    "jsprim": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        },
+                        "json-schema": {
+                          "version": "0.2.3",
+                          "bundled": true
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "bundled": true,
+                          "requires": {
+                            "extsprintf": "1.0.2"
+                          }
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.13.1",
+                      "bundled": true,
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                      },
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "bundled": true
+                        },
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "bcrypt-pbkdf": {
+                          "version": "1.0.1",
+                          "bundled": true,
+                          "optional": true,
+                          "requires": {
+                            "tweetnacl": "0.14.5"
+                          }
+                        },
+                        "dashdash": {
+                          "version": "1.14.1",
+                          "bundled": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "bundled": true,
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.1"
+                          }
+                        },
+                        "getpass": {
+                          "version": "0.1.7",
+                          "bundled": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
+                        },
+                        "jsbn": {
+                          "version": "0.1.1",
+                          "bundled": true,
+                          "optional": true
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.5",
+                          "bundled": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "bundled": true
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "bundled": true
+                },
+                "mime-types": {
+                  "version": "2.1.15",
+                  "bundled": true,
+                  "requires": {
+                    "mime-db": "1.27.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.27.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "bundled": true
+                },
+                "performance-now": {
+                  "version": "0.2.0",
+                  "bundled": true
+                },
+                "qs": {
+                  "version": "6.4.0",
+                  "bundled": true
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "bundled": true
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "bundled": true,
+                  "requires": {
+                    "punycode": "1.4.1"
+                  },
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.4.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.1"
+                  }
+                }
+              }
+            },
+            "retry": {
+              "version": "0.10.1",
+              "bundled": true
+            },
+            "rimraf": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true
+            },
+            "sha": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "readable-stream": "2.3.2"
+              }
+            },
+            "slide": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "sorted-object": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "sorted-union-stream": {
+              "version": "2.1.3",
+              "bundled": true,
+              "requires": {
+                "from2": "1.3.0",
+                "stream-iterate": "1.2.0"
+              },
+              "dependencies": {
+                "from2": {
+                  "version": "1.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "1.1.14"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "bundled": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "stream-iterate": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "readable-stream": "2.3.2",
+                    "stream-shift": "1.0.0"
+                  },
+                  "dependencies": {
+                    "stream-shift": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "ssri": {
+              "version": "4.1.6",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              },
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                }
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "bundled": true
+            },
+            "umask": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "unique-filename": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "unique-slug": "2.0.0"
+              },
+              "dependencies": {
+                "unique-slug": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "imurmurhash": "0.1.4"
+                  }
+                }
+              }
+            },
+            "unpipe": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "update-notifier": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "boxen": "1.1.0",
+                "chalk": "1.1.3",
+                "configstore": "3.1.0",
+                "import-lazy": "2.1.0",
+                "is-npm": "1.0.0",
+                "latest-version": "3.1.0",
+                "semver-diff": "2.1.0",
+                "xdg-basedir": "3.0.0"
+              },
+              "dependencies": {
+                "boxen": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-align": "2.0.0",
+                    "camelcase": "4.1.0",
+                    "chalk": "1.1.3",
+                    "cli-boxes": "1.0.0",
+                    "string-width": "2.1.0",
+                    "term-size": "0.1.1",
+                    "widest-line": "1.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-align": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "2.1.0"
+                      }
+                    },
+                    "camelcase": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    },
+                    "cli-boxes": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "string-width": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                      },
+                      "dependencies": {
+                        "is-fullwidth-code-point": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        },
+                        "strip-ansi": {
+                          "version": "4.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "3.0.0"
+                          }
+                        }
+                      }
+                    },
+                    "term-size": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "requires": {
+                        "execa": "0.4.0"
+                      },
+                      "dependencies": {
+                        "execa": {
+                          "version": "0.4.0",
+                          "bundled": true,
+                          "requires": {
+                            "cross-spawn-async": "2.2.5",
+                            "is-stream": "1.1.0",
+                            "npm-run-path": "1.0.0",
+                            "object-assign": "4.1.1",
+                            "path-key": "1.0.0",
+                            "strip-eof": "1.0.0"
+                          },
+                          "dependencies": {
+                            "cross-spawn-async": {
+                              "version": "2.2.5",
+                              "bundled": true,
+                              "requires": {
+                                "lru-cache": "4.1.1",
+                                "which": "1.2.14"
+                              }
+                            },
+                            "is-stream": {
+                              "version": "1.1.0",
+                              "bundled": true
+                            },
+                            "npm-run-path": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "path-key": "1.0.0"
+                              }
+                            },
+                            "object-assign": {
+                              "version": "4.1.1",
+                              "bundled": true
+                            },
+                            "path-key": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "strip-eof": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "widest-line": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.2"
+                      },
+                      "dependencies": {
+                        "string-width": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
+                          },
+                          "dependencies": {
+                            "code-point-at": {
+                              "version": "1.1.0",
+                              "bundled": true
+                            },
+                            "is-fullwidth-code-point": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "number-is-nan": "1.0.1"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.1",
+                                  "bundled": true
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "bundled": true,
+                              "requires": {
+                                "ansi-regex": "2.1.1"
+                              },
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "chalk": {
+                  "version": "1.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "2.2.1",
+                    "escape-string-regexp": "1.0.5",
+                    "has-ansi": "2.0.0",
+                    "strip-ansi": "3.0.1",
+                    "supports-color": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "bundled": true
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "bundled": true
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "configstore": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "dot-prop": "4.1.1",
+                    "graceful-fs": "4.1.11",
+                    "make-dir": "1.0.0",
+                    "unique-string": "1.0.0",
+                    "write-file-atomic": "2.1.0",
+                    "xdg-basedir": "3.0.0"
+                  },
+                  "dependencies": {
+                    "dot-prop": {
+                      "version": "4.1.1",
+                      "bundled": true,
+                      "requires": {
+                        "is-obj": "1.0.1"
+                      },
+                      "dependencies": {
+                        "is-obj": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "make-dir": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "pify": "2.3.0"
+                      },
+                      "dependencies": {
+                        "pify": {
+                          "version": "2.3.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "unique-string": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "crypto-random-string": "1.0.0"
+                      },
+                      "dependencies": {
+                        "crypto-random-string": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "import-lazy": {
+                  "version": "2.1.0",
+                  "bundled": true
+                },
+                "is-npm": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "latest-version": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "package-json": "4.0.1"
+                  },
+                  "dependencies": {
+                    "package-json": {
+                      "version": "4.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "got": "6.7.1",
+                        "registry-auth-token": "3.3.1",
+                        "registry-url": "3.1.0",
+                        "semver": "5.3.0"
+                      },
+                      "dependencies": {
+                        "got": {
+                          "version": "6.7.1",
+                          "bundled": true,
+                          "requires": {
+                            "create-error-class": "3.0.2",
+                            "duplexer3": "0.1.4",
+                            "get-stream": "3.0.0",
+                            "is-redirect": "1.0.0",
+                            "is-retry-allowed": "1.1.0",
+                            "is-stream": "1.1.0",
+                            "lowercase-keys": "1.0.0",
+                            "safe-buffer": "5.1.1",
+                            "timed-out": "4.0.1",
+                            "unzip-response": "2.0.1",
+                            "url-parse-lax": "1.0.0"
+                          },
+                          "dependencies": {
+                            "create-error-class": {
+                              "version": "3.0.2",
+                              "bundled": true,
+                              "requires": {
+                                "capture-stack-trace": "1.0.0"
+                              },
+                              "dependencies": {
+                                "capture-stack-trace": {
+                                  "version": "1.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            },
+                            "duplexer3": {
+                              "version": "0.1.4",
+                              "bundled": true
+                            },
+                            "get-stream": {
+                              "version": "3.0.0",
+                              "bundled": true
+                            },
+                            "is-redirect": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "is-retry-allowed": {
+                              "version": "1.1.0",
+                              "bundled": true
+                            },
+                            "is-stream": {
+                              "version": "1.1.0",
+                              "bundled": true
+                            },
+                            "lowercase-keys": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "timed-out": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            },
+                            "unzip-response": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            },
+                            "url-parse-lax": {
+                              "version": "1.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "prepend-http": "1.0.4"
+                              },
+                              "dependencies": {
+                                "prepend-http": {
+                                  "version": "1.0.4",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "registry-auth-token": {
+                          "version": "3.3.1",
+                          "bundled": true,
+                          "requires": {
+                            "rc": "1.2.1",
+                            "safe-buffer": "5.1.1"
+                          },
+                          "dependencies": {
+                            "rc": {
+                              "version": "1.2.1",
+                              "bundled": true,
+                              "requires": {
+                                "deep-extend": "0.4.2",
+                                "ini": "1.3.4",
+                                "minimist": "1.2.0",
+                                "strip-json-comments": "2.0.1"
+                              },
+                              "dependencies": {
+                                "deep-extend": {
+                                  "version": "0.4.2",
+                                  "bundled": true
+                                },
+                                "minimist": {
+                                  "version": "1.2.0",
+                                  "bundled": true
+                                },
+                                "strip-json-comments": {
+                                  "version": "2.0.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "registry-url": {
+                          "version": "3.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "rc": "1.2.1"
+                          },
+                          "dependencies": {
+                            "rc": {
+                              "version": "1.2.1",
+                              "bundled": true,
+                              "requires": {
+                                "deep-extend": "0.4.2",
+                                "ini": "1.3.4",
+                                "minimist": "1.2.0",
+                                "strip-json-comments": "2.0.1"
+                              },
+                              "dependencies": {
+                                "deep-extend": {
+                                  "version": "0.4.2",
+                                  "bundled": true
+                                },
+                                "minimist": {
+                                  "version": "1.2.0",
+                                  "bundled": true
+                                },
+                                "strip-json-comments": {
+                                  "version": "2.0.1",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "semver-diff": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "semver": "5.3.0"
+                  }
+                },
+                "xdg-basedir": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
+              },
+              "dependencies": {
+                "spdx-correct": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "spdx-license-ids": "1.2.2"
+                  },
+                  "dependencies": {
+                    "spdx-license-ids": {
+                      "version": "1.2.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "spdx-expression-parse": {
+                  "version": "1.0.4",
+                  "bundled": true
+                }
+              }
+            },
+            "validate-npm-package-name": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "builtins": "1.0.3"
+              },
+              "dependencies": {
+                "builtins": {
+                  "version": "1.0.3",
+                  "bundled": true
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.14",
+              "bundled": true,
+              "requires": {
+                "isexe": "2.0.0"
+              },
+              "dependencies": {
+                "isexe": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "worker-farm": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "errno": "0.1.4",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "errno": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "prr": "0.0.0"
+                  },
+                  "dependencies": {
+                    "prr": {
+                      "version": "0.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write-file-atomic": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              }
+            }
+          }
+        },
+        "npm-package-arg": {
+          "version": "5.1.2",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "osenv": "0.1.4",
+            "semver": "5.4.1",
+            "validate-npm-package-name": "3.0.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "1.1.0"
+          }
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "got": "6.7.1",
+            "registry-auth-token": "3.3.1",
+            "registry-url": "3.1.0",
+            "semver": "5.4.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "registry-auth-token": {
+          "version": "3.3.1",
+          "bundled": true,
+          "requires": {
+            "rc": "1.2.2",
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "rc": "1.2.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "semver": "5.4.1"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "term-size": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "execa": "0.7.0"
+          }
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "crypto-random-string": "1.0.0"
+          }
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "update-notifier": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "boxen": "1.2.2",
+            "chalk": "2.2.0",
+            "configstore": "3.1.1",
+            "import-lazy": "2.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "1.0.4"
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "builtins": "1.0.3"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "widest-line": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            }
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write-file-atomic": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "bundled": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
     "num": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/num/-/num-0.3.0.tgz",
@@ -5867,7 +8609,7 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "numbro": {
-      "version": "github:highvelocityspace/numbro#65a801c05c40496e5701458c0d4e780060e9a742"
+      "version": "github:highvelocityspace/numbro#797eae5605bf217a016a112343e8dd9746b72e15"
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -6054,6 +8796,11 @@
         "error-ex": "1.3.1"
       }
     },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
@@ -6097,8 +8844,7 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -7690,7 +10436,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-      "dev": true,
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -8343,8 +11088,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "style-loader": {
       "version": "0.19.1",
@@ -8457,11 +11201,31 @@
       }
     },
     "talib": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/talib/-/talib-1.0.3.tgz",
-      "integrity": "sha1-6wp+P1MBsyOwrwL7M41DHSubc1o=",
+      "version": "github:drorgl/node-talib#b30dd674e5b11822ea93bb253001169f1bc99e15",
       "requires": {
-        "nan": "2.8.0"
+        "@types/node": "8.5.8",
+        "nan": "2.8.0",
+        "node-gyp": "3.6.2",
+        "npx": "9.7.1",
+        "source-map-support": "0.5.0",
+        "ts-node": "3.3.0",
+        "tslint": "5.8.0",
+        "typescript": "2.6.2"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-support": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+          "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+          "requires": {
+            "source-map": "0.6.1"
+          }
+        }
       }
     },
     "tapable": {
@@ -8575,6 +11339,136 @@
         }
       }
     },
+    "ts-node": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
+      "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
+      "requires": {
+        "arrify": "1.0.1",
+        "chalk": "2.3.0",
+        "diff": "3.4.0",
+        "make-error": "1.3.2",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18",
+        "tsconfig": "6.0.0",
+        "v8flags": "3.0.1",
+        "yn": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "tsconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
+      "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
+      "requires": {
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        }
+      }
+    },
+    "tslib": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
+    },
+    "tslint": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
+      "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "diff": "3.4.0",
+        "glob": "7.1.2",
+        "minimatch": "3.0.4",
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.1",
+        "tsutils": "2.16.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "tsutils": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.16.0.tgz",
+      "integrity": "sha512-9Ier/60O7OZRNPiw+or5QAtAY4kQA+WDiO/r6xOYATEyefH9bdfvTRLCxrYnFhQlZfET2vYXKfpr3Vw2BiArZw==",
+      "requires": {
+        "tslib": "1.8.1"
+      }
+    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -8627,6 +11521,11 @@
       "requires": {
         "is-typedarray": "1.0.0"
       }
+    },
+    "typescript": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -8780,6 +11679,14 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "v8flags": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.1.tgz",
+      "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
+      "requires": {
+        "homedir-polyfill": "1.0.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -9286,6 +12193,11 @@
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         }
       }
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
     },
     "zero-fill": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "test": "jasmine test/**/**.test.js",
-    "postinstall": "./post_install.sh"
+    "postinstall": "node post_install.js"
   },
   "dependencies": {
     "@slack/client": "^3.14.0",
@@ -83,7 +83,7 @@
     "sosa_mongo": "^1.0.3",
     "stats-lite": "2.1.0",
     "style-loader": "^0.19.1",
-    "talib": "^1.0.3",
+    "talib": "drorgl/node-talib#b30dd674e5b11822ea93bb253001169f1bc99e15",
     "timebucket": "^0.4.0",
     "trend": "0.3.0",
     "url-loader": "^0.6.2",

--- a/post_install.js
+++ b/post_install.js
@@ -1,0 +1,9 @@
+var shell = require('shelljs')
+
+console.log('removing node_modules/forex.analytics/.git')
+shell.rm('-rf', 'node_modules/forex.analytics/.git')
+console.log('bundling WebApp components')
+shell.exec('webpack -p')
+console.log('installing genetic_backtester components')
+shell.cd('scripts/genetic_backtester/')
+shell.exec('npm i')

--- a/post_install.sh
+++ b/post_install.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-echo "removing node_modules/forex.analytics/.git"
-rm -rf node_modules/forex.analytics/.git
-echo "bundling WebApp components"
-webpack -p
-echo "installing genetic_backtester components"
-cd scripts/genetic_backtester/ && npm i


### PR DESCRIPTION
switches out the `node-talib` dependency for one that's been updated to correctly build on windows and replaces a shell script with some shelljs (already a dependency of the project)