### PR TITLE
Improve buy order size calculation

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -471,12 +471,16 @@ module.exports = function (s, conf) {
                 let to_buy_pct = n(so.buy_pct).subtract(held_pct).value()
                 buy_pct = to_buy_pct
               }
-              if (so.order_type === 'maker') {
-                size = n(s.balance.currency).multiply(buy_pct).divide(100).multiply(s.exchange.makerFee / 100).format('0.00000000')
+              fee = so.order_type === 'maker' ? s.exchange.makerFee : s.exchange.takerFee
+              trade_balance = n(s.balance.currency).divide(100).multiply(buy_pct)
+              tradeable_balance = n(s.balance.currency).divide(100 + fee).multiply(buy_pct)
+              expected_fee = n(trade_balance).subtract(tradeable_balance).format('0.00000000', Math.ceil) // round up as the exchange will too
+              if (buy_pct + fee < 100) {
+                size = n(tradeable_balance).divide(price).format('0.00000000')
               } else {
-                size = n(s.balance.currency).multiply(buy_pct).divide(100).multiply(s.exchange.takerFee / 100).format('0.00000000')
+                size = n(trade_balance).subtract(expected_fee).divide(price).format('0.00000000')
               }
-              size = n(s.balance.currency).multiply(buy_pct).divide(100).subtract(size).divide(price).format('0.00000000')
+              msg('preparing buy order over ' + fa(size) + ' which equals to ' + buy_pct + '% of our ' + fc(tradeable_balance) + ' tradeable balance with a expected fee of ' + fc(expected_fee))
             } else {
               size = n(s.balance.currency).multiply(so.buy_pct).divide(100).divide(price).format('0.00000000')
             }


### PR DESCRIPTION
This should overall improve sizing our buy orders closer to `buy_pct` and probably even fix one or another `insufficient funds` errors if `buy_pct` plus `fee` is equal or greater than 100% of our balance.