### PR TITLE
Changed all tests to use actual, and consistent, millisecond times

### DIFF
--- a/test/_specs/commands/backfill/backfill.consume.function.test.js
+++ b/test/_specs/commands/backfill/backfill.consume.function.test.js
@@ -22,13 +22,13 @@ describe('The Backfill Consume function', function() {
     it('', function() {
       var callback = jasmine.createSpy('callback')
             
-      var instance = require('../../../../commands/backfill/backfill.consume.function')({tradesArray: [{trade_id: 3001, time: 99994}, {trade_id: 3000, time: 99992}]})
+      var instance = require('../../../../commands/backfill/backfill.consume.function')({tradesArray: [{trade_id:3001, time:1517787104902}, {trade_id:3000, time:1517787104900}]})
 
       instance(undefined, queue, callback)
 
       expect(callback.calls.count()).toEqual(1) 
       expect(callback).toHaveBeenCalledWith(null, 'cp_process', 3000)
-      expect(queue.enqueue).toHaveBeenCalledWith([{trade_id: 3001, time: 99994}, {trade_id: 3000, time: 99992}])
+      expect(queue.enqueue).toHaveBeenCalledWith([{trade_id: 3001, time: 1517787104902}, {trade_id: 3000, time: 1517787104900}])
     })
   })
 
@@ -45,6 +45,5 @@ describe('The Backfill Consume function', function() {
       expect(queue.enqueue).not.toHaveBeenCalled()
     })
   })
-
 
 })

