### PR TITLE
use ccxt for loading binance exchanges pairs; instead of a direct api call

### DIFF
--- a/extensions/exchanges/binance/products.json
+++ b/extensions/exchanges/binance/products.json
@@ -1,146 +1,65 @@
 [
   {
-    "id": "NULSBNB",
-    "asset": "NULS",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "NULS/BNB"
+    "id": "ETHBTC",
+    "asset": "ETH",
+    "currency": "BTC",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "ETH/BTC"
   },
   {
-    "id": "VENBNB",
-    "asset": "VEN",
-    "currency": "BNB",
+    "id": "LTCBTC",
+    "asset": "LTC",
+    "currency": "BTC",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0001",
-    "label": "VEN/BNB"
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "LTC/BTC"
   },
   {
     "id": "BNBBTC",
     "asset": "BNB",
     "currency": "BTC",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
     "label": "BNB/BTC"
-  },
-  {
-    "id": "NULSBTC",
-    "asset": "NULS",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "NULS/BTC"
-  },
-  {
-    "id": "CTRBTC",
-    "asset": "CTR",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "CTR/BTC"
   },
   {
     "id": "NEOBTC",
     "asset": "NEO",
     "currency": "BTC",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
     "label": "NEO/BTC"
   },
   {
-    "id": "NULSETH",
-    "asset": "NULS",
+    "id": "123456",
+    "asset": "123",
+    "currency": "456",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "123/456"
+  },
+  {
+    "id": "QTUMETH",
+    "asset": "QTUM",
     "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "NULS/ETH"
-  },
-  {
-    "id": "LINKBTC",
-    "asset": "LINK",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "LINK/BTC"
-  },
-  {
-    "id": "SALTBTC",
-    "asset": "SALT",
-    "currency": "BTC",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "SALT/BTC"
-  },
-  {
-    "id": "IOTABTC",
-    "asset": "IOTA",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "IOTA/BTC"
-  },
-  {
-    "id": "ETCBTC",
-    "asset": "ETC",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "ETC/BTC"
-  },
-  {
-    "id": "ASTETH",
-    "asset": "AST",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "AST/ETH"
-  },
-  {
-    "id": "KNCBTC",
-    "asset": "KNC",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "KNC/BTC"
-  },
-  {
-    "id": "WTCBTC",
-    "asset": "WTC",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "WTC/BTC"
-  },
-  {
-    "id": "SNGLSBTC",
-    "asset": "SNGLS",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "SNGLS/BTC"
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "QTUM/ETH"
   },
   {
     "id": "EOSETH",
     "asset": "EOS",
     "currency": "ETH",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
     "label": "EOS/ETH"
   },
   {
@@ -148,1115 +67,143 @@
     "asset": "SNT",
     "currency": "ETH",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
     "label": "SNT/ETH"
-  },
-  {
-    "id": "MCOETH",
-    "asset": "MCO",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "MCO/ETH"
-  },
-  {
-    "id": "BTCUSDT",
-    "asset": "BTC",
-    "currency": "USDT",
-    "min_size": "0.00000100",
-    "max_size": "100000",
-    "increment": "0.01",
-    "label": "BTC/USDT"
-  },
-  {
-    "id": "OAXETH",
-    "asset": "OAX",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "OAX/ETH"
-  },
-  {
-    "id": "OMGETH",
-    "asset": "OMG",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "OMG/ETH"
-  },
-  {
-    "id": "GASBTC",
-    "asset": "GAS",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "GAS/BTC"
-  },
-  {
-    "id": "BQXETH",
-    "asset": "BQX",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "BQX/ETH"
-  },
-  {
-    "id": "WTCETH",
-    "asset": "WTC",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "WTC/ETH"
-  },
-  {
-    "id": "QTUMETH",
-    "asset": "QTUM",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "QTUM/ETH"
   },
   {
     "id": "BNTETH",
     "asset": "BNT",
     "currency": "ETH",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
     "label": "BNT/ETH"
   },
   {
-    "id": "DNTETH",
-    "asset": "DNT",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "DNT/ETH"
-  },
-  {
-    "id": "ICNETH",
-    "asset": "ICN",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "ICN/ETH"
-  },
-  {
-    "id": "SNMBTC",
-    "asset": "SNM",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "SNM/BTC"
-  },
-  {
-    "id": "SNMETH",
-    "asset": "SNM",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "SNM/ETH"
-  },
-  {
-    "id": "SNGLSETH",
-    "asset": "SNGLS",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "SNGLS/ETH"
-  },
-  {
-    "id": "BQXBTC",
-    "asset": "BQX",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "BQX/BTC"
-  },
-  {
-    "id": "NEOETH",
-    "asset": "NEO",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "NEO/ETH"
-  },
-  {
-    "id": "KNCETH",
-    "asset": "KNC",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "KNC/ETH"
-  },
-  {
-    "id": "STRATETH",
-    "asset": "STRAT",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "STRAT/ETH"
-  },
-  {
-    "id": "ZRXETH",
-    "asset": "ZRX",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ZRX/ETH"
-  },
-  {
-    "id": "QTUMBTC",
-    "asset": "QTUM",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "QTUM/BTC"
-  },
-  {
-    "id": "FUNETH",
-    "asset": "FUN",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "FUN/ETH"
-  },
-  {
-    "id": "LTCBTC",
-    "asset": "LTC",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "LTC/BTC"
-  },
-  {
-    "id": "LINKETH",
-    "asset": "LINK",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "LINK/ETH"
-  },
-  {
-    "id": "ETHBTC",
-    "asset": "ETH",
-    "currency": "BTC",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "ETH/BTC"
-  },
-  {
-    "id": "XVGETH",
-    "asset": "XVG",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "XVG/ETH"
-  },
-  {
-    "id": "STRATBTC",
-    "asset": "STRAT",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "STRAT/BTC"
-  },
-  {
-    "id": "ZRXBTC",
-    "asset": "ZRX",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ZRX/BTC"
-  },
-  {
-    "id": "IOTAETH",
-    "asset": "IOTA",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "IOTA/ETH"
-  },
-  {
     "id": "BCCBTC",
-    "asset": "BCC",
+    "asset": "BCH",
     "currency": "BTC",
     "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "BCC/BTC"
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "BCH/BTC"
   },
   {
-    "id": "CTRETH",
-    "asset": "CTR",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "CTR/ETH"
-  },
-  {
-    "id": "OMGBTC",
-    "asset": "OMG",
+    "id": "GASBTC",
+    "asset": "GAS",
     "currency": "BTC",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "OMG/BTC"
-  },
-  {
-    "id": "MCOBTC",
-    "asset": "MCO",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "MCO/BTC"
-  },
-  {
-    "id": "SALTETH",
-    "asset": "SALT",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "SALT/ETH"
-  },
-  {
-    "id": "ADABTC",
-    "asset": "ADA",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ADA/BTC"
-  },
-  {
-    "id": "ADAETH",
-    "asset": "ADA",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ADA/ETH"
-  },
-  {
-    "id": "ADXBNB",
-    "asset": "ADX",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "ADX/BNB"
-  },
-  {
-    "id": "ADXBTC",
-    "asset": "ADX",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ADX/BTC"
-  },
-  {
-    "id": "ADXETH",
-    "asset": "ADX",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "ADX/ETH"
-  },
-  {
-    "id": "AIONBNB",
-    "asset": "AION",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "AION/BNB"
-  },
-  {
-    "id": "AIONBTC",
-    "asset": "AION",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "AION/BTC"
-  },
-  {
-    "id": "AIONETH",
-    "asset": "AION",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "AION/ETH"
-  },
-  {
-    "id": "AMBBNB",
-    "asset": "AMB",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "AMB/BNB"
-  },
-  {
-    "id": "AMBBTC",
-    "asset": "AMB",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "AMB/BTC"
-  },
-  {
-    "id": "AMBETH",
-    "asset": "AMB",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "AMB/ETH"
-  },
-  {
-    "id": "APPCBNB",
-    "asset": "APPC",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "APPC/BNB"
-  },
-  {
-    "id": "APPCBTC",
-    "asset": "APPC",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "APPC/BTC"
-  },
-  {
-    "id": "APPCETH",
-    "asset": "APPC",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "APPC/ETH"
-  },
-  {
-    "id": "ARKBTC",
-    "asset": "ARK",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "ARK/BTC"
-  },
-  {
-    "id": "ARKETH",
-    "asset": "ARK",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "ARK/ETH"
-  },
-  {
-    "id": "ARNBTC",
-    "asset": "ARN",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ARN/BTC"
-  },
-  {
-    "id": "ARNETH",
-    "asset": "ARN",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ARN/ETH"
-  },
-  {
-    "id": "ASTBTC",
-    "asset": "AST",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "AST/BTC"
-  },
-  {
-    "id": "BATBNB",
-    "asset": "BAT",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "BAT/BNB"
-  },
-  {
-    "id": "BATBTC",
-    "asset": "BAT",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "BAT/BTC"
-  },
-  {
-    "id": "BATETH",
-    "asset": "BAT",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "BAT/ETH"
-  },
-  {
-    "id": "BCCBNB",
-    "asset": "BCC",
-    "currency": "BNB",
-    "min_size": "0.00001000",
-    "max_size": "100000",
-    "increment": "0.01",
-    "label": "BCC/BNB"
-  },
-  {
-    "id": "BCCETH",
-    "asset": "BCC",
-    "currency": "ETH",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "BCC/ETH"
-  },
-  {
-    "id": "BCCUSDT",
-    "asset": "BCC",
-    "currency": "USDT",
-    "min_size": "0.00001000",
-    "max_size": "100000",
-    "increment": "0.01",
-    "label": "BCC/USDT"
-  },
-  {
-    "id": "BCDBTC",
-    "asset": "BCD",
-    "currency": "BTC",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "BCD/BTC"
-  },
-  {
-    "id": "BCDETH",
-    "asset": "BCD",
-    "currency": "ETH",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "BCD/ETH"
-  },
-  {
-    "id": "BCPTBNB",
-    "asset": "BCPT",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "BCPT/BNB"
-  },
-  {
-    "id": "BCPTBTC",
-    "asset": "BCPT",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "BCPT/BTC"
-  },
-  {
-    "id": "BCPTETH",
-    "asset": "BCPT",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "BCPT/ETH"
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "GAS/BTC"
   },
   {
     "id": "BNBETH",
     "asset": "BNB",
     "currency": "ETH",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
     "label": "BNB/ETH"
   },
   {
-    "id": "BNTBTC",
-    "asset": "BNT",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "BNT/BTC"
+    "id": "BTCUSDT",
+    "asset": "BTC",
+    "currency": "USDT",
+    "min_size": "0.00000100",
+    "max_size": "10000000.00000000",
+    "increment": "0.00000100",
+    "label": "BTC/USDT"
   },
   {
-    "id": "BRDBNB",
-    "asset": "BRD",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "BRD/BNB"
-  },
-  {
-    "id": "BRDBTC",
-    "asset": "BRD",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "BRD/BTC"
-  },
-  {
-    "id": "BRDETH",
-    "asset": "BRD",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "BRD/ETH"
-  },
-  {
-    "id": "BTGBTC",
-    "asset": "BTG",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "BTG/BTC"
-  },
-  {
-    "id": "BTGETH",
-    "asset": "BTG",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "BTG/ETH"
-  },
-  {
-    "id": "BTSBNB",
-    "asset": "BTS",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "BTS/BNB"
-  },
-  {
-    "id": "BTSBTC",
-    "asset": "BTS",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "BTS/BTC"
-  },
-  {
-    "id": "BTSETH",
-    "asset": "BTS",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "BTS/ETH"
-  },
-  {
-    "id": "CDTBTC",
-    "asset": "CDT",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "CDT/BTC"
-  },
-  {
-    "id": "CDTETH",
-    "asset": "CDT",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "CDT/ETH"
-  },
-  {
-    "id": "CMTBNB",
-    "asset": "CMT",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "CMT/BNB"
-  },
-  {
-    "id": "CMTBTC",
-    "asset": "CMT",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "CMT/BTC"
-  },
-  {
-    "id": "CMTETH",
-    "asset": "CMT",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "CMT/ETH"
-  },
-  {
-    "id": "CNDBNB",
-    "asset": "CND",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "CND/BNB"
-  },
-  {
-    "id": "CNDBTC",
-    "asset": "CND",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "CND/BTC"
-  },
-  {
-    "id": "CNDETH",
-    "asset": "CND",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "CND/ETH"
-  },
-  {
-    "id": "DASHBTC",
-    "asset": "DASH",
-    "currency": "BTC",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "DASH/BTC"
-  },
-  {
-    "id": "DASHETH",
-    "asset": "DASH",
-    "currency": "ETH",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "DASH/ETH"
-  },
-  {
-    "id": "DGDBTC",
-    "asset": "DGD",
-    "currency": "BTC",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "DGD/BTC"
-  },
-  {
-    "id": "DGDETH",
-    "asset": "DGD",
-    "currency": "ETH",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "DGD/ETH"
-  },
-  {
-    "id": "DLTBNB",
-    "asset": "DLT",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "DLT/BNB"
-  },
-  {
-    "id": "DLTBTC",
-    "asset": "DLT",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "DLT/BTC"
-  },
-  {
-    "id": "DLTETH",
-    "asset": "DLT",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "DLT/ETH"
-  },
-  {
-    "id": "DNTBTC",
-    "asset": "DNT",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "DNT/BTC"
-  },
-  {
-    "id": "EDOBTC",
-    "asset": "EDO",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "EDO/BTC"
-  },
-  {
-    "id": "EDOETH",
-    "asset": "EDO",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "EDO/ETH"
-  },
-  {
-    "id": "ELFBTC",
-    "asset": "ELF",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ELF/BTC"
-  },
-  {
-    "id": "ELFETH",
-    "asset": "ELF",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ELF/ETH"
-  },
-  {
-    "id": "ENGBTC",
-    "asset": "ENG",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ENG/BTC"
-  },
-  {
-    "id": "ENGETH",
-    "asset": "ENG",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "ENG/ETH"
-  },
-  {
-    "id": "ENJBTC",
-    "asset": "ENJ",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ENJ/BTC"
-  },
-  {
-    "id": "ENJETH",
-    "asset": "ENJ",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ENJ/ETH"
-  },
-  {
-    "id": "EOSBTC",
-    "asset": "EOS",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "EOS/BTC"
-  },
-  {
-    "id": "ETCETH",
-    "asset": "ETC",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "ETC/ETH"
-  },
-  {
-    "id": "EVXBTC",
-    "asset": "EVX",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "EVX/BTC"
-  },
-  {
-    "id": "EVXETH",
-    "asset": "EVX",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "EVX/ETH"
-  },
-  {
-    "id": "FUELBTC",
-    "asset": "FUEL",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "FUEL/BTC"
-  },
-  {
-    "id": "FUELETH",
-    "asset": "FUEL",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "FUEL/ETH"
-  },
-  {
-    "id": "FUNBTC",
-    "asset": "FUN",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "FUN/BTC"
-  },
-  {
-    "id": "GTOBNB",
-    "asset": "GTO",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "GTO/BNB"
-  },
-  {
-    "id": "GTOBTC",
-    "asset": "GTO",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "GTO/BTC"
-  },
-  {
-    "id": "GTOETH",
-    "asset": "GTO",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "GTO/ETH"
-  },
-  {
-    "id": "GVTBTC",
-    "asset": "GVT",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "GVT/BTC"
-  },
-  {
-    "id": "GVTETH",
-    "asset": "GVT",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "GVT/ETH"
-  },
-  {
-    "id": "GXSBTC",
-    "asset": "GXS",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "GXS/BTC"
-  },
-  {
-    "id": "GXSETH",
-    "asset": "GXS",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "GXS/ETH"
+    "id": "ETHUSDT",
+    "asset": "ETH",
+    "currency": "USDT",
+    "min_size": "0.00001000",
+    "max_size": "10000000.00000000",
+    "increment": "0.00001000",
+    "label": "ETH/USDT"
   },
   {
     "id": "HSRBTC",
     "asset": "HSR",
     "currency": "BTC",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
     "label": "HSR/BTC"
   },
   {
-    "id": "HSRETH",
-    "asset": "HSR",
+    "id": "OAXETH",
+    "asset": "OAX",
     "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "HSR/ETH"
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "OAX/ETH"
   },
   {
-    "id": "ICNBTC",
+    "id": "DNTETH",
+    "asset": "DNT",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "DNT/ETH"
+  },
+  {
+    "id": "MCOETH",
+    "asset": "MCO",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "MCO/ETH"
+  },
+  {
+    "id": "ICNETH",
     "asset": "ICN",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "ICN/BTC"
-  },
-  {
-    "id": "ICXBNB",
-    "asset": "ICX",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "ICX/BNB"
-  },
-  {
-    "id": "ICXBTC",
-    "asset": "ICX",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "ICX/BTC"
-  },
-  {
-    "id": "ICXETH",
-    "asset": "ICX",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "ICX/ETH"
-  },
-  {
-    "id": "IOTABNB",
-    "asset": "IOTA",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "IOTA/BNB"
-  },
-  {
-    "id": "KMDBTC",
-    "asset": "KMD",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "KMD/BTC"
-  },
-  {
-    "id": "KMDETH",
-    "asset": "KMD",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "KMD/ETH"
-  },
-  {
-    "id": "LENDBTC",
-    "asset": "LEND",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "LEND/BTC"
-  },
-  {
-    "id": "LENDETH",
-    "asset": "LEND",
     "currency": "ETH",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "LEND/ETH"
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ICN/ETH"
+  },
+  {
+    "id": "MCOBTC",
+    "asset": "MCO",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "MCO/BTC"
+  },
+  {
+    "id": "WTCBTC",
+    "asset": "WTC",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "WTC/BTC"
+  },
+  {
+    "id": "WTCETH",
+    "asset": "WTC",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "WTC/ETH"
   },
   {
     "id": "LRCBTC",
     "asset": "LRC",
     "currency": "BTC",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
     "label": "LRC/BTC"
   },
   {
@@ -1264,116 +211,278 @@
     "asset": "LRC",
     "currency": "ETH",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
     "label": "LRC/ETH"
   },
   {
-    "id": "LSKBNB",
-    "asset": "LSK",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0001",
-    "label": "LSK/BNB"
-  },
-  {
-    "id": "LSKBTC",
-    "asset": "LSK",
+    "id": "QTUMBTC",
+    "asset": "QTUM",
     "currency": "BTC",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "LSK/BTC"
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "QTUM/BTC"
   },
   {
-    "id": "LSKETH",
-    "asset": "LSK",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "LSK/ETH"
-  },
-  {
-    "id": "LTCBNB",
-    "asset": "LTC",
-    "currency": "BNB",
-    "min_size": "0.00001000",
-    "max_size": "100000",
-    "increment": "0.01",
-    "label": "LTC/BNB"
-  },
-  {
-    "id": "LTCETH",
-    "asset": "LTC",
-    "currency": "ETH",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "LTC/ETH"
-  },
-  {
-    "id": "LTCUSDT",
-    "asset": "LTC",
-    "currency": "USDT",
-    "min_size": "0.00001000",
-    "max_size": "100000",
-    "increment": "0.01",
-    "label": "LTC/USDT"
-  },
-  {
-    "id": "LUNBTC",
-    "asset": "LUN",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "LUN/BTC"
-  },
-  {
-    "id": "LUNETH",
-    "asset": "LUN",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "LUN/ETH"
-  },
-  {
-    "id": "MANABTC",
-    "asset": "MANA",
+    "id": "YOYOBTC",
+    "asset": "YOYO",
     "currency": "BTC",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "MANA/BTC"
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "YOYO/BTC"
   },
   {
-    "id": "MANAETH",
-    "asset": "MANA",
+    "id": "OMGBTC",
+    "asset": "OMG",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "OMG/BTC"
+  },
+  {
+    "id": "OMGETH",
+    "asset": "OMG",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "OMG/ETH"
+  },
+  {
+    "id": "ZRXBTC",
+    "asset": "ZRX",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ZRX/BTC"
+  },
+  {
+    "id": "ZRXETH",
+    "asset": "ZRX",
     "currency": "ETH",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "MANA/ETH"
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ZRX/ETH"
   },
   {
-    "id": "MCOBNB",
-    "asset": "MCO",
-    "currency": "BNB",
+    "id": "STRATBTC",
+    "asset": "STRAT",
+    "currency": "BTC",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "MCO/BNB"
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "STRAT/BTC"
+  },
+  {
+    "id": "STRATETH",
+    "asset": "STRAT",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "STRAT/ETH"
+  },
+  {
+    "id": "SNGLSBTC",
+    "asset": "SNGLS",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "SNGLS/BTC"
+  },
+  {
+    "id": "SNGLSETH",
+    "asset": "SNGLS",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "SNGLS/ETH"
+  },
+  {
+    "id": "BQXBTC",
+    "asset": "BQX",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "BQX/BTC"
+  },
+  {
+    "id": "BQXETH",
+    "asset": "BQX",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "BQX/ETH"
+  },
+  {
+    "id": "KNCBTC",
+    "asset": "KNC",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "KNC/BTC"
+  },
+  {
+    "id": "KNCETH",
+    "asset": "KNC",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "KNC/ETH"
+  },
+  {
+    "id": "FUNBTC",
+    "asset": "FUN",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "FUN/BTC"
+  },
+  {
+    "id": "FUNETH",
+    "asset": "FUN",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "FUN/ETH"
+  },
+  {
+    "id": "SNMBTC",
+    "asset": "SNM",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "SNM/BTC"
+  },
+  {
+    "id": "SNMETH",
+    "asset": "SNM",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "SNM/ETH"
+  },
+  {
+    "id": "NEOETH",
+    "asset": "NEO",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "NEO/ETH"
+  },
+  {
+    "id": "IOTABTC",
+    "asset": "IOTA",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "IOTA/BTC"
+  },
+  {
+    "id": "IOTAETH",
+    "asset": "IOTA",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "IOTA/ETH"
+  },
+  {
+    "id": "LINKBTC",
+    "asset": "LINK",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "LINK/BTC"
+  },
+  {
+    "id": "LINKETH",
+    "asset": "LINK",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "LINK/ETH"
+  },
+  {
+    "id": "XVGBTC",
+    "asset": "XVG",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "XVG/BTC"
+  },
+  {
+    "id": "XVGETH",
+    "asset": "XVG",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "XVG/ETH"
+  },
+  {
+    "id": "CTRBTC",
+    "asset": "CTR",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "CTR/BTC"
+  },
+  {
+    "id": "CTRETH",
+    "asset": "CTR",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "CTR/ETH"
+  },
+  {
+    "id": "SALTBTC",
+    "asset": "SALT",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "SALT/BTC"
+  },
+  {
+    "id": "SALTETH",
+    "asset": "SALT",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "SALT/ETH"
   },
   {
     "id": "MDABTC",
     "asset": "MDA",
     "currency": "BTC",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
     "label": "MDA/BTC"
   },
   {
@@ -1381,53 +490,17 @@
     "asset": "MDA",
     "currency": "ETH",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
     "label": "MDA/ETH"
-  },
-  {
-    "id": "MODBTC",
-    "asset": "MOD",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "MOD/BTC"
-  },
-  {
-    "id": "MODETH",
-    "asset": "MOD",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "MOD/ETH"
-  },
-  {
-    "id": "MTHBTC",
-    "asset": "MTH",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "MTH/BTC"
-  },
-  {
-    "id": "MTHETH",
-    "asset": "MTH",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "MTH/ETH"
   },
   {
     "id": "MTLBTC",
     "asset": "MTL",
     "currency": "BTC",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
     "label": "MTL/BTC"
   },
   {
@@ -1435,314 +508,17 @@
     "asset": "MTL",
     "currency": "ETH",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
     "label": "MTL/ETH"
-  },
-  {
-    "id": "NAVBNB",
-    "asset": "NAV",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "NAV/BNB"
-  },
-  {
-    "id": "NAVBTC",
-    "asset": "NAV",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "NAV/BTC"
-  },
-  {
-    "id": "NAVETH",
-    "asset": "NAV",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "NAV/ETH"
-  },
-  {
-    "id": "NEBLBNB",
-    "asset": "NEBL",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "NEBL/BNB"
-  },
-  {
-    "id": "NEBLBTC",
-    "asset": "NEBL",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "NEBL/BTC"
-  },
-  {
-    "id": "NEBLETH",
-    "asset": "NEBL",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "NEBL/ETH"
-  },
-  {
-    "id": "NEOBNB",
-    "asset": "NEO",
-    "currency": "BNB",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.001",
-    "label": "NEO/BNB"
-  },
-  {
-    "id": "NEOUSDT",
-    "asset": "NEO",
-    "currency": "USDT",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.001",
-    "label": "NEO/USDT"
-  },
-  {
-    "id": "OAXBTC",
-    "asset": "OAX",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "OAX/BTC"
-  },
-  {
-    "id": "OSTBNB",
-    "asset": "OST",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "OST/BNB"
-  },
-  {
-    "id": "OSTBTC",
-    "asset": "OST",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "OST/BTC"
-  },
-  {
-    "id": "OSTETH",
-    "asset": "OST",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "OST/ETH"
-  },
-  {
-    "id": "POEBTC",
-    "asset": "POE",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "POE/BTC"
-  },
-  {
-    "id": "POEETH",
-    "asset": "POE",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "POE/ETH"
-  },
-  {
-    "id": "POWRBNB",
-    "asset": "POWR",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "POWR/BNB"
-  },
-  {
-    "id": "POWRBTC",
-    "asset": "POWR",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "POWR/BTC"
-  },
-  {
-    "id": "POWRETH",
-    "asset": "POWR",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "POWR/ETH"
-  },
-  {
-    "id": "PPTBTC",
-    "asset": "PPT",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "PPT/BTC"
-  },
-  {
-    "id": "PPTETH",
-    "asset": "PPT",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "PPT/ETH"
-  },
-  {
-    "id": "QSPBNB",
-    "asset": "QSP",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "QSP/BNB"
-  },
-  {
-    "id": "QSPBTC",
-    "asset": "QSP",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "QSP/BTC"
-  },
-  {
-    "id": "QSPETH",
-    "asset": "QSP",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "QSP/ETH"
-  },
-  {
-    "id": "RCNBNB",
-    "asset": "RCN",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "RCN/BNB"
-  },
-  {
-    "id": "RCNBTC",
-    "asset": "RCN",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "RCN/BTC"
-  },
-  {
-    "id": "RCNETH",
-    "asset": "RCN",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "RCN/ETH"
-  },
-  {
-    "id": "RDNBNB",
-    "asset": "RDN",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "RDN/BNB"
-  },
-  {
-    "id": "RDNBTC",
-    "asset": "RDN",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "RDN/BTC"
-  },
-  {
-    "id": "RDNETH",
-    "asset": "RDN",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "RDN/ETH"
-  },
-  {
-    "id": "REQBTC",
-    "asset": "REQ",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "REQ/BTC"
-  },
-  {
-    "id": "REQETH",
-    "asset": "REQ",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "REQ/ETH"
-  },
-  {
-    "id": "SNTBTC",
-    "asset": "SNT",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "SNT/BTC"
-  },
-  {
-    "id": "STORJBTC",
-    "asset": "STORJ",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "STORJ/BTC"
-  },
-  {
-    "id": "STORJETH",
-    "asset": "STORJ",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "STORJ/ETH"
   },
   {
     "id": "SUBBTC",
     "asset": "SUB",
     "currency": "BTC",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
     "label": "SUB/BTC"
   },
   {
@@ -1750,359 +526,98 @@
     "asset": "SUB",
     "currency": "ETH",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
     "label": "SUB/ETH"
   },
   {
-    "id": "TNBBTC",
-    "asset": "TNB",
+    "id": "EOSBTC",
+    "asset": "EOS",
     "currency": "BTC",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "TNB/BTC"
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "EOS/BTC"
   },
   {
-    "id": "TNBETH",
-    "asset": "TNB",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "TNB/ETH"
-  },
-  {
-    "id": "TNTBTC",
-    "asset": "TNT",
+    "id": "SNTBTC",
+    "asset": "SNT",
     "currency": "BTC",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "TNT/BTC"
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "SNT/BTC"
   },
   {
-    "id": "TNTETH",
-    "asset": "TNT",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "TNT/ETH"
-  },
-  {
-    "id": "TRIGBNB",
-    "asset": "TRIG",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "TRIG/BNB"
-  },
-  {
-    "id": "TRIGBTC",
-    "asset": "TRIG",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "TRIG/BTC"
-  },
-  {
-    "id": "TRIGETH",
-    "asset": "TRIG",
+    "id": "ETCETH",
+    "asset": "ETC",
     "currency": "ETH",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "TRIG/ETH"
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "ETC/ETH"
   },
   {
-    "id": "TRXBTC",
-    "asset": "TRX",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "TRX/BTC"
-  },
-  {
-    "id": "TRXETH",
-    "asset": "TRX",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "TRX/ETH"
-  },
-  {
-    "id": "VENBTC",
-    "asset": "VEN",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "VEN/BTC"
-  },
-  {
-    "id": "VENETH",
-    "asset": "VEN",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "VEN/ETH"
-  },
-  {
-    "id": "VIBBTC",
-    "asset": "VIB",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "VIB/BTC"
-  },
-  {
-    "id": "VIBEBTC",
-    "asset": "VIBE",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "VIBE/BTC"
-  },
-  {
-    "id": "VIBEETH",
-    "asset": "VIBE",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "VIBE/ETH"
-  },
-  {
-    "id": "VIBETH",
-    "asset": "VIB",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "VIB/ETH"
-  },
-  {
-    "id": "WABIBNB",
-    "asset": "WABI",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "WABI/BNB"
-  },
-  {
-    "id": "WABIBTC",
-    "asset": "WABI",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "WABI/BTC"
-  },
-  {
-    "id": "WABIETH",
-    "asset": "WABI",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "WABI/ETH"
-  },
-  {
-    "id": "WAVESBNB",
-    "asset": "WAVES",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0001",
-    "label": "WAVES/BNB"
-  },
-  {
-    "id": "WAVESBTC",
-    "asset": "WAVES",
+    "id": "ETCBTC",
+    "asset": "ETC",
     "currency": "BTC",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "WAVES/BTC"
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "ETC/BTC"
   },
   {
-    "id": "WAVESETH",
-    "asset": "WAVES",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "WAVES/ETH"
-  },
-  {
-    "id": "WINGSBTC",
-    "asset": "WINGS",
+    "id": "MTHBTC",
+    "asset": "MTH",
     "currency": "BTC",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "WINGS/BTC"
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "MTH/BTC"
   },
   {
-    "id": "WINGSETH",
-    "asset": "WINGS",
+    "id": "MTHETH",
+    "asset": "MTH",
     "currency": "ETH",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.0000001",
-    "label": "WINGS/ETH"
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "MTH/ETH"
   },
   {
-    "id": "WTCBNB",
-    "asset": "WTC",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0001",
-    "label": "WTC/BNB"
-  },
-  {
-    "id": "XLMBNB",
-    "asset": "XLM",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "XLM/BNB"
-  },
-  {
-    "id": "XLMBTC",
-    "asset": "XLM",
+    "id": "ENGBTC",
+    "asset": "ENG",
     "currency": "BTC",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "XLM/BTC"
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ENG/BTC"
   },
   {
-    "id": "XLMETH",
-    "asset": "XLM",
+    "id": "ENGETH",
+    "asset": "ENG",
     "currency": "ETH",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "XLM/ETH"
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ENG/ETH"
   },
   {
-    "id": "XMRBTC",
-    "asset": "XMR",
-    "currency": "BTC",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "XMR/BTC"
-  },
-  {
-    "id": "XMRETH",
-    "asset": "XMR",
-    "currency": "ETH",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "XMR/ETH"
-  },
-  {
-    "id": "XRPBTC",
-    "asset": "XRP",
+    "id": "DNTBTC",
+    "asset": "DNT",
     "currency": "BTC",
     "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "XRP/BTC"
-  },
-  {
-    "id": "XRPETH",
-    "asset": "XRP",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "XRP/ETH"
-  },
-  {
-    "id": "XVGBTC",
-    "asset": "XVG",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "XVG/BTC"
-  },
-  {
-    "id": "XZCBNB",
-    "asset": "XZC",
-    "currency": "BNB",
-    "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.001",
-    "label": "XZC/BNB"
-  },
-  {
-    "id": "XZCBTC",
-    "asset": "XZC",
-    "currency": "BTC",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "XZC/BTC"
-  },
-  {
-    "id": "XZCETH",
-    "asset": "XZC",
-    "currency": "ETH",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.000001",
-    "label": "XZC/ETH"
-  },
-  {
-    "id": "YOYOBNB",
-    "asset": "YOYO",
-    "currency": "BNB",
-    "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.00001",
-    "label": "YOYO/BNB"
-  },
-  {
-    "id": "YOYOBTC",
-    "asset": "YOYO",
-    "currency": "BTC",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "YOYO/BTC"
-  },
-  {
-    "id": "YOYOETH",
-    "asset": "YOYO",
-    "currency": "ETH",
-    "min_size": "1.00000000",
-    "max_size": "100000",
-    "increment": "0.00000001",
-    "label": "YOYO/ETH"
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "DNT/BTC"
   },
   {
     "id": "ZECBTC",
     "asset": "ZEC",
     "currency": "BTC",
     "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.000001",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
     "label": "ZEC/BTC"
   },
   {
@@ -2110,26 +625,1547 @@
     "asset": "ZEC",
     "currency": "ETH",
     "min_size": "0.00100000",
-    "max_size": "100000",
-    "increment": "0.00001",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
     "label": "ZEC/ETH"
+  },
+  {
+    "id": "BNTBTC",
+    "asset": "BNT",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "BNT/BTC"
+  },
+  {
+    "id": "ASTBTC",
+    "asset": "AST",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "AST/BTC"
+  },
+  {
+    "id": "ASTETH",
+    "asset": "AST",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "AST/ETH"
+  },
+  {
+    "id": "DASHBTC",
+    "asset": "DASH",
+    "currency": "BTC",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "DASH/BTC"
+  },
+  {
+    "id": "DASHETH",
+    "asset": "DASH",
+    "currency": "ETH",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "DASH/ETH"
+  },
+  {
+    "id": "OAXBTC",
+    "asset": "OAX",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "OAX/BTC"
+  },
+  {
+    "id": "ICNBTC",
+    "asset": "ICN",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ICN/BTC"
+  },
+  {
+    "id": "BTGBTC",
+    "asset": "BTG",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "BTG/BTC"
+  },
+  {
+    "id": "BTGETH",
+    "asset": "BTG",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "BTG/ETH"
+  },
+  {
+    "id": "EVXBTC",
+    "asset": "EVX",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "EVX/BTC"
+  },
+  {
+    "id": "EVXETH",
+    "asset": "EVX",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "EVX/ETH"
+  },
+  {
+    "id": "REQBTC",
+    "asset": "REQ",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "REQ/BTC"
+  },
+  {
+    "id": "REQETH",
+    "asset": "REQ",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "REQ/ETH"
+  },
+  {
+    "id": "VIBBTC",
+    "asset": "VIB",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "VIB/BTC"
+  },
+  {
+    "id": "VIBETH",
+    "asset": "VIB",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "VIB/ETH"
+  },
+  {
+    "id": "HSRETH",
+    "asset": "HSR",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "HSR/ETH"
+  },
+  {
+    "id": "TRXBTC",
+    "asset": "TRX",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "TRX/BTC"
+  },
+  {
+    "id": "TRXETH",
+    "asset": "TRX",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "TRX/ETH"
+  },
+  {
+    "id": "POWRBTC",
+    "asset": "POWR",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "POWR/BTC"
+  },
+  {
+    "id": "POWRETH",
+    "asset": "POWR",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "POWR/ETH"
+  },
+  {
+    "id": "ARKBTC",
+    "asset": "ARK",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "ARK/BTC"
+  },
+  {
+    "id": "ARKETH",
+    "asset": "ARK",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "ARK/ETH"
+  },
+  {
+    "id": "YOYOETH",
+    "asset": "YOYO",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "YOYO/ETH"
+  },
+  {
+    "id": "XRPBTC",
+    "asset": "XRP",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "XRP/BTC"
+  },
+  {
+    "id": "XRPETH",
+    "asset": "XRP",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "XRP/ETH"
+  },
+  {
+    "id": "MODBTC",
+    "asset": "MOD",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "MOD/BTC"
+  },
+  {
+    "id": "MODETH",
+    "asset": "MOD",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "MOD/ETH"
+  },
+  {
+    "id": "ENJBTC",
+    "asset": "ENJ",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ENJ/BTC"
+  },
+  {
+    "id": "ENJETH",
+    "asset": "ENJ",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ENJ/ETH"
+  },
+  {
+    "id": "STORJBTC",
+    "asset": "STORJ",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "STORJ/BTC"
+  },
+  {
+    "id": "STORJETH",
+    "asset": "STORJ",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "STORJ/ETH"
   },
   {
     "id": "BNBUSDT",
     "asset": "BNB",
     "currency": "USDT",
     "min_size": "0.01000000",
-    "max_size": "100000",
-    "increment": "0.0001",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
     "label": "BNB/USDT"
   },
   {
-    "id": "ETHUSDT",
-    "asset": "ETH",
+    "id": "VENBNB",
+    "asset": "VEN",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "VEN/BNB"
+  },
+  {
+    "id": "YOYOBNB",
+    "asset": "YOYO",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "YOYO/BNB"
+  },
+  {
+    "id": "POWRBNB",
+    "asset": "POWR",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "POWR/BNB"
+  },
+  {
+    "id": "VENBTC",
+    "asset": "VEN",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "VEN/BTC"
+  },
+  {
+    "id": "VENETH",
+    "asset": "VEN",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "VEN/ETH"
+  },
+  {
+    "id": "KMDBTC",
+    "asset": "KMD",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "KMD/BTC"
+  },
+  {
+    "id": "KMDETH",
+    "asset": "KMD",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "KMD/ETH"
+  },
+  {
+    "id": "NULSBNB",
+    "asset": "NULS",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "NULS/BNB"
+  },
+  {
+    "id": "RCNBTC",
+    "asset": "RCN",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "RCN/BTC"
+  },
+  {
+    "id": "RCNETH",
+    "asset": "RCN",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "RCN/ETH"
+  },
+  {
+    "id": "RCNBNB",
+    "asset": "RCN",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "RCN/BNB"
+  },
+  {
+    "id": "NULSBTC",
+    "asset": "NULS",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "NULS/BTC"
+  },
+  {
+    "id": "NULSETH",
+    "asset": "NULS",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "NULS/ETH"
+  },
+  {
+    "id": "RDNBTC",
+    "asset": "RDN",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "RDN/BTC"
+  },
+  {
+    "id": "RDNETH",
+    "asset": "RDN",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "RDN/ETH"
+  },
+  {
+    "id": "RDNBNB",
+    "asset": "RDN",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "RDN/BNB"
+  },
+  {
+    "id": "XMRBTC",
+    "asset": "XMR",
+    "currency": "BTC",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "XMR/BTC"
+  },
+  {
+    "id": "XMRETH",
+    "asset": "XMR",
+    "currency": "ETH",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "XMR/ETH"
+  },
+  {
+    "id": "DLTBNB",
+    "asset": "DLT",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "DLT/BNB"
+  },
+  {
+    "id": "WTCBNB",
+    "asset": "WTC",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "WTC/BNB"
+  },
+  {
+    "id": "DLTBTC",
+    "asset": "DLT",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "DLT/BTC"
+  },
+  {
+    "id": "DLTETH",
+    "asset": "DLT",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "DLT/ETH"
+  },
+  {
+    "id": "AMBBTC",
+    "asset": "AMB",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "AMB/BTC"
+  },
+  {
+    "id": "AMBETH",
+    "asset": "AMB",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "AMB/ETH"
+  },
+  {
+    "id": "AMBBNB",
+    "asset": "AMB",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "AMB/BNB"
+  },
+  {
+    "id": "BCCETH",
+    "asset": "BCH",
+    "currency": "ETH",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "BCH/ETH"
+  },
+  {
+    "id": "BCCUSDT",
+    "asset": "BCH",
     "currency": "USDT",
     "min_size": "0.00001000",
-    "max_size": "100000",
-    "increment": "0.01",
-    "label": "ETH/USDT"
+    "max_size": "10000000.00000000",
+    "increment": "0.00001000",
+    "label": "BCH/USDT"
+  },
+  {
+    "id": "BCCBNB",
+    "asset": "BCH",
+    "currency": "BNB",
+    "min_size": "0.00001000",
+    "max_size": "100000.00000000",
+    "increment": "0.00001000",
+    "label": "BCH/BNB"
+  },
+  {
+    "id": "BATBTC",
+    "asset": "BAT",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "BAT/BTC"
+  },
+  {
+    "id": "BATETH",
+    "asset": "BAT",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "BAT/ETH"
+  },
+  {
+    "id": "BATBNB",
+    "asset": "BAT",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "BAT/BNB"
+  },
+  {
+    "id": "BCPTBTC",
+    "asset": "BCPT",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "BCPT/BTC"
+  },
+  {
+    "id": "BCPTETH",
+    "asset": "BCPT",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "BCPT/ETH"
+  },
+  {
+    "id": "BCPTBNB",
+    "asset": "BCPT",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "BCPT/BNB"
+  },
+  {
+    "id": "ARNBTC",
+    "asset": "ARN",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ARN/BTC"
+  },
+  {
+    "id": "ARNETH",
+    "asset": "ARN",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ARN/ETH"
+  },
+  {
+    "id": "GVTBTC",
+    "asset": "GVT",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "GVT/BTC"
+  },
+  {
+    "id": "GVTETH",
+    "asset": "GVT",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "GVT/ETH"
+  },
+  {
+    "id": "CDTBTC",
+    "asset": "CDT",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "CDT/BTC"
+  },
+  {
+    "id": "CDTETH",
+    "asset": "CDT",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "CDT/ETH"
+  },
+  {
+    "id": "GXSBTC",
+    "asset": "GXS",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "GXS/BTC"
+  },
+  {
+    "id": "GXSETH",
+    "asset": "GXS",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "GXS/ETH"
+  },
+  {
+    "id": "NEOUSDT",
+    "asset": "NEO",
+    "currency": "USDT",
+    "min_size": "0.00100000",
+    "max_size": "10000000.00000000",
+    "increment": "0.00100000",
+    "label": "NEO/USDT"
+  },
+  {
+    "id": "NEOBNB",
+    "asset": "NEO",
+    "currency": "BNB",
+    "min_size": "0.00100000",
+    "max_size": "10000000.00000000",
+    "increment": "0.00100000",
+    "label": "NEO/BNB"
+  },
+  {
+    "id": "POEBTC",
+    "asset": "POE",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "POE/BTC"
+  },
+  {
+    "id": "POEETH",
+    "asset": "POE",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "POE/ETH"
+  },
+  {
+    "id": "QSPBTC",
+    "asset": "QSP",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "QSP/BTC"
+  },
+  {
+    "id": "QSPETH",
+    "asset": "QSP",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "QSP/ETH"
+  },
+  {
+    "id": "QSPBNB",
+    "asset": "QSP",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "QSP/BNB"
+  },
+  {
+    "id": "BTSBTC",
+    "asset": "BTS",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "BTS/BTC"
+  },
+  {
+    "id": "BTSETH",
+    "asset": "BTS",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "BTS/ETH"
+  },
+  {
+    "id": "BTSBNB",
+    "asset": "BTS",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "BTS/BNB"
+  },
+  {
+    "id": "XZCBTC",
+    "asset": "XZC",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "XZC/BTC"
+  },
+  {
+    "id": "XZCETH",
+    "asset": "XZC",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "XZC/ETH"
+  },
+  {
+    "id": "XZCBNB",
+    "asset": "XZC",
+    "currency": "BNB",
+    "min_size": "0.00100000",
+    "max_size": "10000000.00000000",
+    "increment": "0.00100000",
+    "label": "XZC/BNB"
+  },
+  {
+    "id": "LSKBTC",
+    "asset": "LSK",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "LSK/BTC"
+  },
+  {
+    "id": "LSKETH",
+    "asset": "LSK",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "LSK/ETH"
+  },
+  {
+    "id": "LSKBNB",
+    "asset": "LSK",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "LSK/BNB"
+  },
+  {
+    "id": "TNTBTC",
+    "asset": "TNT",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "TNT/BTC"
+  },
+  {
+    "id": "TNTETH",
+    "asset": "TNT",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "TNT/ETH"
+  },
+  {
+    "id": "FUELBTC",
+    "asset": "FUEL",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "FUEL/BTC"
+  },
+  {
+    "id": "FUELETH",
+    "asset": "FUEL",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "FUEL/ETH"
+  },
+  {
+    "id": "MANABTC",
+    "asset": "MANA",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "MANA/BTC"
+  },
+  {
+    "id": "MANAETH",
+    "asset": "MANA",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "MANA/ETH"
+  },
+  {
+    "id": "BCDBTC",
+    "asset": "BCD",
+    "currency": "BTC",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "BCD/BTC"
+  },
+  {
+    "id": "BCDETH",
+    "asset": "BCD",
+    "currency": "ETH",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "BCD/ETH"
+  },
+  {
+    "id": "DGDBTC",
+    "asset": "DGD",
+    "currency": "BTC",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "DGD/BTC"
+  },
+  {
+    "id": "DGDETH",
+    "asset": "DGD",
+    "currency": "ETH",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "DGD/ETH"
+  },
+  {
+    "id": "IOTABNB",
+    "asset": "IOTA",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "IOTA/BNB"
+  },
+  {
+    "id": "ADXBTC",
+    "asset": "ADX",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ADX/BTC"
+  },
+  {
+    "id": "ADXETH",
+    "asset": "ADX",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ADX/ETH"
+  },
+  {
+    "id": "ADXBNB",
+    "asset": "ADX",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "ADX/BNB"
+  },
+  {
+    "id": "ADABTC",
+    "asset": "ADA",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ADA/BTC"
+  },
+  {
+    "id": "ADAETH",
+    "asset": "ADA",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ADA/ETH"
+  },
+  {
+    "id": "PPTBTC",
+    "asset": "PPT",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "PPT/BTC"
+  },
+  {
+    "id": "PPTETH",
+    "asset": "PPT",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "PPT/ETH"
+  },
+  {
+    "id": "CMTBTC",
+    "asset": "CMT",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "CMT/BTC"
+  },
+  {
+    "id": "CMTETH",
+    "asset": "CMT",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "CMT/ETH"
+  },
+  {
+    "id": "CMTBNB",
+    "asset": "CMT",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "CMT/BNB"
+  },
+  {
+    "id": "XLMBTC",
+    "asset": "XLM",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "XLM/BTC"
+  },
+  {
+    "id": "XLMETH",
+    "asset": "XLM",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "XLM/ETH"
+  },
+  {
+    "id": "XLMBNB",
+    "asset": "XLM",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "XLM/BNB"
+  },
+  {
+    "id": "CNDBTC",
+    "asset": "CND",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "CND/BTC"
+  },
+  {
+    "id": "CNDETH",
+    "asset": "CND",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "CND/ETH"
+  },
+  {
+    "id": "CNDBNB",
+    "asset": "CND",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "CND/BNB"
+  },
+  {
+    "id": "LENDBTC",
+    "asset": "LEND",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "LEND/BTC"
+  },
+  {
+    "id": "LENDETH",
+    "asset": "LEND",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "LEND/ETH"
+  },
+  {
+    "id": "WABIBTC",
+    "asset": "WABI",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "WABI/BTC"
+  },
+  {
+    "id": "WABIETH",
+    "asset": "WABI",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "WABI/ETH"
+  },
+  {
+    "id": "WABIBNB",
+    "asset": "WABI",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "WABI/BNB"
+  },
+  {
+    "id": "LTCETH",
+    "asset": "LTC",
+    "currency": "ETH",
+    "min_size": "0.00100000",
+    "max_size": "100000.00000000",
+    "increment": "0.00100000",
+    "label": "LTC/ETH"
+  },
+  {
+    "id": "LTCUSDT",
+    "asset": "LTC",
+    "currency": "USDT",
+    "min_size": "0.00001000",
+    "max_size": "10000000.00000000",
+    "increment": "0.00001000",
+    "label": "LTC/USDT"
+  },
+  {
+    "id": "LTCBNB",
+    "asset": "LTC",
+    "currency": "BNB",
+    "min_size": "0.00001000",
+    "max_size": "100000.00000000",
+    "increment": "0.00001000",
+    "label": "LTC/BNB"
+  },
+  {
+    "id": "TNBBTC",
+    "asset": "TNB",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "TNB/BTC"
+  },
+  {
+    "id": "TNBETH",
+    "asset": "TNB",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "TNB/ETH"
+  },
+  {
+    "id": "WAVESBTC",
+    "asset": "WAVES",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "WAVES/BTC"
+  },
+  {
+    "id": "WAVESETH",
+    "asset": "WAVES",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "WAVES/ETH"
+  },
+  {
+    "id": "WAVESBNB",
+    "asset": "WAVES",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "WAVES/BNB"
+  },
+  {
+    "id": "GTOBTC",
+    "asset": "GTO",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "GTO/BTC"
+  },
+  {
+    "id": "GTOETH",
+    "asset": "GTO",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "GTO/ETH"
+  },
+  {
+    "id": "GTOBNB",
+    "asset": "GTO",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "GTO/BNB"
+  },
+  {
+    "id": "ICXBTC",
+    "asset": "ICX",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "ICX/BTC"
+  },
+  {
+    "id": "ICXETH",
+    "asset": "ICX",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "ICX/ETH"
+  },
+  {
+    "id": "ICXBNB",
+    "asset": "ICX",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "ICX/BNB"
+  },
+  {
+    "id": "OSTBTC",
+    "asset": "OST",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "OST/BTC"
+  },
+  {
+    "id": "OSTETH",
+    "asset": "OST",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "OST/ETH"
+  },
+  {
+    "id": "OSTBNB",
+    "asset": "OST",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "OST/BNB"
+  },
+  {
+    "id": "ELFBTC",
+    "asset": "ELF",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ELF/BTC"
+  },
+  {
+    "id": "ELFETH",
+    "asset": "ELF",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "ELF/ETH"
+  },
+  {
+    "id": "AIONBTC",
+    "asset": "AION",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "AION/BTC"
+  },
+  {
+    "id": "AIONETH",
+    "asset": "AION",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "AION/ETH"
+  },
+  {
+    "id": "AIONBNB",
+    "asset": "AION",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "AION/BNB"
+  },
+  {
+    "id": "NEBLBTC",
+    "asset": "NEBL",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "NEBL/BTC"
+  },
+  {
+    "id": "NEBLETH",
+    "asset": "NEBL",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "NEBL/ETH"
+  },
+  {
+    "id": "NEBLBNB",
+    "asset": "NEBL",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "NEBL/BNB"
+  },
+  {
+    "id": "BRDBTC",
+    "asset": "BRD",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "BRD/BTC"
+  },
+  {
+    "id": "BRDETH",
+    "asset": "BRD",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "BRD/ETH"
+  },
+  {
+    "id": "BRDBNB",
+    "asset": "BRD",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "BRD/BNB"
+  },
+  {
+    "id": "MCOBNB",
+    "asset": "MCO",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "MCO/BNB"
+  },
+  {
+    "id": "EDOBTC",
+    "asset": "EDO",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "EDO/BTC"
+  },
+  {
+    "id": "EDOETH",
+    "asset": "EDO",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "EDO/ETH"
+  },
+  {
+    "id": "WINGSBTC",
+    "asset": "WINGS",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "WINGS/BTC"
+  },
+  {
+    "id": "WINGSETH",
+    "asset": "WINGS",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "WINGS/ETH"
+  },
+  {
+    "id": "NAVBTC",
+    "asset": "NAV",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "NAV/BTC"
+  },
+  {
+    "id": "NAVETH",
+    "asset": "NAV",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "NAV/ETH"
+  },
+  {
+    "id": "NAVBNB",
+    "asset": "NAV",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "NAV/BNB"
+  },
+  {
+    "id": "LUNBTC",
+    "asset": "LUN",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "LUN/BTC"
+  },
+  {
+    "id": "LUNETH",
+    "asset": "LUN",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "LUN/ETH"
+  },
+  {
+    "id": "TRIGBTC",
+    "asset": "TRIG",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "TRIG/BTC"
+  },
+  {
+    "id": "TRIGETH",
+    "asset": "TRIG",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "TRIG/ETH"
+  },
+  {
+    "id": "TRIGBNB",
+    "asset": "TRIG",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "TRIG/BNB"
+  },
+  {
+    "id": "APPCBTC",
+    "asset": "APPC",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "APPC/BTC"
+  },
+  {
+    "id": "APPCETH",
+    "asset": "APPC",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "APPC/ETH"
+  },
+  {
+    "id": "APPCBNB",
+    "asset": "APPC",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "APPC/BNB"
+  },
+  {
+    "id": "VIBEBTC",
+    "asset": "VIBE",
+    "currency": "BTC",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "VIBE/BTC"
+  },
+  {
+    "id": "VIBEETH",
+    "asset": "VIBE",
+    "currency": "ETH",
+    "min_size": "1.00000000",
+    "max_size": "100000.00000000",
+    "increment": "1.00000000",
+    "label": "VIBE/ETH"
+  },
+  {
+    "id": "RLCBTC",
+    "asset": "RLC",
+    "currency": "BTC",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "RLC/BTC"
+  },
+  {
+    "id": "RLCETH",
+    "asset": "RLC",
+    "currency": "ETH",
+    "min_size": "0.01000000",
+    "max_size": "100000.00000000",
+    "increment": "0.01000000",
+    "label": "RLC/ETH"
+  },
+  {
+    "id": "RLCBNB",
+    "asset": "RLC",
+    "currency": "BNB",
+    "min_size": "0.01000000",
+    "max_size": "10000.00000000",
+    "increment": "0.01000000",
+    "label": "RLC/BNB"
   }
 ]


### PR DESCRIPTION
thx to @abduegal  binance pairs are know extracted by ccxt. fixes #1133. new products.json file included.