### PR TITLE
Fix to correct number of days shown in darwin backtest CSV output.

### DIFF
--- a/commands/sim.js
+++ b/commands/sim.js
@@ -65,6 +65,8 @@ module.exports = function container (get, set, clear) {
           var d = tb('1d')
           so.start = d.subtract(so.days).toMilliseconds()
         }
+        so.days = moment(so.end).diff(moment(so.start), 'days')
+        
         so.stats = !!cmd.enable_stats
         so.show_options = !cmd.disable_options
         so.verbose = !!cmd.verbose


### PR DESCRIPTION
If you run the simulator with no --days parameter and only --start and/or --end, it seems to default the days parameter to 14, not the difference between start and end. This is not serious for the sim because it does it's calculations based on start and end but messes up the CSV output of the darwin backtester by always putting 14 days in the #Days column. This change should fix that.