### PR TITLE
Intro "global" eventEmitter for loosely coupled inter-module communication

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -1,27 +1,37 @@
 var _ = require('lodash')
+var minimist = require('minimist')
+var version = require('./package.json').version
+var EventEmitter = require('events')
 
 module.exports = function (cb) {
-  var zenbot = require('./')
-  var c = getConfiguration()
+  var zenbot = { version }
+  var args = minimist(process.argv.slice(3))
+  var conf
 
-  var defaults = require('./conf-sample')
-  Object.keys(defaults).forEach(function (k) {
-    if (typeof c[k] === 'undefined') {
-      c[k] = defaults[k]
+  if(!_.isUndefined(args.conf)){
+    try {
+      conf = require(args.conf)
+    } catch (ee) {
+      console.log('Fall back to conf.js, ' + ee)
+      conf = require('./conf')
     }
-  })
-  zenbot.conf = c
-
-  function withMongo () {
-    cb(null, zenbot)
+  } else {
+    conf = require('./conf')
   }
 
-  var authStr = '', authMechanism
-  
-  if(c.mongo.username){
-    authStr = encodeURIComponent(c.mongo.username)
+  var defaults = require('./conf-sample')
+  _.defaultsDeep(conf, defaults)
+  zenbot.conf = conf
 
-    if(c.mongo.password) authStr += ':' + encodeURIComponent(c.mongo.password)
+  var eventBus = new EventEmitter()
+  conf.eventBus = eventBus
+
+  var authStr = '', authMechanism, connectionString
+
+  if(conf.mongo.username){
+    authStr = encodeURIComponent(conf.mongo.username)
+
+    if(conf.mongo.password) authStr += ':' + encodeURIComponent(conf.mongo.password)
 
     authStr += '@'
 
@@ -29,55 +39,24 @@ module.exports = function (cb) {
     authMechanism = 'DEFAULT'
   }
 
-  var u = (function() {
-    if (c.mongo.connectionString) {
-      return c.mongo.connectionString
-    }
-
-    return 'mongodb://' + authStr + c.mongo.host + ':' + c.mongo.port + '/' + c.mongo.db + '?' +
-      (c.mongo.replicaSet ? '&replicaSet=' + c.mongo.replicaSet : '' ) +
+  if (conf.mongo.connectionString) {
+    connectionString = conf.mongo.connectionString
+  } else {
+    connectionString = 'mongodb://' + authStr + conf.mongo.host + ':' + conf.mongo.port + '/' + conf.mongo.db + '?' +
+      (conf.mongo.replicaSet ? '&replicaSet=' + conf.mongo.replicaSet : '' ) +
       (authMechanism ? '&authMechanism=' + authMechanism : '' )
-  })()
-  require('mongodb').MongoClient.connect(u, function (err, client) {
+  }
+
+  require('mongodb').MongoClient.connect(connectionString, function (err, client) {
     if (err) {
-      //zenbot.set('zenbot:db.mongo', null)
       console.error('WARNING: MongoDB Connection Error: ', err)
       console.error('WARNING: without MongoDB some features (such as backfilling/simulation) may be disabled.')
-      console.error('Attempted authentication string: ' + u)
-      return withMongo()
+      console.error('Attempted authentication string: ' + connectionString)
+      cb(null, zenbot)
+      return
     }
-    var db = client.db(c.mongo.db)
+    var db = client.db(conf.mongo.db)
     _.set(zenbot, 'conf.db.mongo', db)
-    withMongo()
+    cb(null, zenbot)
   })
-
-  function getConfiguration() {
-    var conf = undefined
-
-    try {
-      var _allArgs = process.argv.slice()
-      var found = false
-
-      while (!found && _allArgs.length > 0) {
-        found = (_allArgs.shift() == '--conf')
-      }
-
-      if (found) {
-        try {
-          conf = require(_allArgs[0])
-        } catch (ee) {
-          console.log('Fall back to conf.js, ' + ee)
-          conf = require('./conf')
-        }
-      } else {
-        conf = require('./conf')
-      }
-    }
-    catch (e) {
-      console.log('Fall back to sample-conf.js, ' + e)
-      conf = {}
-    }
-
-    return conf
-  }
 }

--- a/commands/sim.js
+++ b/commands/sim.js
@@ -47,6 +47,12 @@ module.exports = function (program, conf) {
       var s = { options: minimist(process.argv) }
       var so = s.options
       delete so._
+      if (cmd.conf) { 
+        var overrides = require(path.resolve(process.cwd(), cmd.conf)) 
+        Object.keys(overrides).forEach(function (k) { 
+          so[k] = overrides[k] 
+        }) 
+      }
       Object.keys(conf).forEach(function (k) {
         if (!_.isUndefined(cmd[k])) {
           so[k] = cmd[k]

--- a/commands/sim.js
+++ b/commands/sim.js
@@ -42,6 +42,7 @@ module.exports = function (program, conf) {
     .option('--enable_stats', 'enable printing order stats')
     .option('--backtester_generation <generation>','creates a json file in simulations with the generation number', Number, -1)
     .option('--verbose', 'print status lines on every period')
+    .option('--silent', 'only output on completion (can speed up sim)')
     .action(function (selector, cmd) {
       var s = { options: minimist(process.argv) }
       var so = s.options

--- a/commands/sim.js
+++ b/commands/sim.js
@@ -8,6 +8,7 @@ var tb = require('timebucket')
   , objectifySelector = require('../lib/objectify-selector')
   , engineFactory = require('../lib/engine')
   , collectionService = require('../lib/services/collection-service')
+  , _ = require('lodash')
 
 module.exports = function (program, conf) {
   program
@@ -42,15 +43,16 @@ module.exports = function (program, conf) {
     .option('--backtester_generation <generation>','creates a json file in simulations with the generation number', Number, -1)
     .option('--verbose', 'print status lines on every period')
     .action(function (selector, cmd) {
-      var s = {options: minimist(process.argv)}
+      var s = { options: minimist(process.argv) }
       var so = s.options
       delete so._
       Object.keys(conf).forEach(function (k) {
-        if (typeof cmd[k] !== 'undefined') {
+        if (!_.isUndefined(cmd[k])) {
           so[k] = cmd[k]
         }
       })
       var tradesCollection = collectionService(conf).getTrades()
+      var eventBus = conf.eventBus
 
       if (so.start) {
         so.start = moment(so.start, 'YYYYMMDDhhmm').valueOf()
@@ -77,12 +79,6 @@ module.exports = function (program, conf) {
       so.selector = objectifySelector(selector || conf.selector)
       so.mode = 'sim'
 
-      if (cmd.conf) {
-        var overrides = require(path.resolve(process.cwd(), cmd.conf))
-        Object.keys(overrides).forEach(function (k) {
-          so[k] = overrides[k]
-        })
-      }
       var engine = engineFactory(s, conf)
       if (!so.min_periods) so.min_periods = 1
       var cursor, reversing, reverse_point
@@ -197,7 +193,6 @@ module.exports = function (program, conf) {
           fs.writeFileSync(out_target, out)
           console.log('wrote', out_target)
         }
-
         process.exit(0)
       }
 
@@ -230,34 +225,40 @@ module.exports = function (program, conf) {
           if (!opts.query.time) opts.query.time = {}
           opts.query.time['$gte'] = query_start
         }
-        tradesCollection.find(opts.query).sort(opts.sort).limit(opts.limit).toArray(function (err, trades) {
-          if (err) throw err
-          if (!trades.length) {
+        var collectionCursor = tradesCollection.find(opts.query).sort(opts.sort).stream()
+        var numTrades = 0
+        var lastTrade
+
+        collectionCursor.on('data', function(trade){
+          lastTrade = trade
+          numTrades++
+          if (so.symmetrical && reversing) {
+            trade.orig_time = trade.time
+            trade.time = reverse_point + (reverse_point - trade.time)
+          }
+          eventBus.emit('trade', trade)
+        })
+
+        collectionCursor.on('end', function(){
+          if(numTrades === 0){
             if (so.symmetrical && !reversing) {
               reversing = true
               reverse_point = cursor
               return getNext()
             }
             engine.exit(exitSim)
-          }
-          if (so.symmetrical && reversing) {
-            trades.forEach(function (trade) {
-              trade.orig_time = trade.time
-              trade.time = reverse_point + (reverse_point - trade.time)
-            })
-          }            
-          engine.update(trades, function (err) {
-            if (err) throw err
+          } else {
             if (reversing) {
-              cursor = trades[trades.length - 1].orig_time
+              cursor = lastTrade.orig_time
             }
             else {
-              cursor = trades[trades.length - 1].time
+              cursor = lastTrade.time
             }
-            setImmediate(getNext)
-          })
+          }
+          setImmediate(getNext)
         })
       }
+      
       getNext()
     })
 }

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -57,6 +57,12 @@ module.exports = function (program, conf) {
       var so = s.options
       var botStartTime = moment().add('m',so.run_for)
       delete so._
+      if (cmd.conf) {
+        var overrides = require(path.resolve(process.cwd(), cmd.conf))
+        Object.keys(overrides).forEach(function (k) {
+          so[k] = overrides[k]
+        })
+      }
       Object.keys(conf).forEach(function (k) {
         if (typeof cmd[k] !== 'undefined') {
           so[k] = cmd[k]
@@ -68,12 +74,7 @@ module.exports = function (program, conf) {
       so.debug = cmd.debug
       so.stats = !cmd.disable_stats
       so.mode = so.paper ? 'paper' : 'live'
-      if (cmd.conf) {
-        var overrides = require(path.resolve(process.cwd(), cmd.conf))
-        Object.keys(overrides).forEach(function (k) {
-          so[k] = overrides[k]
-        })
-      }
+      
       so.selector = objectifySelector(selector || conf.selector)
       var exchange = require(`../extensions/exchanges/${so.selector.exchange_id}/exchange`)(conf)
       if (!exchange) {

--- a/commands/train.js
+++ b/commands/train.js
@@ -77,6 +77,12 @@ module.exports = function (program, conf) {
       var s = {options: minimist(process.argv)}
       var so = s.options
       delete so._
+      if (cmd.conf) {
+        var overrides = require(path.resolve(process.cwd(), cmd.conf))
+        Object.keys(overrides).forEach(function (k) {
+          so[k] = overrides[k]
+        })
+      }
       Object.keys(conf).forEach(function (k) {
         if (typeof cmd[k] !== 'undefined') {
           so[k] = cmd[k]
@@ -117,12 +123,7 @@ module.exports = function (program, conf) {
       }
       so.selector = objectifySelector(selector || conf.selector)
       so.mode = 'train'
-      if (cmd.conf) {
-        var overrides = require(path.resolve(process.cwd(), cmd.conf))
-        Object.keys(overrides).forEach(function (k) {
-          so[k] = overrides[k]
-        })
-      }
+      
       var engine = engineFactory(s, conf)
 
       if (!so.min_periods) so.min_periods = 1

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-module.exports = {}
-
-module.exports.version = require('./package.json').version

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -17,6 +17,7 @@ module.exports = function (s, conf) {
   let eventBus = conf.eventBus
   eventBus.on('trade', onTrade)
   eventBus.on('trades', onTrades)
+
   let so = s.options
   s.exchange = require(path.resolve(__dirname, `../extensions/exchanges/${so.selector.exchange_id}/exchange`))(conf)
   s.product_id = so.selector.product_id
@@ -735,8 +736,8 @@ module.exports = function (s, conf) {
   }
 
   function writeReport (is_progress, blink_off) {
-    if(so.silent) return
     if ((so.mode === 'sim' || so.mode === 'train') && !so.verbose) {
+      if(so.silent) return
       is_progress = true
     }
     else if (is_progress && typeof blink_off === 'undefined' && s.vol_since_last_blink) {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -4,16 +4,19 @@ let tb = require('timebucket')
   , n = require('numbro')
   // eslint-disable-next-line no-unused-vars
   , colors = require('colors')
-  , series = require('run-series')
   , abbreviate = require('number-abbreviate')
   , readline = require('readline')
   , path = require('path')
   , notify = require('./notify')
   , rsi = require('./rsi')
+  , _ = require('lodash')
 
 let nice_errors = new RegExp(/(slippage protection|loss protection)/)
 
 module.exports = function (s, conf) {
+  let eventBus = conf.eventBus
+  eventBus.on('trade', onTrade)
+  eventBus.on('trades', onTrades)
   let so = s.options
   s.exchange = require(path.resolve(__dirname, `../extensions/exchanges/${so.selector.exchange_id}/exchange`))(conf)
   s.product_id = so.selector.product_id
@@ -135,6 +138,7 @@ module.exports = function (s, conf) {
 
   function initBuffer (trade) {
     let d = tb(trade.time).resize(so.period_length)
+    let de = tb(trade.time).resize(so.period_length).add(1)
     s.period = {
       period_id: d.toString(),
       size: so.period_length,
@@ -144,16 +148,16 @@ module.exports = function (s, conf) {
       low: trade.price,
       close: trade.price,
       volume: 0,
-      close_time: null
+      close_time: de.toMilliseconds() - 1
     }
   }
 
-  function onTrade (trade) {
+  function updatePeriod(trade) {
     s.period.high = Math.max(trade.price, s.period.high)
     s.period.low = Math.min(trade.price, s.period.low)
     s.period.close = trade.price
     s.period.volume += trade.size
-    s.period.close_time = trade.time
+    s.period.latest_trade_time = trade.time
     s.strategy.calculate(s)
     s.vol_since_last_blink += trade.size
     if (s.trades && s.last_trade_id !== trade.trade_id) {
@@ -242,8 +246,8 @@ module.exports = function (s, conf) {
     order.price = opts.price
     order.size = opts.size
     if (so.mode !== 'live') {
-      if (!order.orig_time) order.orig_time = s.period.close_time
-      order.time = s.period.close_time
+      if (!order.orig_time) order.orig_time = s.period.latest_trade_time
+      order.time = s.period.latest_trade_time
       return cb(null, order)
     }
     else {
@@ -731,6 +735,7 @@ module.exports = function (s, conf) {
   }
 
   function writeReport (is_progress, blink_off) {
+    if(so.silent) return
     if ((so.mode === 'sim' || so.mode === 'train') && !so.verbose) {
       is_progress = true
     }
@@ -751,7 +756,7 @@ module.exports = function (s, conf) {
     }
     readline.clearLine(process.stdout)
     readline.cursorTo(process.stdout, 0)
-    process.stdout.write(moment(is_progress ? s.period.close_time : tb(s.period.time).resize(so.period_length).add(1).toMilliseconds()).format('YYYY-MM-DD HH:mm:ss')[is_progress && !blink_off ? 'bgBlue' : 'grey'])
+    process.stdout.write(moment(is_progress ? s.period.latest_trade_time : tb(s.period.time).resize(so.period_length).add(1).toMilliseconds()).format('YYYY-MM-DD HH:mm:ss')[is_progress && !blink_off ? 'bgBlue' : 'grey'])
     process.stdout.write('  ' + fc(s.period.close, true, true, true) + ' ' + s.product_id.grey)
     if (s.lookback[0]) {
       let diff = (s.period.close - s.lookback[0].close) / s.lookback[0].close
@@ -835,6 +840,88 @@ module.exports = function (s, conf) {
     }
   }
 
+  function withOnPeriod (trade, period_id) {
+    updatePeriod(trade)
+    if (!s.in_preroll) {
+      if (so.mode !== 'live' && !s.start_capital) {
+        s.start_capital = 0
+        s.start_price = trade.price
+        if (so.asset_capital) {
+          s.start_capital += so.asset_capital * s.start_price
+        }
+        if (so.currency_capital) {
+          s.start_capital += so.currency_capital
+        }
+      }
+      if (!so.manual) {
+        executeStop()
+        if (s.signal) {
+          executeSignal(s.signal)
+          s.signal = null
+        }
+      }
+      if (so.mode !== 'live') {
+        adjustBid(trade)
+        executeOrder(trade)
+      }
+    }
+    s.last_period_id = period_id
+  }
+
+  function onTrade(trade, is_preroll) {
+    if (s.period && trade.time < s.period.time) {
+      return
+    }
+    var day = (new Date(trade.time)).getDate()
+    if (s.last_day && s.last_day && day !== s.last_day) {
+      s.day_count++
+    }
+    s.last_day = day
+    if (!s.period) {
+      initBuffer(trade)
+    }
+    s.in_preroll = is_preroll || (so.start && trade.time < so.start)
+    if (trade.time > s.period.close_time) {
+      var period_id = tb(trade.time).resize(so.period_length).toString()
+      s.strategy.onPeriod.call(s.ctx, s, function () {
+        writeReport()
+        s.acted_on_stop = false
+        if (!s.in_preroll && !so.manual) {
+          executeStop(true)
+          if (s.signal) {
+            executeSignal(s.signal)
+          }
+        }
+        s.lookback.unshift(s.period)
+        s.action = null
+        s.signal = null
+        initBuffer(trade)
+        withOnPeriod(trade, period_id)
+      })
+    }
+    else {
+      withOnPeriod(trade, period_id)
+    }
+  }
+  
+  function onTrades(trades, is_preroll, cb) {
+    if (_.isFunction(is_preroll)) {
+      cb = is_preroll
+      is_preroll = false
+    }
+    trades.sort(function (a, b) {
+      if (a.time < b.time) return -1
+      if (a.time > b.time) return 1
+      return 0
+    })
+    var local_trades = trades.slice(0)
+    var trade
+    while( (trade = local_trades.shift()) !== undefined ) {
+      onTrade(trade, is_preroll)
+    }
+    if(_.isFunction(cb)) cb()
+  }
+
   return {
     writeHeader: function () {
       process.stdout.write([
@@ -848,84 +935,7 @@ module.exports = function (s, conf) {
         z(22, 'PROFIT', ' ').grey
       ].join('') + '\n')
     },
-    update: function (trades, is_preroll, cb) {
-      if (typeof is_preroll === 'function') {
-        cb = is_preroll
-        is_preroll = false
-      }
-      trades.sort(function (a, b) {
-        if (a.time < b.time) return -1
-        if (a.time > b.time) return 1
-        return 0
-      })
-      let tasks = trades.map(function (trade) {
-        return function (done) {
-          if (s.period && trade.time < s.period.time) {
-            return done()
-          }
-          let period_id = tb(trade.time).resize(so.period_length).toString()
-          let day = tb(trade.time).resize('1d')
-          if (s.last_day && s.last_day.toString() && day.toString() !== s.last_day.toString()) {
-            s.day_count++
-          }
-          s.last_day = day
-          if (!s.period) {
-            initBuffer(trade)
-          }
-          s.in_preroll = is_preroll || (so.start && trade.time < so.start)
-          if (period_id !== s.period.period_id) {
-            s.strategy.onPeriod.call(s.ctx, s, function () {
-              s.acted_on_stop = false
-              if (!s.in_preroll && !so.manual) {
-                executeStop(true)
-                if (s.signal) {
-                  executeSignal(s.signal)
-                }
-              }
-              writeReport()
-              s.lookback.unshift(s.period)
-              s.action = null
-              s.signal = null
-              initBuffer(trade)
-              withOnPeriod()
-            })
-          }
-          else {
-            withOnPeriod()
-          }
-          function withOnPeriod () {
-            onTrade(trade)
-            if (!s.in_preroll) {
-              if (so.mode !== 'live' && !s.start_capital) {
-                s.start_capital = 0
-                s.start_price = trade.price
-                if (so.asset_capital) {
-                  s.start_capital += so.asset_capital * s.start_price
-                }
-                if (so.currency_capital) {
-                  s.start_capital += so.currency_capital
-                }
-              }
-              if (!so.manual) {
-                executeStop()
-                if (s.signal) {
-                  executeSignal(s.signal)
-                  s.signal = null
-                }
-              }
-              if (so.mode !== 'live') {
-                adjustBid(trade)
-                executeOrder(trade)
-              }
-            }
-            s.last_period_id = period_id
-            setImmediate(done)
-          }
-        }
-      })
-      series(tasks, cb)
-    },
-
+    update: onTrades,
     exit: function (cb) {
       if(s.strategy.onExit) {
         s.strategy.onExit.call( s.ctx, s )

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "random-port": "^0.1.0",
     "regression": "^2.0.0",
     "resolve-url-loader": "^2.2.1",
-    "run-series": "^1.1.4",
     "sass-loader": "^6.0.6",
     "semver": "^5.4.1",
     "simple-xmpp": "^1.3.0",

--- a/zenbot.js
+++ b/zenbot.js
@@ -1,9 +1,7 @@
 
 var semver = require('semver')
 var path = require('path')
-var version = require('./package.json').version
 var program = require('commander')
-program.version(version)
 program._name = 'zenbot'
 
 var versions = process.versions
@@ -17,10 +15,13 @@ var fs = require('fs')
   , boot = require('./boot')
 
 boot(function (err, zenbot) {
-  var command_name = process.argv[2]
   if (err) {
     throw err
   }
+  program.version(zenbot.version)
+
+  var command_name = process.argv[2]
+  
   var command_directory = './commands'
   fs.readdir(command_directory, function(err, files){
     if (err) {
@@ -51,6 +52,5 @@ boot(function (err, zenbot) {
       program.help()
     }
     program.parse(process.argv)
-    
   })
 })


### PR DESCRIPTION
This PR introduces a concept (or [architecture](https://en.wikipedia.org/wiki/Event-driven_architecture)) I'd like to gradually develop into a main paradigm within the app of a more or less globally available (i.e. on the `conf` object that gets passed to pretty much every module) [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) that will allow modules to subscribe to specific types of events and publish specific types of events as necessary. The [pub/sub](https://en.wikipedia.org/wiki/Publish–subscribe_pattern) style is a well established paradigm that works well for apps with a sort of "plugin" style architecture that Zenbot currently leans toward (for things like `output` and `notifiers` specifically, but even `strategies` and `exchanges` can fall into that category too). 

In this PR, I've only really moved the `sim` command over as a beginning point, with some modifications to `engine` to support it. Instead of `engine` repeatedly polling for sets of trades from `sim`, now it can simply set a handler for `trade` events from the global eventBus and `sim` can `emit` `trade`s on the global eventBus. Neither of them need to call each other's functions directly. Since this takes out the repeat call/callback model, `sim` is free to publish events to the bus directly from the database stream instead of buffering into an `Array` first, letting us remove our query limit and allowing for much better overall memory consumption and garbage collection by the runtime (all references to `trade` are dead almost immediately after `onTrade`). 

Unraveling the `update` function in `engine` led to a clear opportunity to get rid of the `run-series` call which I believe was leading to some maximum call stack issues for some people since each trade callback would execute the next. I left the function signature as is for now until more pieces of the app (specifically `trade`) get updated to use the eventBus. 

I also took a little time to clean up the boot/index/zenbot.js situation which was doing a handful of things that were either unnecessary or not useful. `sim` was also trying to take a second stab at overrides from `conf` where the command line arguments should have the final override.

And finally, introduces a `--silent` option for `sim` which simply doesn't output anything until the sim has completed. This can significantly speed up the execution time of the sim (up to %50+ for small period lengths that have a lot of period reports) and can be very useful in `darwin` where the output isn't super useful. Using this option does have the side effect of not getting all the nice reporting from the new darwin progress interface, but I prefer the speed over the stats and it's optional, so people can pick.

As always, totally open to feedback/discussion.