### PR TITLE
If a full day isn't available, look for less time

### DIFF
--- a/commands/backfill.js
+++ b/commands/backfill.js
@@ -32,6 +32,7 @@ module.exports = function (program, conf) {
       marker._id = marker.id
       var trade_counter = 0
       var day_trade_counter = 0
+      var get_trade_retry_count = 0
       var days_left = cmd.days + 1
       var target_time, start_time
       var mode = exchange.historyScan
@@ -93,8 +94,17 @@ module.exports = function (program, conf) {
               process.exit(0)
             }
             else {
-              console.error('\ngetTrades() returned no trades, --start may be too remotely in the past.')
-              process.exit(1)
+              if (get_trade_retry_count < 5) {
+                console.error('\ngetTrades() returned no trades, retrying with smaller interval.')
+                get_trade_retry_count++
+                start_time += (target_time - start_time)*0.4
+                setImmediate(getNext)
+                return
+              }
+              else {
+                console.error('\ngetTrades() returned no trades, --start may be too remotely in the past.')
+                process.exit(1)
+              }
             }
           }
           else if (!trades.length) {


### PR DESCRIPTION
This morning after Binance came back up post database crash, `./zenbot.sh trade` failed because it couldn't backfill any data. The problem was that the backfilled wanted a whole day's worth of data, but an entire day wasn't available as the exchange had only been up for maybe a few hours. With this code tweak, it'll look for a smaller time frame than a whole day until it finds some data so that you can move forward without zenbot crashing.