### PR TITLE
Add buy loss protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ zenbot trade --help
     --profit_stop_enable_pct <pct>  enable trailing sell stop when reaching this % profit
     --profit_stop_pct <pct>         maintain a trailing stop this % below the high-water mark of profit
     --max_sell_loss_pct <pct>       avoid selling at a loss pct under this float
+    --max_buy_loss_pct <pct>        avoid buying at a loss pct over this float
     --max_slippage_pct <pct>        avoid selling at a slippage pct above this float
     --rsi_periods <periods>         number of periods to calculate RSI at
     --poll_trades <ms>              poll new trades at this interval in ms

--- a/commands/sim.js
+++ b/commands/sim.js
@@ -35,6 +35,7 @@ module.exports = function (program, conf) {
     .option('--profit_stop_enable_pct <pct>', 'enable trailing sell stop when reaching this % profit', Number, conf.profit_stop_enable_pct)
     .option('--profit_stop_pct <pct>', 'maintain a trailing stop this % below the high-water mark of profit', Number, conf.profit_stop_pct)
     .option('--max_sell_loss_pct <pct>', 'avoid selling at a loss pct under this float', conf.max_sell_loss_pct)
+    .option('--max_buy_loss_pct <pct>', 'avoid buying at a loss pct over this float', conf.max_buy_loss_pct)
     .option('--max_slippage_pct <pct>', 'avoid selling at a slippage pct above this float', conf.max_slippage_pct)
     .option('--symmetrical', 'reverse time at the end of the graph, normalizing buy/hold to 0', conf.symmetrical)
     .option('--rsi_periods <periods>', 'number of periods to calculate RSI at', Number, conf.rsi_periods)

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -41,6 +41,7 @@ module.exports = function (program, conf) {
     .option('--profit_stop_enable_pct <pct>', 'enable trailing sell stop when reaching this % profit', Number, conf.profit_stop_enable_pct)
     .option('--profit_stop_pct <pct>', 'maintain a trailing stop this % below the high-water mark of profit', Number, conf.profit_stop_pct)
     .option('--max_sell_loss_pct <pct>', 'avoid selling at a loss pct under this float', conf.max_sell_loss_pct)
+    .option('--max_buy_loss_pct <pct>', 'avoid buying at a loss pct over this float', conf.max_buy_loss_pct)
     .option('--max_slippage_pct <pct>', 'avoid selling at a slippage pct above this float', conf.max_slippage_pct)
     .option('--rsi_periods <periods>', 'number of periods to calculate RSI at', Number, conf.rsi_periods)
     .option('--poll_trades <ms>', 'poll new trades at this interval in ms', Number, conf.poll_trades)

--- a/conf-sample.js
+++ b/conf-sample.js
@@ -129,6 +129,8 @@ c.sell_pct = 99
 c.order_adjust_time = 5000
 // avoid selling at a loss below this pct set to 0 to ensure selling at a higher price...
 c.max_sell_loss_pct = 25
+// avoid buying at a loss above this pct set to 0 to ensure buying at a lower price...
+c.max_buy_loss_pct = 25
 // ms to poll order status
 c.order_poll_time = 5000
 // ms to wait for settlement (after an order cancel)

--- a/extensions/strategies/neural/conf-example.js
+++ b/extensions/strategies/neural/conf-example.js
@@ -126,6 +126,8 @@ c.sell_pct = 100
 c.order_adjust_time = 15000
 // avoid selling at a loss below this pct set to 0 to ensure selling at a higher price...
 c.max_sell_loss_pct = 25
+// avoid buying at a loss above this pct set to 0 to ensure buying at a lower price...
+c.max_buy_loss_pct = 25
 // ms to poll order status
 c.order_poll_time = 15000
 // ms to wait for settlement (after an order cancel)

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -491,25 +491,33 @@ module.exports = function (s, conf) {
                 s.last_sell_price = prev_sells[0].price
               }
             }
-            if (s.buy_order && so.max_slippage_pct != null) {
-              let slippage = n(price).subtract(s.buy_order.orig_price).divide(s.buy_order.orig_price).multiply(100).value()
-              if (so.max_slippage_pct != null && slippage > so.max_slippage_pct) {
-                let err = new Error('\nslippage protection')
-                err.desc = 'refusing to buy at ' + fc(price) + ', slippage of ' + pct(slippage / 100)
-                return cb(err)
-              }
-            }
-            if (n(s.balance.currency).subtract(s.balance.currency_hold || 0).value() < n(price).multiply(size).value() && s.balance.currency_hold > 0) {
-              msg('buy delayed: ' + pct(n(s.balance.currency_hold || 0).divide(s.balance.currency).value()) + ' of funds (' + fc(s.balance.currency_hold) + ') on hold')
-              return setTimeout(function () {
-                if (s.last_signal === signal) {
-                  executeSignal(signal, cb, size, true)
-                }
-              }, conf.wait_for_settlement)
+            let buy_loss = s.last_sell_price ? (s.last_sell_price - Number(price)) / s.last_sell_price * -100 : null
+            if (so.max_buy_loss_pct != null && buy_loss > so.max_buy_loss_pct) {
+              let err = new Error('\nloss protection')
+              err.desc = 'refusing to buy at ' + fc(price) + ', buy loss of ' + pct(buy_loss / 100)
+              return cb(err)
             }
             else {
-              pushMessage('Buying ' + s.exchange.name.toUpperCase(), 'placing buy order at ' + fc(price) + ', ' + fc(quote.bid - Number(price)) + ' under best bid\n')
-              doOrder()
+              if (s.buy_order && so.max_slippage_pct != null) {
+                let slippage = n(price).subtract(s.buy_order.orig_price).divide(s.buy_order.orig_price).multiply(100).value()
+                if (so.max_slippage_pct != null && slippage > so.max_slippage_pct) {
+                  let err = new Error('\nslippage protection')
+                  err.desc = 'refusing to buy at ' + fc(price) + ', slippage of ' + pct(slippage / 100)
+                  return cb(err)
+                }
+              }
+              if (n(s.balance.currency).subtract(s.balance.currency_hold || 0).value() < n(price).multiply(size).value() && s.balance.currency_hold > 0) {
+                msg('buy delayed: ' + pct(n(s.balance.currency_hold || 0).divide(s.balance.currency).value()) + ' of funds (' + fc(s.balance.currency_hold) + ') on hold')
+                return setTimeout(function () {
+                  if (s.last_signal === signal) {
+                    executeSignal(signal, cb, size, true)
+                  }
+                }, conf.wait_for_settlement)
+              }
+              else {
+                pushMessage('Buying ' + s.exchange.name.toUpperCase(), 'placing buy order at ' + fc(price) + ', ' + fc(quote.bid - Number(price)) + ' under best bid\n')
+                doOrder()
+              }
             }
           }
           else {


### PR DESCRIPTION
Works the same as sell loss protection but for buy orders.

As always be careful and avoid setting this to low as it might stop the bot from trading at all if the market moved significantly between two periods.