### PR TITLE
API: Fix s.trades duplicates

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -72,6 +72,7 @@ module.exports = function (s, conf) {
   if (conf.output.api.on) {
     s.boot_time = (new Date).getTime()
     s.tz_offset = new Date().getTimezoneOffset()
+    s.last_trade_id = 0
     s.trades = []
   }
   if (so.strategy) {
@@ -155,7 +156,10 @@ module.exports = function (s, conf) {
     s.period.close_time = trade.time
     s.strategy.calculate(s)
     s.vol_since_last_blink += trade.size
-    s.trades && s.trades.push(trade)
+    if (s.trades && s.last_trade_id !== trade.trade_id) {
+      s.trades.push(trade)
+      s.last_trade_id = trade.trade_id
+    }
   }
 
   function executeStop (do_sell_stop) {


### PR DESCRIPTION
If no trade happened between two periods we kept re-adding the last trade to s.trades.