### PR TITLE
setup queue to handle async strategy execution

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -10,12 +10,13 @@ let tb = require('timebucket')
   , _ = require('lodash')
   , notify = require('./notify')
   , rsi = require('./rsi')
+  , async = require('async')
 
 let nice_errors = new RegExp(/(slippage protection|loss protection)/)
 
 module.exports = function (s, conf) {
   let eventBus = conf.eventBus
-  eventBus.on('trade', onTrade)
+  eventBus.on('trade', queueTrade)
   eventBus.on('trades', onTrades)
 
   let so = s.options
@@ -843,7 +844,7 @@ module.exports = function (s, conf) {
     }
   }
 
-  function withOnPeriod (trade, period_id) {
+  function withOnPeriod (trade, period_id, cb) {
     updatePeriod(trade)
     if (!s.in_preroll) {
       if (so.mode !== 'live' && !s.start_capital) {
@@ -869,9 +870,18 @@ module.exports = function (s, conf) {
       }
     }
     s.last_period_id = period_id
+    cb()
   }
 
-  function onTrade(trade, is_preroll) {
+  var q = async.queue(function(trade, callback){
+    onTrade(trade, null, callback)
+  })
+
+  function queueTrade(trade){
+    q.push(trade)
+  }
+
+  function onTrade(trade, is_preroll, cb) {
     if (s.period && trade.time < s.period.time) {
       return
     }
@@ -899,11 +909,11 @@ module.exports = function (s, conf) {
         s.action = null
         s.signal = null
         initBuffer(trade)
-        withOnPeriod(trade, period_id)
+        withOnPeriod(trade, period_id, cb)
       })
     }
     else {
-      withOnPeriod(trade, period_id)
+      withOnPeriod(trade, period_id, cb)
     }
   }
   
@@ -920,7 +930,7 @@ module.exports = function (s, conf) {
     var local_trades = trades.slice(0)
     var trade
     while( (trade = local_trades.shift()) !== undefined ) {
-      onTrade(trade, is_preroll)
+      queueTrade(trade)
     }
     if(_.isFunction(cb)) cb()
   }


### PR DESCRIPTION
When the strategy `onPeriod` function is asynchronous (like the `ta_` strategies), the event stream can get ahead of itself (attempting to process new trades before the period calculations have completed). This adds an internal queue to ensure that all trades are processed in serially in order.