--- a/test/_specs/commands/backfill/backfill.process.function.test.js
+++ b/test/_specs/commands/backfill/backfill.process.function.test.js
@@ -23,37 +23,37 @@ describe('The Backfill Process function', function() {
   describe('processes trades ', function() {
 
     beforeEach(function () {
-      spyOn(queue, 'dequeue').and.returnValue([{trade_id: 3002, time: 99996}, {trade_id: 3001, time: 99994}, {trade_id: 3000, time: 99992}])
+      spyOn(queue, 'dequeue').and.returnValue([{trade_id:3002, time:1517787104904}, {trade_id:3001, time:1517787104902}, {trade_id:3000, time:1517787104900}])
     })
 
     it('when all are considered new', function() {
       var callback = jasmine.createSpy('callback')
       var instance = mock.reRequire('../../../../commands/backfill/backfill.process.function')({})
 
-      var targetTimeInMillis = 99900
+      var targetTimeInMillis = 1517787104899
       instance(targetTimeInMillis, queue, (trade) => { return trade.trade_id }, callback)
 
       expect(queue.dequeue.calls.count()).toEqual(1)
       expect(callback.calls.count()).toEqual(1) 
-      expect(callback).toHaveBeenCalledWith(null, false, 3000, {trade_id: 3000, time: 99992})
+      expect(callback).toHaveBeenCalledWith(null, false, 3000, {trade_id:3000, time:1517787104900})
     })
   })
 
   describe('indicates exit condition was reached when one of the trades is past our time limit', function() {
     beforeEach(function () {
-      spyOn(queue, 'dequeue').and.returnValue([{trade_id: 3002, time: 99996}, {trade_id: 3001, time: 99994}, {trade_id: 3000, time: 99992}])
+      spyOn(queue, 'dequeue').and.returnValue([{trade_id:3002, time:1517787104904}, {trade_id:3001, time:1517787104902}, {trade_id:3000, time:1517787104900}])
     })
 
     it('', function() {
       var callback = jasmine.createSpy('callback')
       var instance =  mock.reRequire('../../../../commands/backfill/backfill.process.function')({})
 
-      var targetTimeInMillis = 99993
+      var targetTimeInMillis = 1517787104901
       instance(targetTimeInMillis, queue, (trade) => { return trade.trade_id }, callback)
 
       expect(queue.dequeue.calls.count()).toEqual(1)
       expect(callback.calls.count()).toEqual(1)
-      expect(callback).toHaveBeenCalledWith(null, true, 3001, {trade_id: 3001, time: 99994})
+      expect(callback).toHaveBeenCalledWith(null, true, 3001, {trade_id:3001, time:1517787104902})
     })
   })
 
@@ -62,19 +62,19 @@ describe('The Backfill Process function', function() {
   xdescribe('does not insert records that have already been seen', function() {
     beforeEach(function () {
 
-      spyOn(queue, 'dequeue').and.returnValue([{trade_id: 3002, time: 99996}, {trade_id: 3001, time: 99994}, {trade_id: 3000, time: 99992}])
+      spyOn(queue, 'dequeue').and.returnValue([{trade_id:3002, time:1517787104904}, {trade_id:3001, time:1517787104902}, {trade_id:3000, time:1517787104900}])
     })
 
     it('', function() {
       var callback = jasmine.createSpy('callback')
       var instance =  require('../../../../commands/backfill/backfill.process.function')({})
 
-      var targetTimeInMillis = 99900
+      var targetTimeInMillis = 1517787104900
       instance(targetTimeInMillis, queue, callback)
 
       expect(queue.dequeue.calls.count()).toEqual(1)
       expect(callback.calls.count()).toEqual(1)
-      expect(callback).toHaveBeenCalledWith(null, false, {trade_id: 3002, time: 99996})
+      expect(callback).toHaveBeenCalledWith(null, false, {trade_id: 3002, time: 1517787104904}) 
             
       // TODO: How to check that theFunction only called the mockCollectionService twice? 
       //  Because there should only be two inserts when the third is reported as 'already seen'.

--- a/test/_specs/lib/services/resume-marker-service.test.js
+++ b/test/_specs/lib/services/resume-marker-service.test.js
@@ -26,7 +26,7 @@ describe('Resume Marker Service', function() {
     it('sets an id and _id attribute on a newly created range', function() {
       var instance = service(conf)
 
-      instance.createNewRange({trade_id:1300, time:990000})
+      instance.createNewRange({trade_id:3000, time:1517787104900})
 
       expect(instance.getRanges().length).toBe(1)
       expect(instance.getRanges()[0].id).toBeDefined
@@ -36,163 +36,163 @@ describe('Resume Marker Service', function() {
     it('has one range, after creating a range, and it only contains the trade_id we just gave it', function() {
       var instance = service(conf)
             
-      instance.createNewRange({trade_id:1300, time:990000})
+      instance.createNewRange({trade_id:3000, time:1517787104900})
 
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1300)
-      expect(instance.getRanges()[0].to).toBe(1300)
-      expect(instance.getRanges()[0].oldest_time).toBe(990000)
-      expect(instance.getRanges()[0].newest_time).toBe(990000)
+      expect(instance.getRanges()[0].from).toBe(3000)
+      expect(instance.getRanges()[0].to).toBe(3000)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104900)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104900)
     })
 
     it('gets the correct range, when you create a range and then ask is that id in a range', function() {
       var instance = service(conf)
-      var trade = {trade_id:1300, time:990000}
+      var trade = {trade_id:3000, time:1517787104900}
 
       instance.createNewRange(trade)
 
       var rtn = instance.isWithinRange(trade)
       expect(rtn).toBeDefined()
-      expect(rtn.from).toBe(1300)
-      expect(rtn.oldest_time).toBe(990000)
+      expect(rtn.from).toBe(3000)
+      expect(rtn.oldest_time).toBe(1517787104900)
     })
 
     it('returns true when we create a range on XXX, then ask is XXX + 1 within one of any range', function() {
       var instance = service(conf)
-      var trade = {trade_id:1300, time:990000}
+      var trade = {trade_id:3000, time:1517787104900}
 
       instance.createNewRange(trade)
 
-      var trade2 = {trade_id:1301, time:990001}
+      var trade2 = {trade_id:3001, time:1517787104902}
       var rtn = instance.isWithinOneOfAnyRange(trade2)
       expect(rtn).toBeDefined()
-      expect(rtn.from).toBe(1300)
-      expect(rtn.oldest_time).toBe(990000)
+      expect(rtn.from).toBe(3000)
+      expect(rtn.oldest_time).toBe(1517787104900)
 
     })
 
     it('returns false when we create a range on XXX, then ask is XXX + 2 within one of any range', function() {
       var instance = service(conf)
-      var trade = {trade_id:1300, time:990000}
+      var trade = {trade_id:3000, time:1517787104900}
 
       instance.createNewRange(trade)
 
-      var trade2 = {trade_id:1302, time:990002}
+      var trade2 = {trade_id:3002, time:1517787104904}
       var rtn = instance.isWithinOneOfAnyRange(trade2)
       expect(rtn).not.toBeDefined()
     })
 
     it('extends a range', function() {
       var instance = service(conf)
-      var trade = {trade_id:1300, time:990000}
+      var trade = {trade_id:3000, time:1517787104900}
 
       instance.createNewRange(trade)
 
-      var trade2 = {trade_id:1299, time:989998}
+      var trade2 = {trade_id:2999, time:1517787104898}
       instance.extendARange(trade2)
 
-      expect(instance.getRanges()[0].from).toBe(1299)
+      expect(instance.getRanges()[0].from).toBe(2999)
     })
 
     it('merges two now-adjacent ranges', function() {
       var instance = service(conf)
-      var trade = {trade_id:1300, time:990000}
+      var trade = {trade_id:3000, time:1517787104900}
 
       instance.createNewRange(trade)
       expect(instance.getRanges().length).toBe(1)
 
-      var trade2 = {trade_id:1298, time:989994}
+      var trade2 = {trade_id:2998, time:1517787104894}
       instance.createNewRange(trade2)
       expect(instance.getRanges().length).toBe(2)
 
-      instance.extendARange({trade_id:1299, time:989996})
+      instance.extendARange({trade_id:2999, time:1517787104896})
 
       expect(instance.getRanges().length).toBe(2)
       instance.merge()
 
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1298)
-      expect(instance.getRanges()[0].to).toBe(1300)
-      expect(instance.getRanges()[0].oldest_time).toBe(989994)
-      expect(instance.getRanges()[0].newest_time).toBe(990000)
+      expect(instance.getRanges()[0].from).toBe(2998)
+      expect(instance.getRanges()[0].to).toBe(3000)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104894)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104900)
     })
 
     it('pings correctly', function() {
       var instance = service(conf)
-      var trade = {trade_id:1300, time:990000}
+      var trade = {trade_id:3000, time:1517787104900}
 
       var rtn = instance.ping(trade)
 
-      expect(rtn).toBe(1300)
+      expect(rtn).toBe(3000)
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1300)
-      expect(instance.getRanges()[0].to).toBe(1300)
-      expect(instance.getRanges()[0].oldest_time).toBe(990000)
-      expect(instance.getRanges()[0].newest_time).toBe(990000)
+      expect(instance.getRanges()[0].from).toBe(3000)
+      expect(instance.getRanges()[0].to).toBe(3000)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104900)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104900)
 
-      var trade2 = {trade_id:1299, time:989996}
+      var trade2 = {trade_id:2999, time:1517787104896}
       rtn = instance.ping(trade2)
 
-      expect(rtn).toBe(1299)
+      expect(rtn).toBe(2999)
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1299)
-      expect(instance.getRanges()[0].to).toBe(1300)
-      expect(instance.getRanges()[0].oldest_time).toBe(989996)
-      expect(instance.getRanges()[0].newest_time).toBe(990000)
+      expect(instance.getRanges()[0].from).toBe(2999)
+      expect(instance.getRanges()[0].to).toBe(3000)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104896)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104900)
 
       // TODO: Test what happens if you give the same number. It should return that to you as the farthest so far.
 
-      var trade3 = {trade_id:1298, time:989994}
+      var trade3 = {trade_id:2998, time:1517787104894}
       rtn = instance.ping(trade3)
 
-      expect(rtn).toBe(1298)
+      expect(rtn).toBe(2998)
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1298)
-      expect(instance.getRanges()[0].to).toBe(1300)
-      expect(instance.getRanges()[0].oldest_time).toBe(989994)
-      expect(instance.getRanges()[0].newest_time).toBe(990000)
+      expect(instance.getRanges()[0].from).toBe(2998)
+      expect(instance.getRanges()[0].to).toBe(3000)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104894)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104900)
 
       // break from happy path -- skip the next sequential record, should start a new range
 
-      //var trade4 = {trade_id:1297, time:989992};
-      var trade4 = {trade_id:1296, time:989990}
+      //var trade4 = {trade_id:2997, time:1517787104892};
+      var trade4 = {trade_id:2996, time:1517787104890}
       rtn = instance.ping(trade4)
 
-      expect(rtn).toBe(1296)
+      expect(rtn).toBe(2996)
       expect(instance.getRanges().length).toBe(2)
-      expect(instance.getRanges()[0].from).toBe(1298)
-      expect(instance.getRanges()[0].to).toBe(1300)
-      expect(instance.getRanges()[0].oldest_time).toBe(989994)
-      expect(instance.getRanges()[0].newest_time).toBe(990000)
-      expect(instance.getRanges()[1].from).toBe(1296)
-      expect(instance.getRanges()[1].to).toBe(1296)
-      expect(instance.getRanges()[1].oldest_time).toBe(989990)
-      expect(instance.getRanges()[1].newest_time).toBe(989990)
+      expect(instance.getRanges()[0].from).toBe(2998)
+      expect(instance.getRanges()[0].to).toBe(3000)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104894)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104900)
+      expect(instance.getRanges()[1].from).toBe(2996)
+      expect(instance.getRanges()[1].to).toBe(2996)
+      expect(instance.getRanges()[1].oldest_time).toBe(1517787104890)
+      expect(instance.getRanges()[1].newest_time).toBe(1517787104890)
 
