### PR TITLE
only instantiate one copy of an exchange

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -77,8 +77,8 @@ module.exports = function (program, conf) {
         })
       }
       so.selector = objectifySelector(selector || conf.selector)
-      var exchange = require(`../extensions/exchanges/${so.selector.exchange_id}/exchange`)(conf)
-      if (!exchange) {
+      s.exchange = require(`../extensions/exchanges/${so.selector.exchange_id}/exchange`)(conf)
+      if (!s.exchange) {
         console.error('cannot trade ' + so.selector.normalized + ': exchange not implemented')
         process.exit(1)
         
@@ -514,7 +514,7 @@ module.exports = function (program, conf) {
               return
             }
             db_cursor = trades[trades.length - 1].time
-            trade_cursor = exchange.getCursor(trades[trades.length - 1])
+            trade_cursor = s.exchange.getCursor(trades[trades.length - 1])
             engine.update(trades, true, function (err) {
               if (err) throw err
               setImmediate(getNext)
@@ -602,7 +602,7 @@ module.exports = function (program, conf) {
           })
         }
         var opts = {product_id: so.selector.product_id, from: trade_cursor}
-        exchange.getTrades(opts, function (err, trades) {
+        s.exchange.getTrades(opts, function (err, trades) {
           if (err) {
             if (err.code === 'ETIMEDOUT' || err.code === 'ENOTFOUND' || err.code === 'ECONNRESET') {
               if (prev_timeout) {
@@ -630,7 +630,7 @@ module.exports = function (program, conf) {
               return 0
             })
             trades.forEach(function (trade) {
-              var this_cursor = exchange.getCursor(trade)
+              var this_cursor = s.exchange.getCursor(trade)
               trade_cursor = Math.max(this_cursor, trade_cursor)
               saveTrade(trade)
             })

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -8,6 +8,7 @@ let tb = require('timebucket')
   , abbreviate = require('number-abbreviate')
   , readline = require('readline')
   , path = require('path')
+  , _ = require('lodash')
   , notify = require('./notify')
   , rsi = require('./rsi')
 
@@ -15,7 +16,9 @@ let nice_errors = new RegExp(/(slippage protection|loss protection)/)
 
 module.exports = function (s, conf) {
   let so = s.options
-  s.exchange = require(path.resolve(__dirname, `../extensions/exchanges/${so.selector.exchange_id}/exchange`))(conf)
+  if(_.isUndefined(s.exchange)){
+    s.exchange = require(path.resolve(__dirname, `../extensions/exchanges/${so.selector.exchange_id}/exchange`))(conf)
+  }
   s.product_id = so.selector.product_id
   s.asset = so.selector.asset
   s.currency = so.selector.currency


### PR DESCRIPTION
This just makes it so that `trade` isn't making it's own instantiated copy of an `exchange` and letting `engine` make another. Instead, it will instantiate one and attach it to `s`, which `engine` can check for before instantiating it's own. `engine` does need to instantiate one for all the other commands that call for it, so it maintains that ability in the case that it hasn't been done already.