### PR TITLE
update talib to latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "sosa_mongo": "^1.0.3",
     "stats-lite": "2.1.0",
     "style-loader": "^0.20.1",
-    "talib": "drorgl/node-talib#b30dd674e5b11822ea93bb253001169f1bc99e15",
+    "talib": "^1.0.4",
     "timebucket": "^0.4.0",
     "transform-loader": "^0.2.4",
     "trend": "0.3.0",


### PR DESCRIPTION
Puts the `talib` version back to the latest stable release as Windows support has been merged back into the main project. The forked version we're currently on expects to have a bunch of npm tooling that is only default for Node 9.x, so it installs quite a few extra dependencies that we don't need.