### PR TITLE
add back internal API cache reference for orders for websocket failures

### DIFF
--- a/extensions/exchanges/gdax/exchange.js
+++ b/extensions/exchanges/gdax/exchange.js
@@ -325,6 +325,7 @@ module.exports = function container (get, set, clear) {
         }
         if (!err) err = statusErr(resp, body)
         if (err) return retry('buy', func_args, err)
+        orders['~' + body.id] = body
         cb(null, body)
       })
     },
@@ -356,6 +357,7 @@ module.exports = function container (get, set, clear) {
         }
         if (!err) err = statusErr(resp, body)
         if (err) return retry('sell', func_args, err)
+        orders['~' + body.id] = body
         cb(null, body)
       })
     },


### PR DESCRIPTION
Adds back the "normal" order cache so the API calls have something to grab onto if the websocket connection goes down in the interim.