### PR TITLE
Update coloring of formatted currency output

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -2,7 +2,7 @@ let tb = require('timebucket')
   , moment = require('moment')
   , z = require('zero-fill')
   , n = require('numbro')
-  // eslint-disable-next-line no-unused-vars 
+  // eslint-disable-next-line no-unused-vars
   , colors = require('colors')
   , series = require('run-series')
   , abbreviate = require('number-abbreviate')
@@ -186,7 +186,7 @@ module.exports = function (s, conf) {
             stop_signal = 'sell'
             console.log(('\nprofit stop triggered at ' + pct(s.last_trade_worth) + ' trade worth\n').green)
           }
-          
+
         }
         else {
           if (s.buy_stop && s.period.close > s.buy_stop) {
@@ -477,12 +477,12 @@ module.exports = function (s, conf) {
             if (s.product.max_size && Number(size) > Number(s.product.max_size)) {
               size = s.product.max_size
             }
-            if (!s.last_sell_price && s.my_prev_trades.length) { 
-              var prev_sells = s.my_prev_trades.filter(trade => trade.type === 'sell') 
-              if (prev_sells.length) { 
-                s.last_sell_price = prev_sells[0].price 
-              } 
-            } 
+            if (!s.last_sell_price && s.my_prev_trades.length) {
+              var prev_sells = s.my_prev_trades.filter(trade => trade.type === 'sell')
+              if (prev_sells.length) {
+                s.last_sell_price = prev_sells[0].price
+              }
+            }
             if (s.buy_order && so.max_slippage_pct != null) {
               let slippage = n(price).subtract(s.buy_order.orig_price).divide(s.buy_order.orig_price).multiply(100).value()
               if (so.max_slippage_pct != null && slippage > so.max_slippage_pct) {
@@ -517,11 +517,11 @@ module.exports = function (s, conf) {
             if (s.product.max_size && Number(size) > Number(s.product.max_size)) {
               size = s.product.max_size
             }
-            if (!s.last_buy_price && s.my_prev_trades.length) { 
-              var prev_buys = s.my_prev_trades.filter(trade => trade.type === 'buy') 
-              if (prev_buys.length) { 
-                s.last_buy_price = prev_buys[0].price 
-              } 
+            if (!s.last_buy_price && s.my_prev_trades.length) {
+              var prev_buys = s.my_prev_trades.filter(trade => trade.type === 'buy')
+              if (prev_buys.length) {
+                s.last_buy_price = prev_buys[0].price
+              }
             }
             let sell_loss = s.last_buy_price ? (Number(price) - s.last_buy_price) / s.last_buy_price * -100 : null
             if (so.max_sell_loss_pct != null && sell_loss > so.max_sell_loss_pct) {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -122,8 +122,8 @@ module.exports = function (s, conf) {
     }
     if (color_trick) {
       str = str
-        .replace(/^(.*\.)(0*)(.*?)(0*)$/, function (_, m, m2, m3, m4) {
-          return m.cyan + m2.grey + m3.yellow + m4.grey
+        .replace(/^(.*\.)(.*?)(0*)$/, function (_, m1, m2, m3) {
+          return m1.cyan + m2.yellow + m3.grey
         })
     }
     return str + (omit_currency ? '' : ' ' + s.currency)


### PR DESCRIPTION
This is in reference to issue #1225.

This change will "color" up to the first significant digit after the decimal place.  Previously, only non-zero digits were colored.