### PR TITLE
wins is the total minus the losses, not the total

### DIFF
--- a/scripts/genetic_backtester/darwin.js
+++ b/scripts/genetic_backtester/darwin.js
@@ -144,7 +144,7 @@ function processOutput  (output,taskStrategyName, pheno) {
     buyHold = simulationResults.simresults.buy_hold
     vsBuyHold = simulationResults.simresults.vs_buy_hold
     wlMatch = (simulationResults.simresults.total_sells - simulationResults.simresults.total_losses) +'/'+ simulationResults.simresults.total_losses
-    wins          = simulationResults.simresults.total_sells
+    wins          = simulationResults.simresults.total_sells - simulationResults.simresults.total_losses
     losses        = simulationResults.simresults.total_losses
     errorRate     = simulationResults.simresults.total_losses / simulationResults.simresults.total_sells
     days = parseInt(simulationResults.days)


### PR DESCRIPTION
pretty much what it says on the tin. 

recent revisions to darwin introduced some bad math. to say it throws off the fitness scale is an understatement.