### PR TITLE
Corrected engine.js to include held assets in calculations for buy_max_amt and buy_pct

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -438,14 +438,14 @@ module.exports = function container (get, set, clear) {
               if (so.mode === 'live') {
                 var buy_pct = so.buy_pct
                 if(so.buy_max_amt){ // account for held assets as buy_max
-				  var adjusted_buy_max_amt = n(so.buy_max_amt).subtract(s.asset_capital).value()
+                  var adjusted_buy_max_amt = n(so.buy_max_amt).subtract(s.asset_capital).value()
                   var buy_max_as_pct = n(adjusted_buy_max_amt).divide(s.balance.currency).multiply(100).value()
                   buy_pct = buy_max_as_pct
                 }else{ // account for held assets as %
-				  var held_pct = n(s.asset_capital).divide(s.balance.currency).multiply(100).value()
-				  var to_buy_pct = n(so.buy_pct).subtract(held_pct).value()
-				  buy_pct = to_buy_pct
-				}
+                  var held_pct = n(s.asset_capital).divide(s.balance.currency).multiply(100).value()
+                  var to_buy_pct = n(so.buy_pct).subtract(held_pct).value()
+                  buy_pct = to_buy_pct
+                }
                 if (so.order_type === 'maker') {
                   size = n(s.balance.currency).multiply(buy_pct).divide(100).multiply(s.exchange.makerFee / 100).format('0.00000000')
                 } else {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -18,6 +18,7 @@ module.exports = function container (get, set, clear) {
     s.product_id = so.selector.product_id
     s.asset = so.selector.asset
     s.currency = so.selector.currency
+    s.asset_capital = 0
     
     if (typeof so.period_length == 'undefined')
       so.period_length = so.period
@@ -192,18 +193,19 @@ module.exports = function container (get, set, clear) {
       s.exchange.getBalance({currency: s.currency, asset: s.asset}, function (err, balance) {
         if (err) return cb(err)
         s.balance = balance
-        if (!s.start_capital) {
-          s.exchange.getQuote({product_id: s.product_id}, function (err, quote) {
-            if (err) return cb(err)
+        s.exchange.getQuote({product_id: s.product_id}, function (err, quote) {
+          if (err) return cb(err)
+			  
+          if (!s.start_capital) {
             s.start_price = n(quote.ask).value()
             s.start_capital = n(s.balance.currency).add(n(s.balance.asset).multiply(quote.ask)).value()
 
             pushMessage('Balance ' + s.exchange.name.toUpperCase(), 'sync balance ' + s.start_capital + ' ' + s.currency  + '\n')
-
-            cb()
-          })
-        }
-        else cb()
+          }
+		  
+          s.asset_capital = n(s.balance.asset).multiply(quote.ask).value()
+          cb()
+        })
       })
     }
 
@@ -435,12 +437,15 @@ module.exports = function container (get, set, clear) {
             if (!size) {
               if (so.mode === 'live') {
                 var buy_pct = so.buy_pct
-                if(so.buy_max_amt){
-                  var buy_max_as_pct = n(so.buy_max_amt).divide(s.balance.currency).multiply(100)
-                  if(buy_max_as_pct < buy_pct){
-                    buy_pct = buy_max_as_pct
-                  }
-                }
+                if(so.buy_max_amt){ // account for held assets as buy_max
+				  var adjusted_buy_max_amt = n(so.buy_max_amt).subtract(s.asset_capital).value()
+                  var buy_max_as_pct = n(adjusted_buy_max_amt).divide(s.balance.currency).multiply(100).value()
+                  buy_pct = buy_max_as_pct
+                }else{ // account for held assets as %
+				  var held_pct = n(s.asset_capital).divide(s.balance.currency).multiply(100).value()
+				  var to_buy_pct = n(so.buy_pct).subtract(held_pct).value()
+				  buy_pct = to_buy_pct
+				}
                 if (so.order_type === 'maker') {
                   size = n(s.balance.currency).multiply(buy_pct).divide(100).multiply(s.exchange.makerFee / 100).format('0.00000000')
                 } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -389,7 +389,7 @@
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000787",
+        "caniuse-db": "1.0.30000790",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -964,9 +964,9 @@
       }
     },
     "bitstamp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bitstamp/-/bitstamp-1.0.5.tgz",
-      "integrity": "sha512-hgo+gJ6AioE4dZAGAikbscq/F2TInnNi45WyMAV6e00zWQkjpeTKqtCXCu0hP6LRgooIPvZgWUrJbpjNwgmsOQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/bitstamp/-/bitstamp-1.0.6.tgz",
+      "integrity": "sha512-TZDi2OvckUWNl9qDotuOjQsdR9KfByqhy+4eRo2GmpmUbzvG9Fu+fnC9VGeeX9Kc5yAgHWLyvrlOq+6QYdi4eg==",
       "requires": {
         "underscore": "1.4.4"
       }
@@ -1102,7 +1102,7 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -1132,7 +1132,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "requires": {
-        "caniuse-db": "1.0.30000787",
+        "caniuse-db": "1.0.30000790",
         "electron-to-chromium": "1.3.30"
       }
     },
@@ -1211,15 +1211,15 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000787",
+        "caniuse-db": "1.0.30000790",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000787",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000787.tgz",
-      "integrity": "sha1-ygeigb5Taoi9f6yWuolfPPU/gRs="
+      "version": "1.0.30000790",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000790.tgz",
+      "integrity": "sha1-qAI+brn+nA7z1gtEJ84QTqh9OBw="
     },
     "caseless": {
       "version": "0.11.0",
@@ -1227,9 +1227,9 @@
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
     },
     "ccxt": {
-      "version": "1.10.579",
-      "resolved": "https://registry.npmjs.org/ccxt/-/ccxt-1.10.579.tgz",
-      "integrity": "sha512-Tp6tRmj/zV/Wpap8v5Vq5RN1e8jeJFPRO9c8MK9HyKuXueWKXG+L3oVMsD4ZBCTjddsQqHyT/RPO/L3cgHL7bw==",
+      "version": "1.10.640",
+      "resolved": "https://registry.npmjs.org/ccxt/-/ccxt-1.10.640.tgz",
+      "integrity": "sha512-IiRATYlfzRPKCvUw7AEIxW3aSB7AAIKsMLqM1FZ/F5SnVTcG8S8Nzbh1R9bFPWXDr+JlgbnXNJPolnDxXoYcdg==",
       "requires": {
         "crypto-js": "3.1.9-1",
         "fetch-ponyfill": "4.1.0",
@@ -1671,9 +1671,9 @@
       }
     },
     "commander": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -1846,7 +1846,7 @@
         "inherits": "2.0.3",
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5",
+        "randombytes": "2.0.6",
         "randomfill": "1.0.3"
       }
     },
