### PR TITLE
Don't automatically generate html in darwin

### DIFF
--- a/scripts/genetic_backtester/darwin.js
+++ b/scripts/genetic_backtester/darwin.js
@@ -288,7 +288,8 @@ let buildCommand = (taskStrategyName, phenotype) => {
   delete cmdArgs.sim
   delete cmdArgs.command
 
-  cmdArgs.filename = `simulations/${population_data}/gen_${generationCount}/sim_${iteration}_result.html`;
+  if (argv.include_html)
+    cmdArgs.filename = `simulations/${population_data}/gen_${generationCount}/sim_${iteration}_result.html`;
 
   let zenbot_cmd = process.platform === 'win32' ? 'zenbot.bat' : './zenbot.sh'
   let command = `${zenbot_cmd} sim ${selector}`


### PR DESCRIPTION
With the new folder structure, it's pretty handy to automatically have the html for each sim go into the generation's folder by adding `--include_html`. However, I think people are more likely to be upset to wake up in the morning and find over 1GB of space has been taken up by their experiment. Let's leave this off by default.