### PR TITLE
Add option to load previous trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ zenbot trade --help
     --rsi_periods <periods>         number of periods to calculate RSI at
     --poll_trades <ms>              poll new trades at this interval in ms
     --currency_increment <amount>   Currency increment, if different than the asset increment; e.g. 0.000001
+    --use_prev_trades               load and use previous trades for stop-order triggers and loss protection
     --disable_stats                 disable printing order stats
     --reset_profit                  start new profit calculation from 0
     --debug                         output detailed debug info

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -44,6 +44,7 @@ module.exports = function container (get, set, clear) {
       .option('--poll_trades <ms>', 'poll new trades at this interval in ms', Number, c.poll_trades)
       .option('--currency_increment <amount>', 'Currency increment, if different than the asset increment', String, null)
       .option('--keep_lookback_periods <amount>', 'Keep this many lookback periods max. ', Number, c.keep_lookback_periods)
+      .option('--use_prev_trades', 'load and use previous trades for stop-order triggers and loss protection')
       .option('--disable_stats', 'disable printing order stats')
       .option('--reset_profit', 'start new profit calculation from 0')
       .option('--debug', 'output detailed debug info')
@@ -59,6 +60,7 @@ module.exports = function container (get, set, clear) {
         })
         so.currency_increment = cmd.currency_increment
         so.keep_lookback_periods = cmd.keep_lookback_periods
+        so.use_prev_trades = (cmd.use_prev_trades||c.use_prev_trades)
         so.debug = cmd.debug
         so.stats = !cmd.disable_stats
         so.mode = so.paper ? 'paper' : 'live'
