### PR TITLE
Drop obsolete ROI calc in darwin to avoid glitches

### DIFF
--- a/scripts/genetic_backtester/darwin.js
+++ b/scripts/genetic_backtester/darwin.js
@@ -147,9 +147,6 @@ let processOutput = (output,taskStrategyName, pheno)=> {
   }
 
 
-  let roi = roundp(((endBalance - params.currency_capital) / params.currency_capital) * 100, 3 )
-
-
   //todo: figure out what this is trying to do.
   let r = params
   delete r.asset_capital
@@ -193,7 +190,6 @@ let processOutput = (output,taskStrategyName, pheno)=> {
     markdown_buy_pct: params.markdown_buy_pct,
     markup_sell_pct: params.markup_sell_pct,
     order_type: params.order_type,
-    roi: roi,
     wlRatio: losses > 0 ? roundp(wins / losses, 3) : 'Infinity',
     selector: params.selector,
     strategy: params.strategy,


### PR DESCRIPTION
The `roi` calculation in darwin.js does nothing but dump to the generation's json file. It's not used for fitness calcs or anything, it's just extra stuff. The problem with it is that if you run a backtest with `currency_capital == 0` and `asset_capital > 0` then it'll crash because it doesn't know how to compute `roi` without any starting currency. There's lots and lots of ideas about how to get the right information to calculate this correctly, but there's already plenty of other values actually being displayed and used for comparison's sake besides `roi` so it's easier to just get rid of this.

To see it crash for yourself, here's the command:
```
./scripts/genetic_backtester/darwin.js --days=1 --selector="gdax.BTC-USD" --asset_capital=0.4 --currency_capital=0 --use_strategies=trend_ema --periodLength=15m --population=2
```