-      var trade5 = {trade_id:1295, time:989988}
+      var trade5 = {trade_id:2995, time:1517787104888}
       rtn = instance.ping(trade5)
 
-      expect(rtn).toBe(1295)
+      expect(rtn).toBe(2995)
       expect(instance.getRanges().length).toBe(2)
-      expect(instance.getRanges()[0].from).toBe(1298)
-      expect(instance.getRanges()[0].to).toBe(1300)
-      expect(instance.getRanges()[0].oldest_time).toBe(989994)
-      expect(instance.getRanges()[0].newest_time).toBe(990000)
-      expect(instance.getRanges()[1].from).toBe(1295)
-      expect(instance.getRanges()[1].to).toBe(1296)
-      expect(instance.getRanges()[1].oldest_time).toBe(989988)
-      expect(instance.getRanges()[1].newest_time).toBe(989990)
+      expect(instance.getRanges()[0].from).toBe(2998)
+      expect(instance.getRanges()[0].to).toBe(3000)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104894)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104900)
+      expect(instance.getRanges()[1].from).toBe(2995)
+      expect(instance.getRanges()[1].to).toBe(2996)
+      expect(instance.getRanges()[1].oldest_time).toBe(1517787104888)
+      expect(instance.getRanges()[1].newest_time).toBe(1517787104890)
 
       // now, throw some salt in the game, ping the record we skipped earlier
