### PR TITLE
fix phenotype win loss ratio weighting

### DIFF
--- a/scripts/genetic_backtester/phenotype.js
+++ b/scripts/genetic_backtester/phenotype.js
@@ -70,9 +70,11 @@ module.exports = {
     if (typeof phenotype.sim === 'undefined') return 0
     
     var vsBuyHoldRate = (phenotype.sim.vsBuyHold / 50)
-    var wlRatio = phenotype.sim.wins - phenotype.sim.losses
-    // 2.71828 is https://en.wikipedia.org/wiki/E_(mathematical_constant)
-    var wlRatioRate = 1.0 / (1.0 + Math.pow(2.71828, wlRatio < 0 ? wlRatio:-(wlRatio)))
+    var wlRatio = phenotype.sim.wins / phenotype.sim.losses
+    if(isNaN(wlRatio)) { // zero trades will result in 0/0 which is NaN
+      wlRatio = 1
+    }
+    var wlRatioRate = 1.0 / (1.0 + Math.pow(Math.E, -wlRatio))
     var rate = vsBuyHoldRate * (wlRatioRate)
     return rate
   },


### PR DESCRIPTION
Current calculation in the phenotype fitness are incorrect. The `wlRatio` isn't _currently_ a ratio, but as the variable name suggests, it should be. The result being that the scaling for `wlRatioRate` goes properly from 0.5 for all losses compared to wins to 1.0 for all wins compared to losses.

Since 0/0 in JS is `NaN`, there's a special case for no trades made where it will set it to 1 (basically 1/1 ratio of wins to losses, even if both were zero).

Also, Euler's number is a built-in mathematic constant in JS, so we can just use it since it's more precise.