### PR TITLE
adding onExit

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -882,6 +882,9 @@ module.exports = function container (get, set, clear) {
       },
 
       exit: function (cb) {
+        if(s.strategy.onExit) {
+          s.strategy.onExit.call( s.ctx, s )
+        }
         cb()
       },
 


### PR DESCRIPTION
This is a useful/simple feature for strategies that need to cleanup, save files, etc at the end of a simulation run.  