### PR TITLE
re-fix require cache issue with conf file and cyclical reference session

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -22,10 +22,10 @@ module.exports = function (cb) {
 
   var defaults = require('./conf-sample')
   _.defaultsDeep(conf, defaults)
-  zenbot.conf = conf
+  zenbot.conf = _.cloneDeep(conf)
 
   var eventBus = new EventEmitter()
-  conf.eventBus = eventBus
+  zenbot.conf.eventBus = eventBus
 
   var authStr = '', authMechanism, connectionString
 


### PR DESCRIPTION
The fix with the clone of the conf that prevented having the require() cached version getting the db tacked onto it and causing the session save issues got overwritten a bit in the merge to add the eventemitter. This just puts it back.