### PR TITLE
Darwin - %age and ETA's during backtesting, as well as mid-generation resuming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ paper_result*
 *_test
 backtesting_*
 generation_data_*
+simulations/*
 models/**/*.json
 models/**/*.html
 *.pyc

--- a/docs/scripts/genetic_backtester.md
+++ b/docs/scripts/genetic_backtester.md
@@ -37,13 +37,13 @@ The following parameters are available when executing darwin.js:
 // Specific Parameters
 --use_strategies="all | strategy1,strategy2"                                            # With this parameter, you can choose to test all, some (comma separated), or just one of the available strategies defined within darwin.
 --population="150"                                                                      # Optional - Number of simulation per generation
---population_data="./simulations/generation_data_[simtimestamp]_gen_[X].json"           # Optional - Resume backtesting on a previously terminated backtesting session based on results from specified generation.
+--population_data="./simulations/backtest_[simtimestamp]"                               # Optional - Resume backtesting on a previously terminated backtesting session.
 
 ```
 
 ## Results
 
-When the next generation starts testing, a csv file will appear in the simulations folder. This CSV contains all simulations that were executed in that generation, including the parameters and results. 
+When the next generation starts testing, a csv file will appear in the simulations folder. This CSV contains all simulations that were executed in that generation, including the parameters and results.
 
 The top results are listed at the top of the file, in descending order.
 

--- a/scripts/genetic_backtester/darwin.js
+++ b/scripts/genetic_backtester/darwin.js
@@ -4,7 +4,7 @@
  * Clifford Roche <clifford.roche@gmail.com>
  * 07/01/2017
  *
- * Example: ./darwin.js --selector="bitfinex.ETH-USD" --days="10" --currency_capital="5000" --use_strategies="all | macd,trend_ema,etc" --population="101" --population_data="simulations/generation_data_NUMBERS_gen_X.json"
+ * Example: ./darwin.js --selector="bitfinex.ETH-USD" --days="10" --currency_capital="5000" --use_strategies="all | macd,trend_ema,etc" --population="101" --population_data="simulations/generation_data_NUMBERS"
  */
 
 let shell = require('shelljs')
@@ -13,10 +13,17 @@ let json2csv = require('json2csv')
 let roundp = require('round-precision')
 let fs = require('fs')
 let GeneticAlgorithmCtor = require('geneticalgorithm')
+let StripAnsi = require('strip-ansi')
 let moment = require('moment')
+let tb = require('timebucket')
 let path = require('path')
+let colors = require('colors')
+let readline = require('readline')
+const spawn = require('child_process').spawn
 let Phenotypes = require('./phenotype.js')
 let argv = require('yargs').argv
+let z = require('zero-fill')
+let n = require('numbro')
 
 let VERSION = 'Zenbot 4 Genetic Backtester v0.2.2'
 
@@ -33,21 +40,255 @@ let OVERSOLD_RSI_PERIODS_MAX = 25
 
 let iterationCount = 0
 
-let selectedStrategies 
+let selectedStrategies
 let pools = {}
 let simArgs
 let populationSize = 0
-let generationCount = 0
+let generationCount = 1
 let generationProcessing = false
 
-function  runCommand  (taskStrategyName, phenotype, cb) {
+let darwinMonitor = {
+  periodDurations: [],
+  phenotypes: [],
+
+  actualRange: function(so) {
+    // Adapted from sim.js logic to similarly figure out how much time is being processed
+    if (so.start) {
+      so.start = moment(so.start, 'YYYYMMDDhhmm')
+      if (so.days && !so.end) {
+        so.end = so.start.clone().add(so.days, 'days')
+      }
+    }
+    if (so.end) {
+      so.end = moment(so.end, 'YYYYMMDDhhmm')
+      if (so.days && !so.start) {
+        so.start = so.end.clone().subtract(so.days, 'days')
+      }
+    }
+    if (!so.start && so.days) {
+      so.start = moment().subtract(so.days, 'days')
+    }
+
+    if (so.days && !so.end) {
+      so.end = so.start.clone().add(so.days, 'days')
+    }
+
+    if (so.start && so.end) {
+      var actualStart = moment( tb(so.start.valueOf()).resize(so.period_length).subtract(so.min_periods + 2).toMilliseconds() );
+      return {
+        start: actualStart,
+        end: so.end
+      }
+    }
+
+    return { start: so.start, end: so.end };
+  },
+
+  reset: function() {
+    this.phenotypes.length = 0;
+  },
+
+  reportStatus: function() {
+    var genCompleted = 0;
+    var genTotal = 0;
+
+    var simsDone = 0;
+    var simsActive = 0;
+    var simsErrored = 0;
+    var simsAll = populationSize * selectedStrategies.length
+    var simsRemaining = simsAll;
+    var self = this;
+    // console.log(`populationSize: ${populationSize}, this.phenotypes: ${this.phenotypes.length}`);
+
+    readline.clearLine(process.stdout)
+    readline.cursorTo(process.stdout, 0)
+
+    var inProgress = []
+    var inProgressStr = []
+
+    var slowestP = null;
+    var slowestEta = null;
+
+    var bestP = null;
+    var bestBalance = null;
+
+    this.phenotypes.forEach(function(p) {
+      if ('sim' in p) {
+        if (Object.keys(p.sim).length === 0) {
+          simsActive++;
+          inProgress.push(p)
+        }
+        else {
+          simsDone++;
+
+          if (!p.command || !p.command.result)
+            simsErrored++;
+
+          if (p.command) {
+            let balance = p.command.result.endBalance
+
+            if (bestP == null || bestBalance < balance) {
+              bestP = p
+              bestBalance = balance
+            }
+            else if (bestP && bestBalance == balance && bestP.command.iteration > p.command.iteration) {
+              // Always pick the earliest one so it doesn't look like the number is jumping all over the place
+              bestP = p
+              bestBalance = balance
+            }
+          }
+        }
+        simsRemaining--;
+      }
+
+    });
+
+    var homeStretchMode = simsActive < (PARALLEL_LIMIT-1) && simsRemaining == 0;
+
+    inProgress.forEach(function(p) {
+      var c = p.command;
+
+      var currentTime;
+      if (c.currentTimeString) currentTime = moment(c.currentTimeString, 'YYYY-MM-DD HH:mm:ss');
+      if (currentTime && currentTime.isBefore(c.queryStart)) c.queryStart = currentTime;
+      // console.log(`${c.iteration} currentTime: ${currentTime}, queryStart: ${c.queryStart}, queryEnd: ${c.queryEnd}, current: ${c.currentTimeString}`);
+
+      // var timeSoFar = moment().diff(c.startTime);
+      // console.log(`remaining: ${time} - ${timeSoFar} = ${time - timeSoFar}`);
+      // timeLeft += time - timeSoFar;
+      if (currentTime && c.queryStart && c.queryEnd) {
+        var totalTime = c.queryEnd.diff(c.queryStart);
+
+        // 2018-01-25 06:18:00
+        var progress = currentTime.diff(c.queryStart);
+
+        // console.log(`totalTime: ${totalTime} vs progress: ${progress}`);
+        var percentage = progress/totalTime;
+        genCompleted += percentage;
+
+        var now = moment()
+        var timeElapsed = now.diff(c.startTime);
+        // console.log(`startTime: ${c.startTime}, timeElapsed: ${timeElapsed}, adding: ${timeElapsed / percentage}ms`);
+        var eta = c.startTime.clone().add(timeElapsed / percentage, "milliseconds");
+
+        if (slowestP == null || slowestEta.isBefore(eta)) {
+          slowestP = p;
+          slowestEta = eta;
+        }
+
+        if (homeStretchMode)
+          inProgressStr.push(`${(c.iteration + ':').gray} ${(percentage*100).toFixed(1)}% ETA: ${distanceOfTimeInWords(eta, now)}`);
+        else
+          inProgressStr.push(`${(c.iteration + ':').gray} ${(percentage*100).toFixed(1)}%`);
+      }
+    });
+
+
+    // timeLeft /= simsActive; // how many run at one time
+    if (inProgressStr.length > 0) {
+      // process.stdout.write("\u001b[1000D") // Move left
+      process.stdout.write("\u001b[1A")
+    readline.clearLine(process.stdout)
+    readline.cursorTo(process.stdout, 0)
+
+      process.stdout.write(inProgressStr.join(', '));
+      process.stdout.write("\n")
+    }
+
+
+    var percentage = ((simsDone + genCompleted)/simsAll * 100).toFixed(1);
+    // z(8, n(s.period.trend_ema_rate).format('0.0000'), ' ')[color]
+    process.stdout.write(`Done: ${simsDone.toString().green}, Active: ${simsActive.toString().yellow}, Remaining: ${simsRemaining.toString().gray}, `)
+    if (simsErrored > 0)
+      process.stdout.write(`Errored: ${simsErrored.toString().red}, `);
+
+    process.stdout.write(`Completion: ${z(5, (n(percentage).format('0.0') + '%'), ' ').green} `);
+
+    let bestBColor = 'gray'
+
+    if (bestP) {
+      if (argv.currency_capital) {
+        let cc = parseFloat(argv.currency_capital)
+        if (cc < 0.1)
+          bestBColor = 'green'
+        else if (cc > bestBalance)
+          bestBColor = 'red'
+        else
+          bestBColor = 'yellow'
+      }
+    }
+
+    let bestBalanceString = z(5, n(bestBalance || 0).format('0.0000'), ' ')[bestBColor]
+    process.stdout.write(`Best Balance(${(bestP ? bestP.command.iteration.toString() : '?')[bestBColor]}): ${bestBalanceString}`)
+
+    if (inProgressStr.length > 0) {
+      if (!homeStretchMode)
+        process.stdout.write(`, Slowest(${slowestP.command.iteration.toString().yellow}) ETA: ${distanceOfTimeInWords(slowestEta, moment()).yellow}`);
+
+    }
+  },
+
+  startMonitor: function() {
+    process.stdout.write('\n\n')
+    this.generationStarted = moment();
+
+    this.reportInterval = setInterval(() => {
+      this.reportStatus()
+    }, 1000);
+  },
+
+  stopMonitor: function() {
+    this.generationEnded = moment();
+    clearInterval(this.reportInterval);
+    var timeStr = distanceOfTimeInWords(this.generationEnded, this.generationStarted);
+    console.log(`\n\nGeneration ${generationCount} completed at ${this.generationEnded.format('YYYY-MM-DD HH:mm:ss')}, took ${timeStr}, results saved to:`);
+  }
+}
+
+let distanceOfTimeInWords = (timeA, timeB) => {
+  var hourDiff = timeA.diff(timeB, 'hours');
+  if (hourDiff == 0) {
+    var minDiff = timeA.diff(timeB, 'minutes');
+    var secDiff = timeA.clone().subtract(minDiff, 'minutes').diff(timeB, 'seconds');
+
+    return `${minDiff}m ${secDiff}s`;
+  }
+  else {
+    var minDiff = timeA.clone().subtract(hourDiff, 'hours').diff(timeB, 'minutes');
+    return `${hourDiff}h ${minDiff}m`;
+  }
+}
+
+let ensureDirectoryExistence = (filePath) => {
+  var dirname = path.dirname(filePath);
+  if (fs.existsSync(dirname)) {
+    return true;
+  }
+  ensureDirectoryExistence(dirname);
+  fs.mkdirSync(dirname);
+}
+
+let writeFileAndFolder = (filePath, data) => {
+  ensureDirectoryExistence(filePath);
+  fs.writeFile(filePath, data, err => {
+    if (err) throw err
+  })
+}
+
+let buildCommand = (taskStrategyName, phenotype) => {
+  var iteration = iterationCount
+
   var cmdArgs = Object.assign({}, phenotype)
   cmdArgs.strategy = taskStrategyName
   Object.assign(cmdArgs, simArgs)
 
   var selector = cmdArgs.selector
   delete cmdArgs.selector
+  delete cmdArgs.exchangeMarketPair
   delete cmdArgs.sim
+  delete cmdArgs.command
+
+  cmdArgs.filename = `simulations/${population_data}/gen_${generationCount}/sim_${iteration}_result.html`;
 
   let zenbot_cmd = process.platform === 'win32' ? 'zenbot.bat' : './zenbot.sh'
   let command = `${zenbot_cmd} sim ${selector}`
@@ -56,33 +297,89 @@ function  runCommand  (taskStrategyName, phenotype, cb) {
     command += ` --${key}=${value}`
   }
 
-  console.log(`[ ${iterationCount++}/${populationSize * selectedStrategies.length} ] ${command}`)
+  var actualRange = darwinMonitor.actualRange({
+    start: cmdArgs.start, end: cmdArgs.end, days: cmdArgs.days,
+    period_length: cmdArgs.period_length, min_periods: (cmdArgs.min_periods || 1)
+  });
+
+  return {
+    iteration: iteration,
+    commandString: command,
+    queryStart: actualRange.start,
+    queryEnd: actualRange.end
+  }
+}
+
+let readSimDataFile = (iteration) => {
+  let jsonFileName = `simulations/${population_data}/gen_${generationCount}/sim_${iteration}.json`;
+
+  if (fs.existsSync(jsonFileName)) {
+    let simData = JSON.parse( fs.readFileSync(jsonFileName, { encoding:'utf8' }) );
+    return simData;
+  }
+  else {
+    return null;
+  }
+}
+
+let writeSimDataFile = (iteration, data) => {
+  let jsonFileName = `simulations/${population_data}/gen_${generationCount}/sim_${iteration}.json`;
+  writeFileAndFolder(jsonFileName, data);
+}
+
+let runCommand = (taskStrategyName, phenotype, command, cb) => {
+  // console.log(`[ ${command.iteration}/${populationSize * selectedStrategies.length} ] ${command.commandString}`)
 
   phenotype['sim'] = {}
+  phenotype['command'] = command;
 
+  command.startTime = moment();
+  var cmdArgs = command.commandString.split(' ');
+  var cmdName = cmdArgs.shift();
+  const proc = spawn(cmdName, cmdArgs);
+  var endData = "";
 
-  shell.exec(command, {
-    silent: true,
-    async: true
-  }, (code, stdout, stderr) => {
-    if (code) {
-      console.error(command)
-      console.error(stderr)
-      return cb(null, null)
-    }
-
+  proc.on('exit', () => {
     let result = null
+    let stdout = endData.toString()
     try {
       result = processOutput(stdout,taskStrategyName,phenotype)
+
+      command.endTime = moment();
+      command.result = result;
+
+      writeSimDataFile(command.iteration, JSON.stringify(command));
+
       phenotype['sim'] = result
       result['fitness'] = Phenotypes.fitness(phenotype)
+
+      darwinMonitor.reportStatus()
+
     } catch (err) {
       console.log('Bad output detected', err.toString())
       console.log(stdout)
+      console.log(err.stack);
     }
 
     cb(null, result)
-  })
+  });
+  proc.stdout.on('data', (data) => {
+    if (data.length > 500) {
+      endData = data;
+    }
+    else {
+      var str = StripAnsi(data.toString()), lines = str.split(/(\r?\n)/g);
+      for (var i=0; i<lines.length; i++) {
+        var line = lines[i];
+        if (line.indexOf("-") == 4 && line.indexOf(":") == 13) {
+          var timeStr = line.slice(0, 20);
+          command.currentTimeString = timeStr;
+          // console.log(`${command.iteration}: ${command.currentTimeString}`)
+        }
+      }
+
+    }
+  });
 }
 
 function  runUpdate  (days, selector) {
@@ -145,6 +442,9 @@ function processOutput  (output,taskStrategyName, pheno) {
     start = parseInt(simulationResults.start)
     end = parseInt(simulationResults.end || null)
   }
+  else {
+    console.log(`Couldn't find simulationResults for ${pheno.backtester_generation}`)
+  }
 
   let roi
   if  (params.currency_capital == 0.0)