@@ -395,6 +397,14 @@ module.exports = function container (get, set, clear) {
             }
             get('db.trades').select(opts, function (err, trades) {
               if (err) throw err
+              if (trades.length && so.use_prev_trades) {
+                my_trades.select({query: {selector: so.selector.normalized, time : {$gte : trades[0].time}}, limit: 0}, function (err, my_prev_trades) {
+                  if (err) throw err
+                  if (my_prev_trades.length) {
+                    s.my_prev_trades = my_prev_trades.slice(0).sort(function(a,b){return a.time + a.execution_time > b.time + b.execution_time ? -1 : 1}) // simple copy, most recent executed first
+                  }
+                })
+              }
               if (!trades.length) {
                 var head = '------------------------------------------ INITIALIZE  OUTPUT ------------------------------------------';
                 console.log(head)

--- a/conf-sample.js
+++ b/conf-sample.js
@@ -164,6 +164,8 @@ c.balance_snapshot_period = '15m'
 c.avg_slippage_pct = 0.045
 // time to leave an order open, default to 1 day (this feature is not supported on all exchanges, currently: GDAX)
 c.cancel_after = 'day'
+// load and use previous trades for stop-order triggers and loss protection (live/paper mode only)
+c.use_prev_trades = false
 
 // Notifiers:
 c.notifiers = {}

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -69,6 +69,7 @@ module.exports = function container (get, set, clear) {
     s.lookback = []
     s.day_count = 1
     s.my_trades = []
+    s.my_prev_trades = []
     s.vol_since_last_blink = 0
     if (c.output.api.on) {
       s.boot_time = (new Date).getTime()
@@ -159,8 +160,12 @@ module.exports = function container (get, set, clear) {
 
     function executeStop (do_sell_stop) {
       let stop_signal
-      if (s.my_trades.length) {
-        let last_trade = s.my_trades[s.my_trades.length - 1]
+      if (s.my_trades.length || s.my_prev_trades.length) {
+        if (s.my_trades.length) {
+          var last_trade = s.my_trades[s.my_trades.length - 1]
+        } else {
+          var last_trade = s.my_prev_trades[0]
+        }
         s.last_trade_worth = last_trade.type === 'buy' ? (s.period.close - last_trade.price) / last_trade.price : (last_trade.price - s.period.close) / last_trade.price
         if (!s.acted_on_stop) {
           if (last_trade.type === 'buy') {
@@ -466,6 +471,12 @@ module.exports = function container (get, set, clear) {
               if (s.product.max_size && Number(size) > Number(s.product.max_size)) {
                 size = s.product.max_size
               }
+              if (!s.last_sell_price && s.my_prev_trades.length) {
+                var prev_sells = s.my_prev_trades.filter(trade => trade.type === 'sell')
+                if (prev_sells.length) {
+                  s.last_sell_price = prev_sells[0].price
+                }
+              }
               if (s.buy_order && so.max_slippage_pct != null) {
                 let slippage = n(price).subtract(s.buy_order.orig_price).divide(s.buy_order.orig_price).multiply(100).value()
                 if (so.max_slippage_pct != null && slippage > so.max_slippage_pct) {
@@ -499,6 +510,12 @@ module.exports = function container (get, set, clear) {
             if ((s.product.min_size && Number(size) >= Number(s.product.min_size)) || (s.product.min_total && n(size).multiply(price).value() >= Number(s.product.min_total))) {
               if (s.product.max_size && Number(size) > Number(s.product.max_size)) {
                 size = s.product.max_size
+              }
+              if (!s.last_buy_price && s.my_prev_trades.length) {
+                var prev_buys = s.my_prev_trades.filter(trade => trade.type === 'buy')
+                if (prev_buys.length) {
+                  s.last_buy_price = prev_buys[0].price
+                }
               }
               let sell_loss = s.last_buy_price ? (Number(price) - s.last_buy_price) / s.last_buy_price * -100 : null
               if (so.max_sell_loss_pct != null && sell_loss > so.max_sell_loss_pct) {

--- a/templates/dashboard.ejs
+++ b/templates/dashboard.ejs
@@ -359,6 +359,21 @@
                                 </tr>
                                 <% }); %>
                                 <% } %>
+                                <% if (my_prev_trades) { %>
+                                <% my_prev_trades.sort(function(a,b){return a.time > b.time ? -1 : 1;}).forEach(function(trade){ %>
+                                <tr class="text-muted">
+                                    <td><%= trade.type.toUpperCase() %></span></td>
+                                    <td><%= new Intl.NumberFormat("en-US", {useGrouping: false, minimumFractionDigits: 8, maximumFractionDigits: 8}).format(trade.size) %> <%= asset.toUpperCase() %></td>
+                                    <td><%= new Intl.NumberFormat("en-US", {useGrouping: false, minimumFractionDigits: 2, maximumFractionDigits: 7}).format(trade.price) %> <%= currency.toUpperCase() %></td>
+                                    <td><%= new Intl.NumberFormat("en-US", {useGrouping: false, minimumFractionDigits: 2, maximumFractionDigits: 7}).format(trade.size * trade.price) %> <%= currency.toUpperCase() %></td>
+                                    <td><%= new Intl.NumberFormat("en-US", {useGrouping: false, minimumFractionDigits: 2, maximumFractionDigits: 8}).format(trade.fee) %> <% if (trade.type == "buy") { %> <%= asset.toUpperCase() %> <% } else { %> <%= currency.toUpperCase() %> <% } %></td>
+                                    <td><%= new Intl.NumberFormat("en-US", {style: "percent", useGrouping: false, minimumFractionDigits: 4, maximumFractionDigits: 4}).format(trade.slippage) %></td>
+                                    <td><%= moment(trade.time).format('YYYY-MM-DD HH:mm:ss') %></td>
+                                    <td><%= moment.duration(trade.execution_time).humanize() %></td>
+                                    <td><% if (trade.profit) { %><%= new Intl.NumberFormat("en-US", {style: "percent", useGrouping: false, minimumFractionDigits: 2, maximumFractionDigits: 2}).format(trade.profit) %><% } else { %>-<% } %></td>
+                                </tr>
+                                <% }); %>
+                                <% } %>
 
                                 <% if (!(typeof buy_order != "undefined" || typeof sell_order != "undefined") && !my_trades) { %>
                                 <tr><td colspan="6" class="text-center">There is no trades at the moment</td></tr>


### PR DESCRIPTION
Closes #1239

This is an opt-in, either use `--use_prev_trades` or set `c.use_prev_trades = true` in conf.js

If enabled we will load N of our previous trades within the time range of all previous trades (currently up to 1000) and use them for initial sell-stop triggers and loss protection.
This way its no longer necessary to wait for a trade in a new session to get triggers/protection to fire, e.g. after a restart.

The age of previous trades is limited so we don't accidentally end up with a stuck bot which isn't trading at all because the market moved too far since our last trade.

All previous trades are exposed by the API in `my_prev_trades` and included in the dashboard under "My Trades" as "muted" trades at the bottom.

![muted_trades](https://user-images.githubusercontent.com/5265345/35541222-06ff2b26-055a-11e8-94a5-1681e0a5941d.png)