### PR TITLE
update gdax dependency, simplify websocket, add order tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "express": "^4.16.2",
     "file-loader": "^1.1.6",
     "forex.analytics": "mkmarek/forex.analytics#7bc278987700d4204e959af17de61495941d1a14",
-    "gdax": "coinbase/gdax-node#v0.5.0",
+    "gdax": "^0.5.1", 
     "gemini-api": "^2.0.4",
     "glob": "^7.1.1",
     "har-validator": "^5.0.3",


### PR DESCRIPTION
Updates the GDAX node dependency to latest npm released version and updates API calls accordingly.

Removes use of the OrderbookSync class in favor of just handling the relevant websocket messages on the ticker channel to keep track of best buy/ask. OrderbookSync was a source of much startup lag due to the slow underlying decimal library they're using. They've updated it in their current master, but there's insufficient error handling for updating the book and it occasionally throws an error, so I think that just using a cache on the ticker channel is simpler and more robust and Zenbot doesn't currently concern itself with the current state of the orderbook besides best buy and ask.

Adds user order tracking websocket cache so we can use that instead of making lots of order check API calls. 

Puts debug messages behind the debug flag.

Websocket connection will completely remove itself and start over on `error` messages/events.