@@ -205,6 +505,9 @@ function processOutput  (output,taskStrategyName, pheno) {
     strategy: params.strategy,
     frequency: roundp((wins + losses) / days, 3)
   }
+
+
+
   return results
 }
 
@@ -336,7 +639,7 @@ const strategies = {
     smalen1: Range(1, 300),
     smalen2: Range(1, 300),
     vwap_length: Range(1, 300),
-    vwap_max: RangeFactor(0, 10000, 10) //0 disables this max cap. Test in increments of 10
+    vwap_max: RangeFactor(0, 10000, 10)//0 disables this max cap. Test in increments of 10
   },
   dema: {
     // -- common
@@ -678,23 +981,34 @@ function generateCommandParams (input)  {
 }
 
 function  saveGenerationData (csvFileName, jsonFileName, dataCSV, dataJSON) {
-  fs.writeFileSync(csvFileName, dataCSV, err => {
-    if (err) throw err
+  try {
+    fs.writeFileSync(csvFileName, dataCSV)
     console.log('> Finished writing generation csv to ' + csvFileName)
-  //  callback(1)
-  })
-  fs.writeFileSync(jsonFileName, dataJSON, err => {
-    if (err) throw err
+  }
+  catch (err) {
+    throw err
+  }
+
+  try {
+    fs.writeFileSync(jsonFileName, dataJSON)
     console.log('> Finished writing generation json to ' + jsonFileName)
-  //  callback(2)
-  })
+  }
+  catch (err) {
+    throw err
+  }
 }
 
+let population_data = argv.population_data || `backtest_${moment().format('YYYYMMDDhhmm')}`
 
+// Find the first incomplete generation of this session, where incomplete means no "results" files
+while (fs.existsSync(`simulations/${population_data}/gen_${generationCount}`)) { generationCount++ }
+generationCount--;
+if (generationCount > 0 && !fs.existsSync(`simulations/${population_data}/gen_${generationCount}/results.csv`)) { generationCount-- }
 
 function simulateGeneration  () {
   generationProcessing = true
   console.log(`\n\n=== Simulating generation ${++generationCount} ===\n`)
+  darwinMonitor.reset();
 
   let days = argv.days
   if (!days) {
@@ -709,19 +1023,51 @@ function simulateGeneration  () {
   }
   iterationCount = 1
   if (iterationCount == 1)
-    runUpdate(days, argv.selector)
+  runUpdate(days, argv.selector)
 
 
   let tasks = selectedStrategies.map(v => pools[v]['pool'].population().map(phenotype => {
+
     return cb => {
       phenotype.backtester_generation = iterationCount
       phenotype.exchangeMarketPair = argv.selector
-      runCommand(v, phenotype, cb)
+      darwinMonitor.phenotypes.push(phenotype);
+
+      var command;
+      let simData = readSimDataFile(iterationCount);
+      if (simData) {
+        if (simData.result) {
+          // Found a complete and cached sim, don't run anything, just forward the results of it
+          phenotype['sim'] = simData.result;
+          iterationCount++;
+          return cb(null, simData.result);
+        }
+        else {
+          command = {
+            iteration: iterationCount,
+            commandString: simData.commandString,
+            queryStart: moment(simData.queryStart),
+            queryEnd: moment(simData.queryEnd)
+          };
+        }
+      }
+
+      if (!command) {
+        // Default flow, build the command to run, and cache it so there's no need to duplicate work when resuming
+        command = buildCommand(v, phenotype);
+        writeSimDataFile(iterationCount, JSON.stringify(command));
+      }
+
+      iterationCount++;
+      runCommand(v, phenotype, command, cb);
     }
   })).reduce((a, b) => a.concat(b))
 
+  darwinMonitor.startMonitor();
+
   parallel(tasks, PARALLEL_LIMIT, (err, results) => {
-    console.log('\nGeneration complete, saving results...')
+    darwinMonitor.stopMonitor();
+
     results = results.filter(function(r) {
       return !!r
     })
@@ -736,41 +1082,41 @@ function simulateGeneration  () {
       fields: fieldsGeneral,
       fieldNames: fieldNamesGeneral
     })
-
-    let fileDate = Math.round(+new Date() / 1000)
-    let csvFileName = `simulations/backtesting_${fileDate}.csv`
+    let csvFileName = `simulations/${population_data}/gen_${generationCount}/results.csv`
 
     let poolData = {}
     selectedStrategies.forEach(function(v) {
       poolData[v] = pools[v]['pool'].population()
     })
 
-    let jsonFileName = `simulations/generation_data_${fileDate}_gen_${generationCount}.json`
+    let jsonFileName = `simulations/${population_data}/gen_${generationCount}/results.json`
     let dataJSON = JSON.stringify(poolData, null, 2)
+    saveGenerationData(csvFileName, jsonFileName, dataCSV, dataJSON )
+
 
     //Display best of the generation
-    console.log('\n\nGeneration\'s Best Results')
+        console.log('\n\nGeneration\'s Best Results')
     let bestOverallResult = []
     let prefix = './zenbot.sh sim '
-    selectedStrategies.forEach((v)=> {
-      let best = pools[v]['pool'].best()
-      let bestCommand 
-      if(best.sim){
+        selectedStrategies.forEach((v)=> {
+          let best = pools[v]['pool'].best()
+      let bestCommand
+          if(best.sim){
         console.log(`\t(${best.sim.strategy}) Sim Fitness ${best.sim.fitness}, VS Buy and Hold: ${best.sim.vsBuyHold} End Balance: ${best.sim.endBalance}, Wins/Losses ${best.sim.wins}/${best.sim.losses}, ROI ${best.sim.roi}.`)
         bestCommand = generateCommandParams(best.sim)
         bestOverallResult.push(best.sim)
-      } else {
+          } else {
         console.log(`\t(${results[0].strategy}) Result Fitness ${results[0].fitness}, VS Buy and Hold: ${results[0].vsBuyHold}, End Balance: ${results[0].endBalance}, Wins/Losses ${results[0].wins}/${results[0].losses}.`)
         bestCommand = generateCommandParams(results[0])
         bestOverallResult.push(results[0])
-      }
+          }
 
-      // prepare command snippet from top result for this strat
+          // prepare command snippet from top result for this strat
 
-      bestCommand = prefix + bestCommand
-      bestCommand = bestCommand + ' --asset_capital=' + argv.asset_capital + ' --currency_capital=' + argv.currency_capital
-      console.log(bestCommand + '\n')
-    })
+          bestCommand = prefix + bestCommand
+          bestCommand = bestCommand + ' --asset_capital=' + argv.asset_capital + ' --currency_capital=' + argv.currency_capital
+          console.log(bestCommand + '\n')
+        })
 
     bestOverallResult.sort((a, b) => (a.fitness < b.fitness) ? 1 : ((b.fitness < a.fitness) ? -1 : 0))
     if (selectedStrategies.length > 1){
@@ -781,9 +1127,7 @@ function simulateGeneration  () {
     bestOverallCommand = bestOverallCommand + ' --asset_capital=' + argv.asset_capital + ' --currency_capital=' + argv.currency_capital
     if (selectedStrategies.length > 1) {
       console.log(bestOverallCommand + '\n')
-    }
-
-    saveGenerationData(csvFileName, jsonFileName, dataCSV, dataJSON )
+      }
 
     selectedStrategies.forEach((v)=> {
       pools[v]['pool'] = pools[v]['pool'].evolve()
@@ -792,7 +1136,7 @@ function simulateGeneration  () {
     generationProcessing = false
 
 
-  }) 
+  })
 }
 
 
@@ -818,11 +1162,9 @@ populationSize = (argv.population) ? argv.population : 100
 console.log(`Backtesting strategy ${strategyName} ...`)
 console.log(`Creating population of ${populationSize} ...\n`)
 
- 
+
 selectedStrategies = (strategyName === 'all') ? allStrategyNames() : strategyName.split(',')
 
-
-let importedPoolData = (populationFileName) ? JSON.parse(fs.readFileSync(populationFileName, 'utf8')) : null
 
 //Clean up any generation files left over in the simulation directory
 //they will be overwritten, but best not to confuse the issue.
@@ -847,14 +1189,14 @@ try
   console.log('error deleting lint from prior run')
 }
 
-  
+
 for (var i = 0; i < selectedStrategies.length; i++)
 {
   let v = selectedStrategies[i]
   let strategyPool = pools[v] = {}
 
   let evolve = true
-  let population = (importedPoolData && importedPoolData[v]) ? importedPoolData[v] : []
+  let population = []
   for (var i2 = population.length; i2 < populationSize; ++i2) {
     population.push(Phenotypes.create(strategies[v]))
     evolve = false
@@ -878,6 +1220,44 @@ for (var i = 0; i < selectedStrategies.length; i++)
     strategyPool['pool'].evolve()
   }
 }
+
+// BEGIN - exitHandler
+var exitHandler = function(options, exitErr) {
+
+  if (generationCount && options.cleanup) {
+    console.log("Resume this backtest later with:")
+    var darwin_args = process.argv.slice(2, process.argv.length)
+
+    var hasPopData = false
+    var popDataArg = `--population_data=${population_data}`
+    darwin_args.forEach(function(arg) {
+      if (arg === popDataArg) {
+        hasPopData = true
+      }
+    });
+
+    if (!hasPopData) {
+      darwin_args.push(popDataArg)
+    }
+
+    console.log(`./scripts/genetic_backtester/darwin.js ${darwin_args.join(' ')}`)
+  }
+
+  if (exitErr) console.log(exitErr.stack || exitErr);
+  if (options.exit) process.exit();
+}
+process.on('exit', exitHandler.bind(null,{cleanup:true}));
+
+//catches ctrl+c event
+process.on('SIGINT', exitHandler.bind(null, {exit:true}));
+
+// catches "kill pid" (for example: nodemon restart)
+process.on('SIGUSR1', exitHandler.bind(null, {exit:true}));
+process.on('SIGUSR2', exitHandler.bind(null, {exit:true}));
+
+//catches uncaught exceptions
+process.on('uncaughtException', exitHandler.bind(null, {exit:true}));
+// END - exitHandler
 
 
 setInterval( ()=>{


### PR DESCRIPTION
### Problems I hoped to solve:
1. A backtest with a very high population might take more than 24 hrs to execute. If you're 80% done, but need your computer back for other things, you might really struggle with the decision on whether or not to let the generation finish, or kill it.
2. A sim might be broken (see #1249) or maybe taking longer than others, or maybe it's just taking a while and you'd like to know more. Current output gives no information about any of this.

### To solve resuming mid-generation:
I now generate a token for the "run" that looks like "backtest_201801300356" where the number there is the timestamp. Inside it are nested files and folders related to the data. The pro being no more scattered millions of files in a single simulations folder. Now everything for the entire "run" is stored in one place.

To resume, you just add `--population_data=backtest_201801300356` to your previous command and it'll re-start on the correct generation and sim set. So if you were at 87/100 sims and you closed it and restarted, you'll still be at 87/100 sims remaining.

As another benefit to this is that as soon as a sim is done, you can view its info and results within its own file within its generation folder, including the html output.

The only downside here is that this is not backward compatible with the old `population_data` param so any old runs you may have stored will no longer be resumable. I could revisit this if people think it's a real problem but I didn't want to clutter the codebase with multiple solutions to the same problem.

### To add meaningful console output:
Instead of printing out the command along with the sim number, the command info is added to its sim file in the generation folder immediately, and now the output is made to be something more useful.

1. Start of the run, and at the end of each generation, timestamp and duration is printed.
2. During a run, you get info about how many sims are running, and the completion of each active run, and an ETA for the slowest currently running.
```
Done: 18, Active: 8, Remaining: 4, Completion: 66.4%, Slowest sim ETA: 1m 22s  18: 44.0%, 20: 26.7%, 21: 28.0%, 22: 26.4%, 23: 23.9%, 24: 13.7%, 25: 28.7%^C
```
3. Once a generation gets near completion, you'll get an ETA for every remaining sim. This can be useful for figuring out what's up with some particularly long running sims.
4. Like during trade/sim where it keeps updating the same line over and over, this does the same thing to not be overly noisy.

### Final thoughts:
I don't actually think the PR should be simply accepted as is. I'm hoping for some people to really hammer at this and give some feedback and ideas on how to give it some better polish. I was originally hoping that I could give an ETA for the entire run early on, but considering some sims may take much longer than others, I can't figure out a way that doesn't involve lots of guesses with averages to compute and that'll just annoy people because it'll be wrong.

At any rate, I feel like there's more opportunity for useful output there but now that I've hit a solid stopping point I'm low on ideas. Let me know what you think!