### PR TITLE
Remove sosa-mongo, run-parallel dependencies

### DIFF
--- a/commands/backfill.js
+++ b/commands/backfill.js
@@ -1,9 +1,7 @@
 var tb = require('timebucket')
-  , parallel = require('run-parallel')
   , crypto = require('crypto')
-  , tradesCollection = require('../db/trades')
-  , resume_markersCollection = require('../db/resume_markers')
   , objectifySelector = require('../lib/objectify-selector')
+  , collectionService = require('../lib/services/collection-service')
 
 module.exports = function (program, conf) {
   program
@@ -19,8 +17,9 @@ module.exports = function (program, conf) {
         process.exit(1)
       }
 
-      var trades = tradesCollection(conf)
-      var resume_markers = resume_markersCollection(conf)
+      var collectionServiceInstance = collectionService(conf)
+      var tradesCollection = collectionServiceInstance.getTrades()
+      var resume_markers = collectionServiceInstance.getResumeMarkers()
 
       var marker = {
         id: crypto.randomBytes(4).toString('hex'),
@@ -30,12 +29,14 @@ module.exports = function (program, conf) {
         oldest_time: null,
         newest_time: null
       }
+      marker._id = marker.id
       var trade_counter = 0
       var day_trade_counter = 0
       var days_left = cmd.days + 1
       var target_time, start_time
       var mode = exchange.historyScan
       var last_batch_id, last_batch_opts
+      var markers, trades
       if (!mode) {
         console.error('cannot backfill ' + selector.normalized + ': exchange does not offer historical data')
         process.exit(0)
@@ -47,9 +48,9 @@ module.exports = function (program, conf) {
         target_time = new Date().getTime()
         start_time = new Date().getTime() - (86400000 * cmd.days)
       }
-      resume_markers.select({query: {selector: selector.normalized}}, function (err, markers) {
+      resume_markers.find({selector: selector.normalized}).toArray(function (err, results) {
         if (err) throw err
-        markers.sort(function (a, b) {
+        markers = results.sort(function (a, b) {
           if (mode === 'backward') {
             if (a.to > b.to) return -1
             if (a.to < b.to) return 1
@@ -61,149 +62,154 @@ module.exports = function (program, conf) {
           return 0
         })
         getNext()
-        function getNext () {
-          var opts = {product_id: selector.product_id}
-          if (mode === 'backward') {
-            opts.to = marker.from
+      })
+
+      function getNext () {
+        var opts = {product_id: selector.product_id}
+        if (mode === 'backward') {
+          opts.to = marker.from
+        }
+        else {
+          if (marker.to) opts.from = marker.to + 1
+          else opts.from = exchange.getCursor(start_time)
+        }
+        last_batch_opts = opts
+        exchange.getTrades(opts, function (err, results) {
+          trades = results
+          if (err) {
+            console.error('err backfilling selector: ' + selector.normalized)
+            console.error(err)
+            if (err.code === 'ETIMEDOUT' || err.code === 'ENOTFOUND' || err.code === 'ECONNRESET') {
+              console.error('retrying...')
+              setImmediate(getNext)
+              return
+            }
+            console.error('aborting!')
+            process.exit(1)
           }
-          else {
-            if (marker.to) opts.from = marker.to + 1
-            else opts.from = exchange.getCursor(start_time)
-          }
-          last_batch_opts = opts
-          exchange.getTrades(opts, function (err, trades) {
-            if (err) {
-              console.error('err backfilling selector: ' + selector.normalized)
-              console.error(err)
-              if (err.code === 'ETIMEDOUT' || err.code === 'ENOTFOUND' || err.code === 'ECONNRESET') {
-                console.error('retrying...')
-                setImmediate(getNext)
-                return
-              }
-              console.error('aborting!')
+          if (mode !== 'backward' && !trades.length) {
+            if (trade_counter) {
+              console.log('\ndownload complete!\n')
+              process.exit(0)
+            }
+            else {
+              console.error('\ngetTrades() returned no trades, --start may be too remotely in the past.')
               process.exit(1)
             }
-            if (mode !== 'backward' && !trades.length) {
-              if (trade_counter) {
-                console.log('\ndownload complete!\n')
-                process.exit(0)
-              }
-              else {
-                console.error('\ngetTrades() returned no trades, --start may be too remotely in the past.')
-                process.exit(1)
-              }
+          }
+          else if (!trades.length) {
+            console.log('\ngetTrades() returned no trades, we may have exhausted the historical data range.')
+            process.exit(0)
+          }
+          trades.sort(function (a, b) {
+            if (mode === 'backward') {
+              if (a.time > b.time) return -1
+              if (a.time < b.time) return 1
             }
-            else if (!trades.length) {
-              console.log('\ngetTrades() returned no trades, we may have exhausted the historical data range.')
-              process.exit(0)
+            else {
+              if (a.time < b.time) return -1
+              if (a.time > b.time) return 1
             }
-            trades.sort(function (a, b) {
-              if (mode === 'backward') {
-                if (a.time > b.time) return -1
-                if (a.time < b.time) return 1
-              }
-              else {
-                if (a.time < b.time) return -1
-                if (a.time > b.time) return 1
-              }
-              return 0
-            })
-            if (last_batch_id && last_batch_id === trades[0].trade_id) {
-              console.error('\nerror: getTrades() returned duplicate results')
-              console.error(opts)
-              console.error(last_batch_opts)
-              process.exit(0)
-            }
-            last_batch_id = trades[0].trade_id
-            var tasks = trades.map(function (trade) {
-              return function (cb) {
-                saveTrade(trade, cb)
-              }
-            })
-            function runTasks () {
-              parallel(tasks, function (err) {
-                if (err) {
-                  console.error(err)
-                  console.error('retrying...')
-                  return setTimeout(runTasks, 10000)
-                }
-                var oldest_time = marker.oldest_time
-                var newest_time = marker.newest_time
-                markers.forEach(function (other_marker) {
-                  // for backward scan, if the oldest_time is within another marker's range, skip to the other marker's start point.
-                  // for forward scan, if the newest_time is within another marker's range, skip to the other marker's end point.
-                  if (mode === 'backward' && marker.id !== other_marker.id && marker.from <= other_marker.to && marker.from > other_marker.from) {
-                    marker.from = other_marker.from
-                    marker.oldest_time = other_marker.oldest_time
-                  }
-                  else if (mode !== 'backward' && marker.id !== other_marker.id && marker.to >= other_marker.from && marker.to < other_marker.to) {
-                    marker.to = other_marker.to
-                    marker.newest_time = other_marker.newest_time
-                  }
-                })
-                var diff
-                if (oldest_time !== marker.oldest_time) {
-                  diff = tb(oldest_time - marker.oldest_time).resize('1h').value
-                  console.log('\nskipping ' + diff + ' hrs of previously collected data')
-                }
-                else if (newest_time !== marker.newest_time) {
-                  diff = tb(marker.newest_time - newest_time).resize('1h').value
-                  console.log('\nskipping ' + diff + ' hrs of previously collected data')
-                }
-                resume_markers.save(marker, function (err) {
-                  if (err) throw err
-                  trade_counter += trades.length
-                  day_trade_counter += trades.length
-                  var current_days_left = 1 + (mode === 'backward' ? tb(marker.oldest_time - target_time).resize('1d').value : tb(target_time - marker.newest_time).resize('1d').value)
-                  if (current_days_left >= 0 && current_days_left != days_left) {
-                    console.log('\n' + selector.normalized, 'saved', day_trade_counter, 'trades', current_days_left, 'days left')
-                    day_trade_counter = 0
-                    days_left = current_days_left
-                  }
-                  else {
-                    process.stdout.write('.')
-                  }
-                  if (mode === 'backward' && marker.oldest_time <= target_time) {
-                    console.log('\ndownload complete!\n')
-                    process.exit(0)
-                  }
-                  if (exchange.backfillRateLimit) {
-                    setTimeout(getNext, exchange.backfillRateLimit)
-                  } else {
-                    setImmediate(getNext)
-                  }
-                })
-              })
-            }
-
-            runTasks()
+            return 0
           })
-        }
-        function saveTrade (trade, cb) {
-          trade.id = selector.normalized + '-' + String(trade.trade_id)
-          trade.selector = selector.normalized
-          var cursor = exchange.getCursor(trade)
-          if (mode === 'backward') {
-            if (!marker.to) {
-              marker.to = cursor
-              marker.oldest_time = trade.time
-              marker.newest_time = trade.time
-            }
-            marker.from = marker.from ? Math.min(marker.from, cursor) : cursor
-            marker.oldest_time = Math.min(marker.oldest_time, trade.time)
+          if (last_batch_id && last_batch_id === trades[0].trade_id) {
+            console.error('\nerror: getTrades() returned duplicate results')
+            console.error(opts)
+            console.error(last_batch_opts)
+            process.exit(0)
           }
-          else {
-            if (!marker.from) {
-              marker.from = cursor
-              marker.oldest_time = trade.time
-              marker.newest_time = trade.time
+          last_batch_id = trades[0].trade_id
+          runTasks(trades)
+        })
+      }
+
+      function runTasks (trades) {
+        Promise.all(trades.map((trade)=>saveTrade(trade))).then(function(/*results*/){
+          var oldest_time = marker.oldest_time
+          var newest_time = marker.newest_time
+          markers.forEach(function (other_marker) {
+            // for backward scan, if the oldest_time is within another marker's range, skip to the other marker's start point.
+            // for forward scan, if the newest_time is within another marker's range, skip to the other marker's end point.
+            if (mode === 'backward' && marker.id !== other_marker.id && marker.from <= other_marker.to && marker.from > other_marker.from) {
+              marker.from = other_marker.from
+              marker.oldest_time = other_marker.oldest_time
             }
-            marker.to = marker.to ? Math.max(marker.to, cursor) : cursor
-            marker.newest_time = Math.max(marker.newest_time, trade.time)
+            else if (mode !== 'backward' && marker.id !== other_marker.id && marker.to >= other_marker.from && marker.to < other_marker.to) {
+              marker.to = other_marker.to
+              marker.newest_time = other_marker.newest_time
+            }
+          })
+          var diff
+          if (oldest_time !== marker.oldest_time) {
+            diff = tb(oldest_time - marker.oldest_time).resize('1h').value
+            console.log('\nskipping ' + diff + ' hrs of previously collected data')
           }
-          trades.save(trade, cb)
+          else if (newest_time !== marker.newest_time) {
+            diff = tb(marker.newest_time - newest_time).resize('1h').value
+            console.log('\nskipping ' + diff + ' hrs of previously collected data')
+          }
+          resume_markers.save(marker)
+            .then(setupNext)
+            .catch(function(err){
+              if (err) throw err
+            })
+        }).catch(function(err){
+          if (err) {
+            console.error(err)
+            console.error('retrying...')
+            return setTimeout(runTasks, 10000, trades)
+          }
+        })
+      }
+
+      function setupNext() {
+        trade_counter += trades.length
+        day_trade_counter += trades.length
+        var current_days_left = 1 + (mode === 'backward' ? tb(marker.oldest_time - target_time).resize('1d').value : tb(target_time - marker.newest_time).resize('1d').value)
+        if (current_days_left >= 0 && current_days_left != days_left) {
+          console.log('\n' + selector.normalized, 'saved', day_trade_counter, 'trades', current_days_left, 'days left')
+          day_trade_counter = 0
+          days_left = current_days_left
         }
-      })
+        else {
+          process.stdout.write('.')
+        }
+        if (mode === 'backward' && marker.oldest_time <= target_time) {
+          console.log('\ndownload complete!\n')
+          process.exit(0)
+        }
+        if (exchange.backfillRateLimit) {
+          setTimeout(getNext, exchange.backfillRateLimit)
+        } else {
+          setImmediate(getNext)
+        }
+      }
+
+      function saveTrade (trade) {
+        trade.id = selector.normalized + '-' + String(trade.trade_id)
+        trade._id = trade.id
+        trade.selector = selector.normalized
+        var cursor = exchange.getCursor(trade)
+        if (mode === 'backward') {
+          if (!marker.to) {
+            marker.to = cursor
+            marker.oldest_time = trade.time
+            marker.newest_time = trade.time
+          }
+          marker.from = marker.from ? Math.min(marker.from, cursor) : cursor
+          marker.oldest_time = Math.min(marker.oldest_time, trade.time)
+        }
+        else {
+          if (!marker.from) {
+            marker.from = cursor
+            marker.oldest_time = trade.time
+            marker.newest_time = trade.time
+          }
+          marker.to = marker.to ? Math.max(marker.to, cursor) : cursor
+          marker.newest_time = Math.max(marker.newest_time, trade.time)
+        }
+        return tradesCollection.save(trade)
+      }
     })
 }
 

--- a/commands/sim.js
+++ b/commands/sim.js
@@ -7,7 +7,7 @@ var tb = require('timebucket')
   , colors = require('colors')
   , objectifySelector = require('../lib/objectify-selector')
   , engineFactory = require('../lib/engine')
-  , tradesCollection = require('../db/trades')
+  , collectionService = require('../lib/services/collection-service')
 
 module.exports = function (program, conf) {
   program
@@ -50,6 +50,7 @@ module.exports = function (program, conf) {
           so[k] = cmd[k]
         }
       })
+      var tradesCollection = collectionService(conf).getTrades()
 
       if (so.start) {
         so.start = moment(so.start, 'YYYYMMDDhhmm').valueOf()
@@ -172,7 +173,6 @@ module.exports = function (program, conf) {
           fs.writeFileSync(path.resolve(__dirname, '..', 'simulations','sim_'+so.strategy.replace('_','')+'_'+ so.selector.normalized.replace('_','').toLowerCase()+'_'+so.backtester_generation+'.json'),options_json, {encoding: 'utf8'})
         }
 
-
         if (so.filename !== 'none') {
           var html_output = output_lines.map(function (line) {
             return colors.stripColors(line)
@@ -230,7 +230,7 @@ module.exports = function (program, conf) {
           if (!opts.query.time) opts.query.time = {}
           opts.query.time['$gte'] = query_start
         }
-        tradesCollection(conf).select(opts, function (err, trades) {
+        tradesCollection.find(opts.query).sort(opts.sort).limit(opts.limit).toArray(function (err, trades) {
           if (err) throw err
           if (!trades.length) {
             if (so.symmetrical && !reversing) {

--- a/commands/train.js
+++ b/commands/train.js
@@ -11,7 +11,7 @@ var tb = require('timebucket')
   , crypto = require('crypto')
   , objectifySelector = require('../lib/objectify-selector')
   , engineFactory = require('../lib/engine')
-  , trades = require('../db/trades')
+  , collectionService = require('../lib/services/collection-service')
 
 var fa_defaultIndicators = [
   'CCI',
@@ -82,7 +82,7 @@ module.exports = function (program, conf) {
           so[k] = cmd[k]
         }
       })
-
+      var tradesCollection = collectionService(conf).getTrades()
       if (!so.days_test) { so.days_test = 0 }
       so.strategy = 'noop'
 
@@ -378,7 +378,7 @@ module.exports = function (program, conf) {
           if (!opts.query.time) opts.query.time = {}
           opts.query.time['$gte'] = query_start
         }
-        trades(conf).select(opts, function (err, trades) {
+        tradesCollection.find(opts.query).limit(opts.limit).sort(opts.sort).toArray(function (err, trades) {
           if (err) throw err
           if (!trades.length) {
             if (so.symmetrical && !reversing) {

--- a/db/balances.js
+++ b/db/balances.js
@@ -1,4 +1,0 @@
-var createCollection = require('./createCollection')
-module.exports = function(conf) {
-  return createCollection('balances', null, conf)
-}

--- a/db/createCollection.js
+++ b/db/createCollection.js
@@ -1,5 +1,0 @@
-var sosa_mongo = require('sosa_mongo')
-
-module.exports = function createCollection (name, options, conf) {
-  return sosa_mongo({ db: conf.db.mongo })(name, options)
-}

--- a/db/my_trades.js
+++ b/db/my_trades.js
@@ -1,4 +1,0 @@
-var createCollection = require('./createCollection')
-module.exports = function(conf) {
-  return createCollection('my_trades', null, conf)
-}

--- a/db/periods.js
+++ b/db/periods.js
@@ -1,4 +1,0 @@
-var createCollection = require('./createCollection')
-module.exports = function(conf) {
-  return createCollection('periods', null, conf)
-}

--- a/db/resume_markers.js
+++ b/db/resume_markers.js
@@ -1,4 +1,0 @@
-var createCollection = require('./createCollection')
-module.exports = function(conf) {
-  return createCollection('resume_markers', null, conf)
-}

--- a/db/sessions.js
+++ b/db/sessions.js
@@ -1,4 +1,0 @@
-var createCollection = require('./createCollection')
-module.exports = function(conf) {
-  return createCollection('sessions', null, conf)
-}

--- a/db/trades.js
+++ b/db/trades.js
@@ -1,4 +1,0 @@
-var createCollection = require('./createCollection')
-module.exports = function(conf){
-  return createCollection('trades', null, conf)
-}

--- a/lib/rsi.js
+++ b/lib/rsi.js
@@ -1,5 +1,3 @@
-var mathjs = require('mathjs')
-
 module.exports = function rsi (s, key, length) {
   if (s.lookback.length >= length) {
     var avg_gain = s.lookback[0][key + '_avg_gain']
@@ -33,7 +31,7 @@ module.exports = function rsi (s, key, length) {
       s.period[key] = 100
     } else {
       var rs = s.period[key + '_avg_gain'] / s.period[key + '_avg_loss']
-      s.period[key] = mathjs.round(100 - (100 / (1 + rs)), 2)
+      s.period[key] = (100 - (100 / (1 + rs))).toFixed(2)
     }
   }
 }

--- a/lib/services/collection-service.js
+++ b/lib/services/collection-service.js
@@ -8,6 +8,22 @@ module.exports = function (conf) {
     getResumeMarkers: () => {
       conf.db.mongo.collection('resume_markers').ensureIndex({selector: 1, to: -1})
       return conf.db.mongo.collection('resume_markers')
+    },
+
+    getBalances: () => {
+      return conf.db.mongo.collection('balances')
+    },
+
+    getSessions: () => {
+      return conf.db.mongo.collection('sessions')
+    },
+
+    getPeriods: () => {
+      return conf.db.mongo.collection('periods')
+    },
+
+    getMyTrades: () => {
+      return conf.db.mongo.collection('my_trades')
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "sass-loader": "^6.0.6",
     "semver": "^5.4.1",
     "simple-xmpp": "^1.3.0",
-    "sosa_mongo": "^1.0.3",
     "stats-lite": "2.1.0",
     "style-loader": "^0.20.1",
     "superagent": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "random-port": "^0.1.0",
     "regression": "^2.0.0",
     "resolve-url-loader": "^2.2.1",
-    "run-parallel": "^1.1.6",
     "run-series": "^1.1.4",
     "sass-loader": "^6.0.6",
     "semver": "^5.4.1",


### PR DESCRIPTION
I wasn't a huge fan of the "magic"/abstraction of the sosa wrapper and after going over the source code, it didn't really do anything except add a couple different layers between the code and the database. It also made it significantly harder to modernize database calls with newer mongo paradigms (read: Promises and async/await). Mostly just need to ad `_id` properties to objects we're saving to the database (because `sosa` just copies the `id` property to `_id`, that's what I did to maintain parity with existing stuff).

The backfill command gets unwound a little, dropping the parallel call in favor of Promise handling and un-nesting functions so we're not re-defining them every loop (read: memory and callstack savings).

I also just noticed that RSI was loading a huge math library to do a really complicated decimal rounding call. Using a native rounding function shaved 15% off of a simulation time.