### PR TITLE
Rebuild Websocket Client instead a "re"-connect

### DIFF
--- a/extensions/exchanges/gdax/exchange.js
+++ b/extensions/exchanges/gdax/exchange.js
@@ -20,7 +20,7 @@ module.exports = function container (get, set, clear) {
       try {
         auth = authedClient()
       } catch(e){}
-      websocket_client[product_id] = new Gdax.OrderbookSync([product_id], c.gdax.apiURI, c.gdax.websocketURI, auth)
+      websocket_client[product_id] = new Gdax.OrderbookSync([product_id], c.gdax.apiURI, c.gdax.websocketURI, auth, { heartbeat: true })
       // initialize a cache for the websocket connection
       websocket_cache[product_id] = {
         trades: [],
@@ -43,9 +43,11 @@ module.exports = function container (get, set, clear) {
       })
       websocket_client[product_id].on('close', () => {
         console.error('websocket connection to '+product_id+' closed, attempting reconnect')
-        websocket_client[product_id].connect()
+        websocket_client[product_id] = null
+        websocket_client[product_id] = websocketClient(product_id)
       })
     }
+    return websocket_client[product_id]
   }
 
   function authedClient () {


### PR DESCRIPTION
Hi,
I had the issue, that zenbot got random locked sell or buy prices. the error appeared for me after 3-4 hours every day.
As i did not find any strange behavior in the zenbot code itself i started some investigation on my exchanges code (gdax).

I found a PR in the Gdax-API repository, which enables the heart beat channel by default. For our current used version the heart beat channel is optional.

Also i somehow does not trust the "reconnect" function. For me the locked price all time appeared right after a reconnect. so i changed the onClose handler, that it builds a complete fresh websocket client instead.

Also see #1089 

After this changes no locked price issue for 23h now.