### PR TITLE
Respect buy_max_amt also in paper mode

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -433,7 +433,7 @@ module.exports = function container (get, set, clear) {
           if (signal === 'buy') {
             price = n(quote.bid).subtract(n(quote.bid).multiply(so.markdown_buy_pct / 100)).format(s.product.increment, Math.floor)
             if (!size) {
-              if (so.mode === 'live') {
+              if (so.mode === 'live' || so.mode === 'paper') {
                 var buy_pct = so.buy_pct
                 if(so.buy_max_amt){
                   var buy_max_as_pct = n(so.buy_max_amt).divide(s.balance.currency).multiply(100)


### PR DESCRIPTION
The buy_max_amt parameter was working only on live, now it works also on paper mode