@@ -2129,7 +2129,7 @@
       "requires": {
         "bn.js": "4.11.8",
         "miller-rabin": "4.0.1",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "doctrine": {
@@ -2216,9 +2216,9 @@
       }
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "1.4.0"
       }
@@ -2363,9 +2363,9 @@
       }
     },
     "eslint": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.14.0.tgz",
-      "integrity": "sha512-Ul6CSGRjKscEyg0X/EeNs7o2XdnbTEOD1OM8cTjmx85RPcBJQrEhZLevhuJZNAE/vS2iVl5Uhgiqf3h5uLMCJQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.15.0.tgz",
+      "integrity": "sha512-zEO/Z1ZUxIQ+MhDVKkVTUYpIPDTEJLXGMrkID+5v1NeQHtCz6FZikWuFRgxE1Q/RV2V4zVl1u3xmpPADHhMZ6A==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -2995,14 +2995,12 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "bundled": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "co": "4.6.0",
@@ -3011,19 +3009,16 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "bundled": true
         },
         "aproba": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "bundled": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "delegates": "1.0.0",
@@ -3032,43 +3027,36 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "bundled": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "bundled": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "bundled": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "bundled": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "bundled": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+          "bundled": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "tweetnacl": "0.14.5"
@@ -3076,24 +3064,21 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "bundled": true,
           "requires": {
             "inherits": "2.0.3"
           }
         },
         "boom": {
           "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "bundled": true,
           "requires": {
             "hoek": "2.16.3"
           }
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "bundled": true,
           "requires": {
             "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
@@ -3101,61 +3086,51 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+          "bundled": true
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "bundled": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "bundled": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "bundled": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "bundled": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+          "bundled": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "bundled": true,
           "requires": {
             "boom": "2.10.1"
           }
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
@@ -3163,16 +3138,14 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "optional": true
             }
           }
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -3180,31 +3153,26 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "bundled": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
-          "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
+          "bundled": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1"
@@ -3212,25 +3180,21 @@
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "bundled": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+          "bundled": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "bundled": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "asynckit": "0.4.0",
@@ -3240,13 +3204,11 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+          "bundled": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "bundled": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
@@ -3256,8 +3218,7 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "fstream": "1.0.11",
@@ -3267,8 +3228,7 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "aproba": "1.1.1",
@@ -3283,8 +3243,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
@@ -3292,16 +3251,14 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "optional": true
             }
           }
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -3313,19 +3270,16 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+          "bundled": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "bundled": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "ajv": "4.11.8",
@@ -3334,14 +3288,12 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "bundled": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -3351,13 +3303,11 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+          "bundled": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "assert-plus": "0.2.0",
@@ -3367,8 +3317,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -3376,44 +3325,37 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "bundled": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "bundled": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "bundled": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "bundled": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1"
@@ -3421,20 +3363,17 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "bundled": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "bundled": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "jsonify": "0.0.0"
@@ -3442,20 +3381,17 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "bundled": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+          "bundled": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -3466,56 +3402,48 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "optional": true
             }
           }
         },
         "mime-db": {
           "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+          "bundled": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "bundled": true,
           "requires": {
             "mime-db": "1.27.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "requires": {
             "brace-expansion": "1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "bundled": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "detect-libc": "1.0.2",
@@ -3533,8 +3461,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "abbrev": "1.1.0",
@@ -3543,8 +3470,7 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
@@ -3555,45 +3481,38 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "bundled": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "bundled": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
@@ -3602,36 +3521,30 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+          "bundled": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "bundled": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+          "bundled": true
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "bundled": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "bundled": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "deep-extend": "0.4.2",
@@ -3642,16 +3555,14 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "bundled": true,
           "requires": {
             "buffer-shims": "1.0.0",
             "core-util-is": "1.0.2",
@@ -3664,8 +3575,7 @@
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "aws-sign2": "0.6.0",
@@ -3694,47 +3604,40 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "bundled": true,
           "requires": {
             "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+          "bundled": true
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "bundled": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "bundled": true,
           "requires": {
             "hoek": "2.16.3"
           }
         },
         "sshpk": {
           "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "asn1": "0.2.3",
@@ -3750,16 +3653,14 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "optional": true
             }
           }
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -3768,36 +3669,31 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "bundled": true,
           "requires": {
             "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "bundled": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "requires": {
             "block-stream": "0.0.9",
             "fstream": "1.0.11",
@@ -3806,8 +3702,7 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "debug": "2.6.8",
@@ -3822,8 +3717,7 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "punycode": "1.4.1"
@@ -3831,8 +3725,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -3840,31 +3733,26 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "bundled": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+          "bundled": true
         },
         "uuid": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "bundled": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "extsprintf": "1.0.2"
@@ -3872,8 +3760,7 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "string-width": "1.0.2"
@@ -3881,8 +3768,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "bundled": true
         }
       }
     },