-      var trade6 = {trade_id:1297, time:989992}
+      var trade6 = {trade_id:2997, time:1517787104892}
       rtn = instance.ping(trade6)
 
-      expect(rtn).toBe(1295)
+      expect(rtn).toBe(2995)
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1295)
-      expect(instance.getRanges()[0].to).toBe(1300)
-      expect(instance.getRanges()[0].oldest_time).toBe(989988)
-      expect(instance.getRanges()[0].newest_time).toBe(990000)
+      expect(instance.getRanges()[0].from).toBe(2995)
+      expect(instance.getRanges()[0].to).toBe(3000)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104888)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104900)
 
       expect(instance.getPingCount()).toBe(6)
     })
@@ -211,42 +211,42 @@ describe('Resume Marker Service', function() {
       var instance = service(conf)
       instance.setDirection('forward') // TODO: put this in a constants object
             
-      instance.createNewRange({trade_id:1300, time:990000})
+      instance.createNewRange({trade_id:3000, time:1517787104900})
 
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1300)
-      expect(instance.getRanges()[0].to).toBe(1300)
-      expect(instance.getRanges()[0].oldest_time).toBe(990000)
-      expect(instance.getRanges()[0].newest_time).toBe(990000)
+      expect(instance.getRanges()[0].from).toBe(3000)
+      expect(instance.getRanges()[0].to).toBe(3000)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104900)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104900)
     })
 
     it('gets the correct range, when you create a range and then ask is that id in a range', function() {
       var instance = service(conf)
       instance.setDirection('forward') // TODO: put this in a constants object
 
-      var trade = {trade_id:1300, time:990000}
+      var trade = {trade_id:3000, time:1517787104900}
 
       instance.createNewRange(trade)
 
       var rtn = instance.isWithinRange(trade)
       expect(rtn).toBeDefined()
-      expect(rtn.from).toBe(1300)
-      expect(rtn.oldest_time).toBe(990000)
+      expect(rtn.from).toBe(3000)
+      expect(rtn.oldest_time).toBe(1517787104900)
     })
 
     it('returns true when we create a range on XXX, then ask is XXX + 1 within one of any range', function() {
       var instance = service(conf)
       instance.setDirection('forward') // TODO: put this in a constants object
 
-      var trade = {trade_id:1300, time:990000}
+      var trade = {trade_id:3000, time:1517787104900}
 
       instance.createNewRange(trade)
 
-      var trade2 = {trade_id:1301, time:990001}
+      var trade2 = {trade_id:3001, time:1517787104902}
       var rtn = instance.isWithinOneOfAnyRange(trade2)
       expect(rtn).toBeDefined()
-      expect(rtn.from).toBe(1300)
-      expect(rtn.oldest_time).toBe(990000)
+      expect(rtn.from).toBe(3000)
+      expect(rtn.oldest_time).toBe(1517787104900)
 
     })
 
