### PR TITLE
Fix #1184 cexio update-products.sh

### DIFF
--- a/extensions/exchanges/cexio/update-products.sh
+++ b/extensions/exchanges/cexio/update-products.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 const ccxt = require('ccxt')
 const path = require('path')
 var client = new ccxt.cex()


### PR DESCRIPTION
This fixes the error `/usr/bin/env: ‘node\r’: No such file or directory`