### PR TITLE
Actually use avg_slippage_pct to adjust balances

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -633,6 +633,7 @@ module.exports = function (s, conf) {
           if (so.order_type === 'maker') {
             price = n(s.buy_order.price).add(n(s.buy_order.price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
             if (s.exchange.makerFee) {
+              fee = n(s.buy_order.size).multiply(s.exchange.makerFee / 100).value()
               s.balance.asset = n(s.balance.asset).subtract(fee).format('0.00000000')
             }
           }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -633,7 +633,6 @@ module.exports = function (s, conf) {
           if (so.order_type === 'maker') {
             price = n(s.buy_order.price).add(n(s.buy_order.price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
             if (s.exchange.makerFee) {
-              fee = n(s.buy_order.size).multiply(s.exchange.makerFee / 100).value()
               s.balance.asset = n(s.balance.asset).subtract(fee).format('0.00000000')
             }
           }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -630,8 +630,6 @@ module.exports = function (s, conf) {
         }
         if (so.mode !== 'live') {
           s.balance.asset = n(s.balance.asset).add(s.buy_order.size).format('0.00000000')
-          let total = n(price).multiply(s.buy_order.size)
-          s.balance.currency = n(s.balance.currency).subtract(total).format('0.00000000')
           if (so.order_type === 'maker') {
             price = n(s.buy_order.price).add(n(s.buy_order.price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
             if (s.exchange.makerFee) {
@@ -643,6 +641,8 @@ module.exports = function (s, conf) {
               s.balance.asset = n(s.balance.asset).subtract(fee).format('0.00000000')
             }
           }
+          let total = n(price).multiply(s.buy_order.size)
+          s.balance.currency = n(s.balance.currency).subtract(total).format('0.00000000')
         }
         s.action = 'bought'
         let my_trade = {
@@ -690,11 +690,10 @@ module.exports = function (s, conf) {
         }
         if (so.mode !== 'live') {
           s.balance.asset = n(s.balance.asset).subtract(s.sell_order.size).value()
-          let total = n(price).multiply(s.sell_order.size)
-          s.balance.currency = n(s.balance.currency).add(total).value()
           if (so.order_type === 'maker') {
             price = n(s.sell_order.price).subtract(n(s.sell_order.price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
             if (s.exchange.makerFee) {
+              fee = n(s.sell_order.size).multiply(s.exchange.makerFee / 100).multiply(price).value()
               s.balance.currency = n(s.balance.currency).subtract(fee).format('0.00000000')
             }
           }
@@ -703,6 +702,8 @@ module.exports = function (s, conf) {
               s.balance.currency = n(s.balance.currency).subtract(fee).format('0.00000000')
             }
           }
+          let total = n(price).multiply(s.sell_order.size)
+          s.balance.currency = n(s.balance.currency).add(total).value()
         }
         s.action = 'sold'
         let my_trade = {


### PR DESCRIPTION
Discovered a bug where currently the `balance.currency` get's adjusted with a `price` _before_ that `price` is adjusted with potential `avg_slippage_pct`. Also, the `fee` is being calculated off the `price` before applying the `avg_slippage_pct`. In it's current state, `avg_slippage_pct` has no effect on the running and final balance - only the price that gets recorded in an individual trade (in the `my_trades`) array, but that's not used in any of the final calculations (i.e. `vsBuyHold`, `profit`, etc) - only the `balance.currency` is. Once taking the `avg_slippage_pct` into account for the `balance.currency`, simulations seem to, in general, perform worse (and most likely more in-line with reality). 