### PR TITLE
Added Momentum Indicator and Strategy

### DIFF
--- a/extensions/strategies/momentum/_codemap.js
+++ b/extensions/strategies/momentum/_codemap.js
@@ -1,0 +1,6 @@
+module.exports = {
+  _ns: 'zenbot',
+
+  'strategies.momentum': require('./strategy'),
+  'strategies.list[]': '#strategies.momentum'
+}

--- a/extensions/strategies/momentum/strategy.js
+++ b/extensions/strategies/momentum/strategy.js
@@ -1,0 +1,52 @@
+let z = require('zero-fill')
+  , n = require('numbro')
+
+module.exports = function container(get, set, clear) {
+  return {
+    name: 'Momentum',
+    description: 'MOM = Close(Period) - Close(Length)',
+
+    getOptions: function () {
+      this.option('momentum_size', 'number of periods to look back for momentum', Number, 5)
+    },
+
+    calculate: function (s) {
+      if (s.in_preroll) { return }
+      get('lib.momentum')(s, 'mom0', s.options.momentum_size)
+      get('lib.momentum')(s, 'mom1', s.options.momentum_size)
+    },
+
+    onPeriod: function (s, cb) {
+      if (s.in_preroll) {
+        cb()
+        return
+      }
+
+      if (s.period.mom0 > 0 && s.period.mom1 > 0) {
+        s.signal = 'buy'
+      }
+      if (s.period.mom0 < 0 && s.period.mom1 < 0) {
+        s.signal = 'sell'
+      }
+      cb()
+    },
+
+    onReport: function (s) {
+      var cols = []
+
+      if (s.period.mom0 != null) {
+        var color = s.period.mom0 < 0 ? 'red' : s.period.mom0 > 0 ? 'green' : 'grey'
+        cols.push(z(5, n(s.period.mom0).format('000'), ' ')[color])
+      } else {
+        cols.push(' '.repeat(5))
+      }
+      if (s.period.mom1 != null) {
+        var color = s.period.mom1 < 0 ? 'red' : s.period.mom1 > 0 ? 'green' : 'grey'
+        cols.push(z(5, n(s.period.mom1).format('000'), ' ')[color])
+      } else {
+        cols.push(' '.repeat(5))
+      }
+      return cols
+    }
+  }
+}

--- a/lib/_codemap.js
+++ b/lib/_codemap.js
@@ -24,5 +24,5 @@ module.exports = {
   'collection-service': require('./services/collection-service'),
   'cmf': require('./cmf'),
   'bollinger': require('./bollinger'),
- 'momentum': require('./momentum')
+  'momentum': require('./momentum')
 }

--- a/lib/_codemap.js
+++ b/lib/_codemap.js
@@ -23,5 +23,6 @@ module.exports = {
   'slow_stochastic': require('./slow_stochastic'),
   'collection-service': require('./services/collection-service'),
   'cmf': require('./cmf'),
-  'bollinger': require('./bollinger')
+  'bollinger': require('./bollinger'),
+ 'momentum': require('./momentum')
 }

--- a/lib/momentum.js
+++ b/lib/momentum.js
@@ -1,0 +1,9 @@
+module.exports = function container(get, set, clear) {
+    return function momentum(s, key, length) {
+        if (s.period == null || s.lookback == null || s.lookback.length < length) {
+            s.period[key] = 0
+        } else {
+            s.period[key] = s.period.close - s.lookback[length - 1].close
+        }
+    }
+}


### PR DESCRIPTION
Since there are a few questions about "simple" strategies (#898, #335 ) i have added the momentum indicator and a strategy based on that.
https://en.wikipedia.org/wiki/Momentum_(technical_analysis)

As Strategy i have used a strategy based on double momentum analysis, which i found on tradingview.com. If both momentums have the same result it sends buy/sell signal.

It also performs okayish on paper trade for short terms trades.
Simulation 

>end balance: 4543.31295643 (354.33%)
>buy hold: 752.83890672 (-24.72%)
>vs. buy hold: 503.49%
>13481 trades over 9 days (avg 1497.88 trades/day)
>win/loss: 3070/3671
>error rate: 54.45%

Paper-Trade for ~6h

>last balance: 1344.79165820 (34.47%)
>buy hold: 1027.19439233 (2.71%)
>vs. buy hold: 30.91%
>122 trades over 1 days (avg 122.00 trades/day)
>win/loss: 38/23
>error rate: 37.70%

