### PR TITLE
Bitfinex: avoid crash when getOrder is called and no order is found.

### DIFF
--- a/extensions/exchanges/bitfinex/exchange.js
+++ b/extensions/exchanges/bitfinex/exchange.js
@@ -489,6 +489,10 @@ module.exports = function container (get, set, clear) {
     getOrder: function (opts, cb) {
       var order = ws_orders['~' + opts.order_id]
 
+      if(!order) {
+        return cb(new Error('order id ' + opts.order_id + ' not found'))
+      }
+
       if (order.status === 'rejected' && order.reject_reason === 'post only') {
         return cb(null, order)
       } else if (order.status === 'rejected' && order.reject_reason === 'zenbot canceled') {


### PR DESCRIPTION
Bitfinex: avoid crash when getOrder is called and no order is found:

```
exchange.js:492
      if (order.status === 'rejected' && order.reject_reason === 'post only') {
                ^

TypeError: Cannot read property 'status' of undefined
    at Object.getOrder (zenbot/extensions/exchanges/bitfinex/exchange.js:492:17)
    at Timeout.checkHold [as _onTimeout] (zenbot/lib/engine.js:279:28)
    at ontimeout (timers.js:475:11)
    at tryOnTimeout (timers.js:310:5)
    at Timer.listOnTimeout (timers.js:270:5)
```