### PR TITLE
preserve is_preroll from batch updates

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -879,14 +879,14 @@ module.exports = function (s, conf) {
     }
     s.last_period_id = period_id
     cb()
-  }
+  } 
 
-  var q = async.queue(function(trade, callback){
-    onTrade(trade, null, callback)
+  var q = async.queue(function({trade, is_preroll}, callback){
+    onTrade(trade, is_preroll, callback)
   })
 
-  function queueTrade(trade){
-    q.push(trade)
+  function queueTrade(trade, is_preroll){
+    q.push({trade, is_preroll})
   }
 
   function onTrade(trade, is_preroll, cb) {
@@ -938,7 +938,7 @@ module.exports = function (s, conf) {
     var local_trades = trades.slice(0)
     var trade
     while( (trade = local_trades.shift()) !== undefined ) {
-      queueTrade(trade)
+      queueTrade(trade, is_preroll)
     }
     if(_.isFunction(cb)) cb()
   }


### PR DESCRIPTION
Lets the `is_preroll` argument be preserved in processing incoming trades. 