@@ -254,11 +254,11 @@ describe('Resume Marker Service', function() {
       var instance = service(conf)
       instance.setDirection('forward') // TODO: put this in a constants object
 
-      var trade = {trade_id:1300, time:990000}
+      var trade = {trade_id:3000, time:1517787104900}
 
       instance.createNewRange(trade)
 
-      var trade2 = {trade_id:1302, time:990002}
+      var trade2 = {trade_id:3002, time:1517787104902}
       var rtn = instance.isWithinOneOfAnyRange(trade2)
       expect(rtn).not.toBeDefined()
     })
@@ -267,120 +267,120 @@ describe('Resume Marker Service', function() {
       var instance = service(conf)
       instance.setDirection('forward') // TODO: put this in a constants object
 
-      var trade = {trade_id:1299, time:989998}
+      var trade = {trade_id:2999, time:1517787104898}
 
       instance.createNewRange(trade)
 
-      var trade2 = {trade_id:1300, time:990000}
+      var trade2 = {trade_id:3000, time:1517787104900}
       instance.extendARange(trade2)
 
-      expect(instance.getRanges()[0].from).toBe(1299)
-      expect(instance.getRanges()[0].to).toBe(1300)
+      expect(instance.getRanges()[0].from).toBe(2999)
+      expect(instance.getRanges()[0].to).toBe(3000)
     })
 
     it('merges two now-adjacent ranges', function() {
       var instance = service(conf)
       instance.setDirection('forward') // TODO: put this in a constants object
 
-      var trade = {trade_id:1298, time:989994}
+      var trade = {trade_id:2998, time:1517787104894}
 
       instance.createNewRange(trade)
       expect(instance.getRanges().length).toBe(1)
 
-      var trade2 = {trade_id:1300, time:990000}
+      var trade2 = {trade_id:3000, time:1517787104900}
       instance.createNewRange(trade2)
       expect(instance.getRanges().length).toBe(2)
 
-      instance.extendARange({trade_id:1299, time:989996})
+      instance.extendARange({trade_id:2999, time:1517787104896})
 
       expect(instance.getRanges().length).toBe(2)
       instance.merge()
 
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1298)
-      expect(instance.getRanges()[0].to).toBe(1300)
-      expect(instance.getRanges()[0].oldest_time).toBe(989994)
-      expect(instance.getRanges()[0].newest_time).toBe(990000)
+      expect(instance.getRanges()[0].from).toBe(2998)
+      expect(instance.getRanges()[0].to).toBe(3000)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104894)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104900)
     })
 
     it('pings correctly', function() {
       var instance = service(conf)
       instance.setDirection('forward') // TODO: put this in a constants object
 
-      var trade = {trade_id:1300, time:990000}
+      var trade = {trade_id:3000, time:1517787104900}
 
       var rtn = instance.ping(trade)
 
-      expect(rtn).toBe(1300)
+      expect(rtn).toBe(3000)
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1300)
-      expect(instance.getRanges()[0].to).toBe(1300)
-      expect(instance.getRanges()[0].oldest_time).toBe(990000)
-      expect(instance.getRanges()[0].newest_time).toBe(990000)
+      expect(instance.getRanges()[0].from).toBe(3000)
+      expect(instance.getRanges()[0].to).toBe(3000)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104900)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104900)
 
