### PR TITLE
properly initialize websocket if non-auth config

### DIFF
--- a/extensions/exchanges/gdax/exchange.js
+++ b/extensions/exchanges/gdax/exchange.js
@@ -17,12 +17,16 @@ module.exports = function gdax (conf) {
     if (!websocket_client[product_id]) {
       var auth = null
       var client_state = {}
-      auth = {
-        key: conf.gdax.key, 
-        secret: conf.gdax.b64secret, 
-        passphrase: conf.gdax.passphrase
+      if(conf.gdax.key && conf.gdax.key !== 'YOUR-API-KEY'){
+        auth = {
+          key: conf.gdax.key, 
+          secret: conf.gdax.b64secret, 
+          passphrase: conf.gdax.passphrase
+        }
       }
-      websocket_client[product_id] = new Gdax.WebsocketClient([product_id], conf.gdax.websocketURI, auth, {channels: ['matches', 'user', 'ticker']})
+      var channels = ['matches', 'ticker']
+      if(auth) { channels.push('user') }
+      websocket_client[product_id] = new Gdax.WebsocketClient([product_id], conf.gdax.websocketURI, auth, {channels})
       // initialize a cache for the websocket connection
       websocket_cache[product_id] = {
         trades: [],


### PR DESCRIPTION
Only pass in the `auth` object if it contains potentially valid configuration values and only subscribe to the `user` channel on the websocket if we have some form of `auth` attempt. Otherwise the websocket will return an error message and attempt to reconnect every `poll_trades` interval. This probably doesn't come up too often as people aren't often running the bot against an exchange without valid credentials, but it's nice if you just want to have an instance with no real config running for constant backfill.