### PR TITLE
Limit Loopback Size

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -42,6 +42,7 @@ module.exports = function container (get, set, clear) {
       .option('--max_slippage_pct <pct>', 'avoid selling at a slippage pct above this float', c.max_slippage_pct)
       .option('--rsi_periods <periods>', 'number of periods to calculate RSI at', Number, c.rsi_periods)
       .option('--poll_trades <ms>', 'poll new trades at this interval in ms', Number, c.poll_trades)
+      .option('--keep_lookback_periods <amount>', 'Keep this many lookback periods max. ', Number, c.keep_lookback_periods)
       .option('--disable_stats', 'disable printing order stats')
       .option('--reset_profit', 'start new profit calculation from 0')
       .option('--debug', 'output detailed debug info')
@@ -55,7 +56,7 @@ module.exports = function container (get, set, clear) {
             so[k] = cmd[k]
           }
         })
-
+        so.keep_lookback_periods = cmd.keep_lookback_periods
         so.debug = cmd.debug
         so.stats = !cmd.disable_stats
         so.mode = so.paper ? 'paper' : 'live'
@@ -421,7 +422,10 @@ module.exports = function container (get, set, clear) {
                         }
                       }
                     }
-                    lookback_size = s.lookback.length
+                    if(lookback_size = s.lookback.length > so.keep_lookback_periods){
+                      s.lookback.splice(-1,1)
+                    }
+
                     forwardScan()
                     setInterval(forwardScan, so.poll_trades)
                     readline.emitKeypressEvents(process.stdin)

--- a/conf-sample.js
+++ b/conf-sample.js
@@ -141,6 +141,8 @@ c.post_only = true
 
 // default # days for backfill and sim commands
 c.days = 14
+// defaults to a high number of lookback periods
+c.keep_lookback_periods = 50000
 // ms to poll new trades at
 c.poll_trades = 30000
 // amount of currency to start simulations with


### PR DESCRIPTION
adds a flag / configuration parameter to limit the loopback size.  This appears to have been in the original plan as the `lookback_size` variable was already there and being updated.  This just adds a comparison and removes the last element if the comparison passes