-      var trade2 = {trade_id:1301, time:990002}
+      var trade2 = {trade_id:3001, time:1517787104902}
       rtn = instance.ping(trade2)
 
-      expect(rtn).toBe(1301)
+      expect(rtn).toBe(3001)
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1300)
-      expect(instance.getRanges()[0].to).toBe(1301)
-      expect(instance.getRanges()[0].oldest_time).toBe(990000)
-      expect(instance.getRanges()[0].newest_time).toBe(990002)
+      expect(instance.getRanges()[0].from).toBe(3000)
+      expect(instance.getRanges()[0].to).toBe(3001)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104900)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104902)
 
       // TODO: Test what happens if you give the same number. It should return that to you as the farthest so far.
 
-      var trade3 = {trade_id:1302, time:990004}
+      var trade3 = {trade_id:3002, time:1517787104904}
       rtn = instance.ping(trade3)
 
-      expect(rtn).toBe(1302)
+      expect(rtn).toBe(3002)
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1300)
-      expect(instance.getRanges()[0].to).toBe(1302)
-      expect(instance.getRanges()[0].oldest_time).toBe(990000)
-      expect(instance.getRanges()[0].newest_time).toBe(990004)
+      expect(instance.getRanges()[0].from).toBe(3000)
+      expect(instance.getRanges()[0].to).toBe(3002)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104900)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104904)
 
       // break from happy path -- skip the next sequential record, should start a new range
 
-      //var trade4 = {trade_id:1304, time:990006};
-      var trade4 = {trade_id:1304, time:990006}
+      //var trade4 = {trade_id:3004, time:1517787104906};
+      var trade4 = {trade_id:3004, time:1517787104906}
       rtn = instance.ping(trade4)
 
-      expect(rtn).toBe(1304)
+      expect(rtn).toBe(3004)
       expect(instance.getRanges().length).toBe(2)
-      expect(instance.getRanges()[0].from).toBe(1300)
-      expect(instance.getRanges()[0].to).toBe(1302)
-      expect(instance.getRanges()[0].oldest_time).toBe(990000)
-      expect(instance.getRanges()[0].newest_time).toBe(990004)
-      expect(instance.getRanges()[1].from).toBe(1304)
-      expect(instance.getRanges()[1].to).toBe(1304)
-      expect(instance.getRanges()[1].oldest_time).toBe(990006)
-      expect(instance.getRanges()[1].newest_time).toBe(990006)
+      expect(instance.getRanges()[0].from).toBe(3000)
+      expect(instance.getRanges()[0].to).toBe(3002)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104900)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104904)
+      expect(instance.getRanges()[1].from).toBe(3004)
+      expect(instance.getRanges()[1].to).toBe(3004)
+      expect(instance.getRanges()[1].oldest_time).toBe(1517787104906)
+      expect(instance.getRanges()[1].newest_time).toBe(1517787104906)
 
-      var trade5 = {trade_id:1305, time:990008}
+      var trade5 = {trade_id:3005, time:1517787104908}
       rtn = instance.ping(trade5)
 
-      expect(rtn).toBe(1305)
+      expect(rtn).toBe(3005)
       expect(instance.getRanges().length).toBe(2)