@@ -4019,6 +3905,11 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
           "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
         },
         "ws": {
           "version": "3.0.0",
@@ -4429,7 +4320,7 @@
       "resolved": "https://registry.npmjs.org/idgen/-/idgen-2.0.2.tgz",
       "integrity": "sha1-ZFpO6n7bUz2UH1jt2UMVVUWPwqg=",
       "requires": {
-        "commander": "2.12.2"
+        "commander": "2.13.0"
       }
     },
     "ieee754": {
@@ -4960,7 +4851,7 @@
       "dev": true,
       "requires": {
         "cli-table": "0.3.1",
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "debug": "3.1.0",
         "flat": "4.0.0",
         "lodash.clonedeep": "4.5.0",
@@ -5661,7 +5552,7 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.12.2",
+            "commander": "2.13.0",
             "is-my-json-valid": "2.17.1",
             "pinkie-promise": "2.0.1"
           }
@@ -6162,16 +6053,16 @@
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.5.tgz",
-      "integrity": "sha512-9fAxS/+I3fBLBLJpZkuUTa1nY78BDWiP4Z8NFebaBCt3NuInv31J4YrljAaktsJ5QodyQ1qyr5EdBzTITF1cxw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.5"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-dir": {
@@ -7065,7 +6956,7 @@
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "pump": {
@@ -7073,7 +6964,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "once": "1.4.0"
       }
     },
