### PR TITLE
engine expects rsi to be numeric

### DIFF
--- a/lib/rsi.js
+++ b/lib/rsi.js
@@ -1,3 +1,7 @@
+var precisionRound = function(number, precision) {
+  var factor = Math.pow(10, precision)
+  return Math.round(number * factor) / factor
+}
 module.exports = function rsi (s, key, length) {
   if (s.lookback.length >= length) {
     var avg_gain = s.lookback[0][key + '_avg_gain']
@@ -31,7 +35,7 @@ module.exports = function rsi (s, key, length) {
       s.period[key] = 100
     } else {
       var rs = s.period[key + '_avg_gain'] / s.period[key + '_avg_loss']
-      s.period[key] = (100 - (100 / (1 + rs))).toFixed(2)
+      s.period[key] = precisionRound(100 - (100 / (1 + rs)), 2)
     }
   }
 }


### PR DESCRIPTION
since engine.js is particular about the typeof returned from RSI, and technically multiplication, division and rounding are faster than conversion to a string