-      expect(instance.getRanges()[0].from).toBe(1300)
-      expect(instance.getRanges()[0].to).toBe(1302)
-      expect(instance.getRanges()[0].oldest_time).toBe(990000)
-      expect(instance.getRanges()[0].newest_time).toBe(990004)
-      expect(instance.getRanges()[1].from).toBe(1304)
-      expect(instance.getRanges()[1].to).toBe(1305)
-      expect(instance.getRanges()[1].oldest_time).toBe(990006)
-      expect(instance.getRanges()[1].newest_time).toBe(990008)
+      expect(instance.getRanges()[0].from).toBe(3000)
+      expect(instance.getRanges()[0].to).toBe(3002)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104900)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104904)
+      expect(instance.getRanges()[1].from).toBe(3004)
+      expect(instance.getRanges()[1].to).toBe(3005)
+      expect(instance.getRanges()[1].oldest_time).toBe(1517787104906)
+      expect(instance.getRanges()[1].newest_time).toBe(1517787104908)
 
       // now, throw some salt in the game, ping the record we skipped earlier
-      var trade6 = {trade_id:1303, time:990005}
+      var trade6 = {trade_id:3003, time:1517787104905}
       rtn = instance.ping(trade6)
 
-      expect(rtn).toBe(1305)
+      expect(rtn).toBe(3005)
       expect(instance.getRanges().length).toBe(1)
-      expect(instance.getRanges()[0].from).toBe(1300)
-      expect(instance.getRanges()[0].to).toBe(1305)
-      expect(instance.getRanges()[0].oldest_time).toBe(990000)
-      expect(instance.getRanges()[0].newest_time).toBe(990008)
+      expect(instance.getRanges()[0].from).toBe(3000)
+      expect(instance.getRanges()[0].to).toBe(3005)
+      expect(instance.getRanges()[0].oldest_time).toBe(1517787104900)
+      expect(instance.getRanges()[0].newest_time).toBe(1517787104908)
     })
   })
 
@@ -404,9 +404,9 @@ describe('Resume Marker Service', function() {
   describe('database stuff', function() {
     var conf = {
       selector: {normalized: 'tests.BTC-USD'},
-      resumeMarkersArray: [	{from: 2994, to: 2998, oldest_time: 99960, newest_time: 99986},
-        {from: 2894, to: 2898, oldest_time: 98960, newest_time: 98986},
-        {from: 2794, to: 2798, oldest_time: 97960, newest_time: 97986}
+      resumeMarkersArray: [	{from: 2994, to: 2998, oldest_time: 1517787104960, newest_time: 1517787104986},
+        {from: 2894, to: 2898, oldest_time: 1517787103960, newest_time: 1517787103986},
+        {from: 2794, to: 2798, oldest_time: 1517787102960, newest_time: 1517787102986}
       ],
       mockDeleteManyFunction: jasmine.createSpy('mockDeleteManyFunction'),
       mockInsertManyFunction: jasmine.createSpy('mockInsertManyFunction')
@@ -444,10 +444,10 @@ describe('Resume Marker Service', function() {
     it('increases, but not when a number is already in range', function() {
       var instance = service(conf)
 
-      var trade = {trade_id:1300, time:990000}
+      var trade = {trade_id:3000, time:1517787104900}
       instance.ping(trade)
 
-      var trade2 = {trade_id:1299, time:989996}
+      var trade2 = {trade_id:2999, time:1517787104896}
       instance.ping(trade2)
 
       // this should already be in range
@@ -459,10 +459,10 @@ describe('Resume Marker Service', function() {
       var instance = service(conf)
       instance.setDirection('forward') // TODO: put this in a constants object			
 
-      var trade = {trade_id:1299, time:990000}
+      var trade = {trade_id:2999, time:1517787104900}
       instance.ping(trade)
 
-      var trade2 = {trade_id:1300, time:989996}
+      var trade2 = {trade_id:3000, time:1517787104896}
       instance.ping(trade2)
 
       // this should already be in range


### PR DESCRIPTION
All the trades used in test now have consistent IDs and timestamps. #sanity 