@@ -7335,9 +7226,9 @@
       }
     },
     "randombytes": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -7347,7 +7238,7 @@
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
       "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
       "requires": {
-        "randombytes": "2.0.5",
+        "randombytes": "2.0.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -7393,16 +7284,6 @@
           "requires": {
             "path-exists": "2.1.0",
             "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "requires": {
-                "pinkie": "2.0.5"
-              }
-            }
           }
         },
         "path-exists": {
@@ -7411,16 +7292,6 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
             "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "requires": {
-                "pinkie": "2.0.5"
-              }
-            }
           }
         }
       }
@@ -7631,19 +7502,9 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.12.2",
+            "commander": "2.13.0",
             "is-my-json-valid": "2.17.1",
             "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "requires": {
-                "pinkie": "2.0.5"
-              }
-            }
           }
         }
       }
@@ -8791,11 +8652,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
@@ -9203,12 +9059,12 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-      "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.1.tgz",
+      "integrity": "sha512-7uRL1HZdCbc1QTP+X8mehOPuCYKC/XTaqAPj7gABLfTt6pgLyVRn3QVte4qhtilZouWCvqd1kipgMKl5tKsFiw==",
       "dev": true,
       "requires": {
-        "cliui": "3.2.0",
+        "cliui": "4.0.0",
         "decamelize": "1.2.0",
         "find-up": "2.1.0",
         "get-caller-file": "1.0.2",
@@ -9233,6 +9089,17 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
+        },
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",

