### PR TITLE
Reorder and fix config file loading

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -8,16 +8,9 @@ module.exports = function (cb) {
   var zenbot = { version }
   var args = minimist(process.argv.slice(3))
   var conf = {}
+  var config
 
-  // 1. load default config
-  try {
-    defaults = require('./conf')
-  } catch (err) {
-    console.error(err + ', falling back to conf-sample.js')
-    defaults = require('./conf-sample')
-  }
-
-  // 2. load custom config
+  // 1. load conf overrides file if present
   if(!_.isUndefined(args.conf)){
     try {
       conf = require(path.resolve(process.cwd(), args.conf))
@@ -26,8 +19,16 @@ module.exports = function (cb) {
     }
   }
 
-  // 3. Merge them
-  _.defaultsDeep(conf, defaults)
+  // 2. load conf.js if present
+  try {
+    config = require('./conf')
+  } catch (err) {
+    console.error(err + ', falling back to conf-sample')
+  }
+
+  // 3. Load conf-sample.js and merge
+  var defaults = require('./conf-sample')
+  _.defaultsDeep(conf, config, defaults)
   zenbot.conf = _.cloneDeep(conf)
 
   var eventBus = new EventEmitter()

--- a/boot.js
+++ b/boot.js
@@ -7,20 +7,26 @@ var EventEmitter = require('events')
 module.exports = function (cb) {
   var zenbot = { version }
   var args = minimist(process.argv.slice(3))
-  var conf
+  var conf = {}
 
+  // 1. load default config
+  try {
+    defaults = require('./conf')
+  } catch (err) {
+    console.error(err + ', falling back to conf-sample.js')
+    defaults = require('./conf-sample')
+  }
+
+  // 2. load custom config
   if(!_.isUndefined(args.conf)){
     try {
       conf = require(path.resolve(process.cwd(), args.conf))
     } catch (err) {
-      console.log('Fall back to conf.js, ' + err)
-      conf = require('./conf')
+      console.error(err + ', failed to load conf overrides file!')
     }
-  } else {
-    conf = require('./conf')
   }
 
-  var defaults = require('./conf-sample')
+  // 3. Merge them
   _.defaultsDeep(conf, defaults)
   zenbot.conf = _.cloneDeep(conf)
 


### PR DESCRIPTION
This is a rework of #1327

Fixes:
* If conf.js is missing fall back to conf-sample as "default" config
* --~~conf oddly looking for the config file in the selector directory~~ this is actually just a display bug because the error message uses `__dirname` instead of `process.cwd()` the real problem gets fixed by above

Config files will now get loaded in this order on boot:

1. conf overrides file if provided by `--conf`
2. `conf.js` if present
3. and finally `conf-sample.js` to fill up possible blanks

Priority of the settings (from left to right) are `--conf -> conf.js -> conf-sample.js`