### PR TITLE
MACD trigger sell signal for overbought instead of just notify

### DIFF
--- a/extensions/strategies/macd/strategy.js
+++ b/extensions/strategies/macd/strategy.js
@@ -47,7 +47,7 @@ module.exports = function container (get, set, clear) {
         if (s.overbought) {
           s.overbought = false
           s.trend = 'overbought'
-          s.signal = 'sold'
+          s.signal = 'sell'
           return cb()
         }
       }


### PR DESCRIPTION
I found no reasen in MACD (for at least) why not trigger a sell signal for overbought_rsi indicator. as this indicator triggers only one signal per trend. moreover i am also wondering why all strategies that implement this also only notify an upcoming event. so do i miss something here. A 'sold' signal is catche nowhere? 

whenever there is a simulation running into rsi with this changes iam getting higher profit from it.

Please review this **change extensively**, because of behavior change