--- a/test/lib/engine.test.js
+++ b/test/lib/engine.test.js
@@ -1,121 +1,227 @@
 describe("Engine", function() {
 	describe("executeSignal", function() {
-		describe("when maker", function(){
-			it("with buy_max_amt less than buy_pct amount should use buy_max_amt", function(){
-				// arrange
-				var signal_type = "buy"
-				var currency_amount = 1
-				var buy_pct = 50
-				var buy_max_amt = 0.25
-				var order_type = "maker"			
-				var buy_spy = jasmine.createSpy()
-				var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, buy_spy)
-				// act
-				sut.executeSignal(signal_type)
-				// assert
-				var expected = "2.77500000"
-				var buyArgs = buy_spy.calls.mostRecent().args[0]
-				expect(buyArgs.size).toBe(expected)
+		describe("when maker in live mode", function(){
+			describe("with buy_max set", function(){
+				it("and no held assets should use raw buy_max_amt", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 1.0
+					var buy_pct = 50
+					var buy_max_amt = 0.25
+					var order_type = "maker"
+					var held_asset = 0
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					var expected = "2.77500000"
+					var buyArgs = buy_spy.calls.mostRecent().args[0]
+					expect(buyArgs.size).toBe(expected)
+				})
+				it("and held assets should use adjusted buy_max_amt", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 3.0
+					var buy_pct = 50
+					var buy_max_amt = 0.25
+					var order_type = "maker"
+					var held_asset = 0.75
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					var expected = "1.85925000"
+					var buyArgs = buy_spy.calls.mostRecent().args[0]
+					expect(buyArgs.size).toBe(expected)
+				})
+				it("and held assets so large adjusted buy_max_amt is below order minimum should not place order", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 1.0
+					var buy_pct = 50
+					var buy_max_amt = 0.25
+					var order_type = "maker"
+					var held_asset = 2.0
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					expect(buy_spy).not.toHaveBeenCalled()
+				})
 			})
-			
-			it("with buy_max_amt more than buy_pct amount should use buy_pct", function(){
-				// arrange
-				var signal_type = "buy"
-				var currency_amount = 1
-				var buy_pct = 50
-				var buy_max_amt = 0.75
-				var order_type = "maker"			
-				var buy_spy = jasmine.createSpy()
-				var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, buy_spy)
-				// act
-				sut.executeSignal(signal_type)
-				// assert
-				var expected = "5.55000000"
-				var buyArgs = buy_spy.calls.mostRecent().args[0]
-				expect(buyArgs.size).toBe(expected)
-			})
-			
-			it("with buy_max_amt equals buy_pct amount should use buy_pct", function(){
-				// arrange
-				var signal_type = "buy"
-				var currency_amount = 1
-				var buy_pct = 50
-				var buy_max_amt = 0.50
-				var order_type = "maker"			
-				var buy_spy = jasmine.createSpy()
-				var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, buy_spy)
-				// act
-				sut.executeSignal(signal_type)
-				// assert
-				var expected = "5.55000000"
-				var buyArgs = buy_spy.calls.mostRecent().args[0]
-				expect(buyArgs.size).toBe(expected)
+			describe("with no buy_max set", function(){
+				it("and no held assets should use raw buy_pct", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 1.0
+					var buy_pct = 50
+					var buy_max_amt = undefined
+					var order_type = "maker"
+					var held_asset = 0				
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					var expected = "5.55000000"
+					var buyArgs = buy_spy.calls.mostRecent().args[0]
+					expect(buyArgs.size).toBe(expected)
+				})
+				it("and held assets should use adjusted buy_pct", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 1.0
+					var buy_pct = 50
+					var buy_max_amt = undefined
+					var order_type = "maker"
+					var held_asset = 0.5				
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					var expected = "4.93950000"
+					var buyArgs = buy_spy.calls.mostRecent().args[0]
+					expect(buyArgs.size).toBe(expected)
+				})
+				it("and held assets so large adjusted buy_pct is below order minimum should not place order", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 1.0
+					var buy_pct = 50
+					var buy_max_amt = undefined
+					var order_type = "maker"
+					var held_asset = 5.25				
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					expect(buy_spy).not.toHaveBeenCalled()
+				})
 			})
 		})
 		
-		describe("when taker", function(){
-			it("with buy_max_amt less than buy_pct amount should use buy_max_amt", function(){
-				// arrange
-				var signal_type = "buy"
-				var currency_amount = 1
-				var buy_pct = 50
-				var buy_max_amt = 0.25
-				var order_type = "taker"
-				var buy_spy = jasmine.createSpy()
-				var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, buy_spy)
-				// act
-				sut.executeSignal(signal_type)
-				// assert
-				var expected = "2.77222222"
-				var buyArgs = buy_spy.calls.mostRecent().args[0]
-				expect(buyArgs.size).toBe(expected)
+		describe("when taker in live mode", function(){
+			describe("with buy_max_amt set",function(){
+				it("and no held assets should use raw buy_max_amt", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 1
+					var buy_pct = 50
+					var buy_max_amt = 0.25
+					var order_type = "taker"
+					var held_asset = 0
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					var expected = "2.77222222"
+					var buyArgs = buy_spy.calls.mostRecent().args[0]
+					expect(buyArgs.size).toBe(expected)
+				})
+				
+				it("and held assets should use adjusted buy_max_amt", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 3.0
+					var buy_pct = 50
+					var buy_max_amt = 0.25
+					var order_type = "taker"
+					var held_asset = 0.75
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					var expected = "1.85738888"
+					var buyArgs = buy_spy.calls.mostRecent().args[0]
+					expect(buyArgs.size).toBe(expected)
+				})
+				
+				it("and held assets so large adjusted buy_max_amt is below order minimum should not place order", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 1.0
+					var buy_pct = 50
+					var buy_max_amt = 0.25
+					var order_type = "taker"
+					var held_asset = 2.0
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					expect(buy_spy).not.toHaveBeenCalled()
+				})
 			})
-			
-			it("with buy_max_amt more than buy_pct amount should use buy_pct", function(){
-				// arrange
-				var signal_type = "buy"
-				var currency_amount = 1
-				var buy_pct = 50
-				var buy_max_amt = 0.75
-				var order_type = "taker"			
-				var buy_spy = jasmine.createSpy()
-				var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, buy_spy)
-				// act
-				sut.executeSignal(signal_type)
-				// assert
-				var expected = "5.54444444"
-				var buyArgs = buy_spy.calls.mostRecent().args[0]
-				expect(buyArgs.size).toBe(expected)
-			})
-			
-			it("with buy_max_amt equals buy_pct amount should use buy_pct", function(){
-				// arrange
-				var signal_type = "buy"
-				var currency_amount = 1
-				var buy_pct = 50
-				var buy_max_amt = 0.50
-				var order_type = "taker"			
-				var buy_spy = jasmine.createSpy()
-				var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, buy_spy)
-				// act
-				sut.executeSignal(signal_type)
-				// assert
-				var expected = "5.54444444"
-				var buyArgs = buy_spy.calls.mostRecent().args[0]
-				expect(buyArgs.size).toBe(expected)
+			describe("with no buy_max_amt set",function(){
+				it("with no buy_max_amt set and no held assets should use raw buy_pct", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 1
+					var buy_pct = 50
+					var buy_max_amt = undefined
+					var order_type = "taker"
+					var held_asset = 0
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					var expected = "5.54444444"
+					var buyArgs = buy_spy.calls.mostRecent().args[0]
+					expect(buyArgs.size).toBe(expected)
+				})
+				it("and held assets should use adjusted buy_pct", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 1.0
+					var buy_pct = 50
+					var buy_max_amt = undefined
+					var order_type = "taker"
+					var held_asset = 0.5				
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					var expected = "4.93455555"
+					var buyArgs = buy_spy.calls.mostRecent().args[0]
+					expect(buyArgs.size).toBe(expected)
+				})
+				it("and held assets so large adjusted buy_pct is below order minimum should not place order", function(){
+					// arrange
+					var signal_type = "buy"
+					var currency_amount = 1.0
+					var buy_pct = 50
+					var buy_max_amt = undefined
+					var order_type = "taker"
+					var held_asset = 5.25				
+					var buy_spy = jasmine.createSpy()
+					var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+					// act
+					sut.executeSignal(signal_type)
+					// assert
+					expect(buy_spy).not.toHaveBeenCalled()
+				})
 			})
 		})
 	})
 })
 
-function createEngine(currency_amount, buy_pct, buy_max_amt, order_type, buy_spy){	
+function createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy){	
 	var fake_asset = "test_asset"
 	var fake_currency = "BTC"
 	var fake_exchange = "test_exchange"
 	var fake_project = "test_product"
 	var fake_bid = 0.10
 	var fake_ask = 0.11
-	var fake_balance = { currency: currency_amount, asset:0}
+	var fake_balance = { currency: currency_amount, asset:held_asset}
 	
 	var fakes = {
 		get: function() { },


### PR DESCRIPTION
This will stop the behavior described in this issue https://github.com/DeviaVir/zenbot/issues/878
and fix it for when the bot is running in standard mode too.

It is not perfect because it uses the current quote price in calculation, thus large price fluctuations can impact its correctness. 
