### PR TITLE
Faster Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM node:8
 RUN mkdir -p /app
 WORKDIR /app
 
-COPY . /app
 RUN npm install -g node-gyp
+COPY package-lock.json package.json post_install.js ./
 RUN npm install --unsafe
+COPY . .
 
 RUN ln -s /app/zenbot.sh /usr/local/bin/zenbot
 


### PR DESCRIPTION
avoid downloading the dependencies in each build, they are downloaded only if the package-lock.json or package.json is modified