### PR TITLE
Implement sim exchange to make sim perform more like live

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ zenbot trade --help
     --poll_trades <ms>              poll new trades at this interval in ms
     --currency_increment <amount>   Currency increment, if different than the asset increment; e.g. 0.000001
     --use_prev_trades               load and use previous trades for stop-order triggers and loss protection
+    --exact_buy_orders              instead of only adjusting maker buy when the price goes up, adjust it if price has changed at all
+    --exact_sell_orders             instead of only adjusting maker sell when the price goes down, adjust it if price has changed at all
     --disable_stats                 disable printing order stats
     --reset_profit                  start new profit calculation from 0
     --debug                         output detailed debug info
@@ -506,7 +508,7 @@ ta_macd_ext
     --down_trend_threshold=<value>  threshold to trigger a sold signal (default: 0)
     --overbought_rsi_periods=<value>  number of periods for overbought RSI (default: 25)
     --overbought_rsi=<value>  sold when RSI exceeds this value (default: 70)
-    
+
 ta_trix
   description:
     TRIX - 1-day Rate-Of-Change (ROC) of a Triple Smooth EMA with rsi oversold
@@ -552,7 +554,7 @@ ta_ultosc
     --timeperiod3=<value>  talib ULTOSC timeperiod3 (default: 28)
     --overbought_rsi_periods=<value>  number of periods for overbought RSI (default: 25)
     --overbought_rsi=<value>  sold when RSI exceeds this value (default: 90)
-    
+
 trendline
   description:
     Calculate a trendline and trade when trend is positive vs negative.
@@ -580,7 +582,7 @@ trust_distrust
     --buy_threshold=<value>  buy when the bottom increased at least above this percentage (default: 2)
     --buy_threshold_max=<value>  wait for multiple buy signals before buying (kill whipsaw, 0 to disable) (default: 0)
     --greed=<value>  sell if we reach this much profit (0 to be greedy and either win or lose) (default: 0)
-    
+
 wavetrend
   description:
     Buy when (Signal < Oversold) and sell when (Signal > Overbought).

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -47,6 +47,8 @@ module.exports = function (program, conf) {
     .option('--poll_trades <ms>', 'poll new trades at this interval in ms', Number, conf.poll_trades)
     .option('--currency_increment <amount>', 'Currency increment, if different than the asset increment', String, null)
     .option('--keep_lookback_periods <amount>', 'Keep this many lookback periods max. ', Number, conf.keep_lookback_periods)
+    .option('--exact_buy_orders', 'instead of only adjusting maker buy when the price goes up, adjust it if price has changed at all')
+    .option('--exact_sell_orders', 'instead of only adjusting maker sell when the price goes down, adjust it if price has changed at all')
     .option('--use_prev_trades', 'load and use previous trades for stop-order triggers and loss protection')
     .option('--disable_stats', 'disable printing order stats')
     .option('--reset_profit', 'start new profit calculation from 0')
@@ -77,13 +79,13 @@ module.exports = function (program, conf) {
       so.debug = cmd.debug
       so.stats = !cmd.disable_stats
       so.mode = so.paper ? 'paper' : 'live'
-      
+
       so.selector = objectifySelector(selector || conf.selector)
       s.exchange = require(`../extensions/exchanges/${so.selector.exchange_id}/exchange`)(conf)
       if (!s.exchange) {
         console.error('cannot trade ' + so.selector.normalized + ': exchange not implemented')
         process.exit(1)
-        
+
       }
       var engine = engineFactory(s, conf)
       var collectionServiceInstance = collectionService(conf)
@@ -111,7 +113,7 @@ module.exports = function (program, conf) {
           console.log(' ' + key + ' - ' + value)
         })
       }
-      
+
       function listOptions () {
         console.log()
         console.log(s.exchange.name.toUpperCase() + ' exchange active trading options:'.grey)
@@ -146,7 +148,7 @@ module.exports = function (program, conf) {
           z(20, so.profit_stop_pct + '%', ' ')
         ].join('') + '\n')
         process.stdout.write('')
-      }              
+      }
 
       /* Implementing statistical Exit */
       function printTrade (quit, dump, statsonly = false) {
@@ -239,14 +241,14 @@ module.exports = function (program, conf) {
             var out_target_prefix = so.paper ? 'simulations/paper_result_' : 'stats/trade_result_'
             if(dump){
               var dt = new Date().toISOString()
-              
+
               //ymd
               var today = dt.slice(2, 4) + dt.slice(5, 7) + dt.slice(8, 10)
               out_target = so.filename || out_target_prefix + so.selector.normalized +'_' + today + '_UTC.html'
               fs.writeFileSync(out_target, out)
             }else
               out_target = so.filename || out_target_prefix + so.selector.normalized +'_' + new Date().toISOString().replace(/T/, '_').replace(/\..+/, '').replace(/-/g, '').replace(/:/g, '').replace(/20/, '') + '_UTC.html'
-            
+
             fs.writeFileSync(out_target, out)
             console.log('\nwrote'.grey, out_target)
           }
@@ -254,7 +256,7 @@ module.exports = function (program, conf) {
         }
       }
       /* The end of printTrade */
-      
+
       /* Implementing statistical status dump every 10 secs */
       var shouldSaveStats = false
       function toggleStats(){
@@ -264,7 +266,7 @@ module.exports = function (program, conf) {
         else
           console.log('Auto stats dump disabled')
       }
-      
+
       function saveStatsLoop(){
         saveStats()
         setTimeout(function () {
@@ -272,13 +274,13 @@ module.exports = function (program, conf) {
         }, 10000)
       }
       saveStatsLoop()
-      
+
       function saveStats () {
         if(!shouldSaveStats) return
-        
+
         var output_lines = []
         var tmp_balance = n(s.balance.currency).add(n(s.period.close).multiply(s.balance.asset)).format('0.00000000')
-        
+
         var profit = s.start_capital ? n(tmp_balance).subtract(s.start_capital).divide(s.start_capital) : n(0)
         output_lines.push('last balance: ' + n(tmp_balance).format('0.00000000').yellow + ' (' + profit.format('0.00%') + ')')
         var buy_hold = s.start_price ? n(s.period.close).multiply(n(s.start_capital).divide(s.start_price)) : n(tmp_balance)
@@ -318,7 +320,7 @@ module.exports = function (program, conf) {
           s.stats.losses = losses
           s.stats.error_rate = (sells ? n(losses).divide(sells).format('0.00%') : '0.00%')
         }
-        
+
         var html_output = output_lines.map(function (line) {
           return colors.stripColors(line)
         }).join('\n')
@@ -341,7 +343,7 @@ module.exports = function (program, conf) {
         if (so.filename !== 'none') {
           var out_target
           var dt = new Date().toISOString()
-          
+
           //ymd
           var today = dt.slice(2, 4) + dt.slice(5, 7) + dt.slice(8, 10)
           out_target = so.filename || 'simulations/trade_result_' + so.selector.normalized +'_' + today + '_UTC.html'
@@ -377,7 +379,7 @@ module.exports = function (program, conf) {
       var my_trades_size = 0
       var my_trades = collectionServiceInstance.getMyTrades()
       var periods = collectionServiceInstance.getPeriods()
-      
+
       console.log('fetching pre-roll data:')
       var zenbot_cmd = process.platform === 'win32' ? 'zenbot.bat' : 'zenbot.sh' // Use 'win32' for 64 bit windows too
       var command_args = ['backfill', so.selector.normalized, '--days', days || 1]
@@ -398,12 +400,12 @@ module.exports = function (program, conf) {
             },
             sort: {time: 1},
             limit: 1000
-          }         
+          }
           if (db_cursor) {
             opts.query.time = {$gt: db_cursor}
           }
           else {
-            trade_cursor = s.exchange.getCursor(query_start) 
+            trade_cursor = s.exchange.getCursor(query_start)
             opts.query.time = {$gte: query_start}
           }
           trades.find(opts.query).limit(opts.limit).sort(opts.sort).toArray(function (err, trades) {

--- a/extensions/exchanges/sim/exchange.js
+++ b/extensions/exchanges/sim/exchange.js
@@ -1,0 +1,218 @@
+let path = require('path')
+  , n = require('numbro')
+  , _ = require('underscore')
+
+
+module.exports = function sim (conf, s) {
+
+  let so = s.options
+  let exchange_id = so.selector.exchange_id
+  let real_exchange = require(path.resolve(__dirname, `../${exchange_id}/exchange`))(conf)
+
+  var now
+  var balance = { asset: so.asset_capital, currency: so.currency_capital }
+
+  var last_order_id = 1001
+  var orders = {}
+  var openOrders = {}
+
+  var exchange = {
+    name: 'sim',
+    historyScan: real_exchange.historyScan,
+    historyScanUsesTime: real_exchange.historyScanUsesTime,
+    makerFee: real_exchange.makerFee,
+    takerFee: real_exchange.takerFee,
+    dynamicFees: real_exchange.dynamicFees,
+
+    getProducts: real_exchange.getProducts,
+
+    getTrades: function (opts, cb) {
+      return cb(null, [])
+    },
+
+    getBalance: function (opts, cb) {
+      return cb(null, balance)
+    },
+
+    getQuote: function (opts, cb) {
+      return cb(null, {
+        bid: s.period.close,
+        ask: s.period.close
+      })
+    },
+
+    cancelOrder: function (opts, cb) {
+      var order_id = '~' + opts.order_id
+      var order = orders[order_id]
+
+      if (order.status === 'open') {
+        order.status = 'cancelled'
+        delete openOrders[order_id]
+      }
+
+      cb(null)
+    },
+
+    buy: function (opts, cb) {
+      var result = {
+        id: last_order_id++
+      }
+
+      var order = {
+        id: result.id,
+        status: 'open',
+        price: opts.price,
+        size: opts.size,
+        orig_size: opts.size,
+        post_only: !!opts.post_only,
+        filled_size: '0',
+        ordertype: opts.order_type,
+        tradetype: 'buy',
+        orig_time: now,
+        time: now,
+        created_at: now
+
+      }
+      orders['~' + result.id] = order
+      openOrders['~' + result.id] = order
+      cb(null, order)
+    },
+
+    sell: function (opts, cb) {
+      var result = {
+        id: last_order_id++
+      }
+
+      var order = {
+        id: result.id,
+        status: 'open',
+        price: opts.price,
+        size: opts.size,
+        orig_size: opts.size,
+        post_only: !!opts.post_only,
+        filled_size: '0',
+        ordertype: opts.order_type,
+        tradetype: 'sell',
+        orig_time: now,
+        time: now,
+        created_at: now
+      }
+      orders['~' + result.id] = order
+      openOrders['~' + result.id] = order
+      cb(null, order)
+    },
+
+    getOrder: function (opts, cb) {
+      var order = orders['~' + opts.order_id]
+      cb(null, order)
+    },
+
+    getCursor: function (trade) {
+      return (trade.time || trade)
+    },
+
+    getTime: function() {
+      return now
+    },
+
+    processTrade: function(trade) {
+      now = trade.time
+
+      _.each(openOrders, function(order, order_id) {
+        if (order.tradetype === 'buy') {
+          if (trade.time - order.time < so.order_adjust_time) {
+            // Not time yet
+          }
+          else if (trade.price <= Number(order.price)) {
+            processBuy(order)
+            order.done_at = trade.time
+            delete openOrders[order_id]
+          }
+        }
+        else if (order.tradetype === 'sell') {
+          if (trade.time - order.time < so.order_adjust_time) {
+            // Not time yet
+          }
+          else if (trade.price >= order.price) {
+            processSell(order)
+            order.done_at = trade.time
+            delete openOrders[order_id]
+          }
+        }
+      })
+    }
+  }
+
+  function processBuy (buy_order) {
+    let fee
+    let price = buy_order.price
+    if (so.order_type === 'maker') {
+      if (exchange.makerFee) {
+        fee = n(buy_order.size).multiply(exchange.makerFee / 100).value()
+      }
+    }
+    if (so.order_type === 'taker') {
+      if (s.exchange.takerFee) {
+        fee = n(buy_order.size).multiply(exchange.takerFee / 100).value()
+      }
+    }
+
+    balance.asset = n(balance.asset).add(buy_order.size).format('0.00000000')
+    if (so.order_type === 'maker') {
+      price = n(buy_order.price).add(n(buy_order.price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
+      if (exchange.makerFee) {
+        balance.asset = n(balance.asset).subtract(fee).format('0.00000000')
+      }
+    }
+    if (so.order_type === 'taker') {
+      if (exchange.takerFee) {
+        balance.asset = n(balance.asset).subtract(fee).format('0.00000000')
+      }
+    }
+    let total = n(price).multiply(buy_order.size)
+    balance.currency = n(balance.currency).subtract(total).format('0.00000000')
+
+
+    buy_order.status = 'done'
+    buy_order.filled_size = buy_order.size
+    buy_order.remaining_size = 0
+  }
+
+  function processSell (sell_order) {
+    let fee
+    let price = sell_order.price
+
+    if (so.order_type === 'maker') {
+      if (exchange.makerFee) {
+        fee = n(sell_order.size).multiply(exchange.makerFee / 100).multiply(price).value()
+      }
+    }
+    if (so.order_type === 'taker') {
+      if (exchange.takerFee) {
+        fee = n(sell_order.size).multiply(exchange.takerFee / 100).multiply(price).value()
+      }
+    }
+
+    balance.asset = n(balance.asset).subtract(sell_order.size).value()
+    if (so.order_type === 'maker') {
+      price = n(sell_order.price).subtract(n(sell_order.price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
+      if (exchange.makerFee) {
+        fee = n(sell_order.size).multiply(exchange.makerFee / 100).multiply(price).value()
+        balance.currency = n(balance.currency).subtract(fee).format('0.00000000')
+      }
+    }
+    if (so.order_type === 'taker') {
+      if (exchange.takerFee) {
+        balance.currency = n(balance.currency).subtract(fee).format('0.00000000')
+      }
+    }
+    let total = n(price).multiply(sell_order.size)
+    balance.currency = n(balance.currency).add(total).value()
+
+    sell_order.status = 'done'
+    sell_order.filled_size = sell_order.size
+    sell_order.remaining_size = 0
+  }
+
+  return exchange
+}

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -21,7 +21,12 @@ module.exports = function (s, conf) {
 
   let so = s.options
   if(_.isUndefined(s.exchange)){
-    s.exchange = require(path.resolve(__dirname, `../extensions/exchanges/${so.selector.exchange_id}/exchange`))(conf)
+    if (so.mode == 'sim') {
+      s.exchange = require(path.resolve(__dirname, '../extensions/exchanges/sim/exchange'))(conf, s)
+    }
+    else {
+      s.exchange = require(path.resolve(__dirname, `../extensions/exchanges/${so.selector.exchange_id}/exchange`))(conf)
+    }
   }
   s.product_id = so.selector.product_id
   s.asset = so.selector.asset
@@ -43,7 +48,7 @@ module.exports = function (s, conf) {
     console.error('error: could not find product "' + s.product_id + '"')
     process.exit(1)
   }
-  if ((so.mode === 'live' || so.mode === 'paper') && s.exchange.dynamicFees) {
+  if (s.exchange.dynamicFees) {
     s.exchange.setFees({asset: s.asset, currency: s.currency})
   }
   if (so.mode === 'sim' || so.mode === 'paper') {
@@ -87,11 +92,21 @@ module.exports = function (s, conf) {
     if (s.strategy.getOptions) {
       s.strategy.getOptions.call(s.ctx, s)
     }
+    if (s.strategy.orderExecuted) {
+      eventBus.on('orderExecuted', function(type) {
+        s.strategy.orderExecuted(s, type, executeSignal)
+      })
+    }
   }
 
   function msg (str) {
     if (so.debug) {
-      console.error('\n' + moment().format('YYYY-MM-DD HH:mm:ss') + ' - ' + str)
+      if (lastTickCheckOrder) {
+        console.error('\n' + moment(lastTickCheckOrder).format('YYYY-MM-DD HH:mm:ss') + ' - ' + str)
+      }
+      else {
+        console.error('\n' + moment().format('YYYY-MM-DD HH:mm:ss') + ' - ' + str)
+      }
     }
   }
 
@@ -156,6 +171,19 @@ module.exports = function (s, conf) {
     }
   }
 
+  function nextBuyForQuote(s, quote) {
+    if (s.next_buy_price)
+      return n(s.next_buy_price).format(s.product.increment, Math.floor)
+    else
+      return n(quote.bid).subtract(n(quote.bid).multiply(s.options.markdown_buy_pct / 100)).format(s.product.increment, Math.floor)
+  }
+  function nextSellForQuote(s, quote) {
+    if (s.next_sell_price)
+      return n(s.next_sell_price).format(s.product.increment, Math.ceil)
+    else
+      return n(quote.ask).add(n(quote.ask).multiply(s.options.markup_sell_pct / 100)).format(s.product.increment, Math.ceil)
+  }
+
   function updatePeriod(trade) {
     s.period.high = Math.max(trade.price, s.period.high)
     s.period.low = Math.min(trade.price, s.period.low)
@@ -211,10 +239,6 @@ module.exports = function (s, conf) {
   }
 
   function syncBalance (cb) {
-    if (so.mode !== 'live') {
-      return cb()
-    }
-
     s.exchange.getBalance({currency: s.currency, asset: s.asset}, function (err, balance) {
       if (err) return cb(err)
       s.balance = balance
@@ -249,160 +273,54 @@ module.exports = function (s, conf) {
     let order = s[type + '_order']
     order.price = opts.price
     order.size = opts.size
-    if (so.mode !== 'live') {
-      if (!order.orig_time) order.orig_time = s.period.latest_trade_time
-      order.time = s.period.latest_trade_time
-      return cb(null, order)
-    }
-    else {
-      order.product_id = s.product_id
-      order.post_only = conf.post_only
-      msg('placing ' + type + ' order...')
-      let order_copy = JSON.parse(JSON.stringify(order))
-      s.exchange[type](order_copy, function (err, api_order) {
-        if (err) return cb(err)
-        s.api_order = api_order
-        if (api_order.status === 'rejected') {
-          if (api_order.reject_reason === 'post only') {
-            // trigger immediate price adjustment and re-order
-            msg('post-only ' + type + ' failed, re-ordering')
-            return cb(null, null)
-          }
-          else if (api_order.reject_reason === 'balance') {
-            // treat as a no-op.
-            msg('not enough balance for ' + type + ', aborting')
-            return cb(null, false)
-          }
-          else if (api_order.reject_reason === 'price') {
-            // treat as a no-op.
-            msg('invalid price for ' + type + ', aborting')
-            return cb(null, false)
-          }
-          err = new Error('\norder rejected')
-          err.order = api_order
-          return cb(err)
+
+    order.product_id = s.product_id
+    order.post_only = conf.post_only
+    msg('placing ' + type + ' order...')
+    let order_copy = JSON.parse(JSON.stringify(order))
+    s.exchange[type](order_copy, function (err, api_order) {
+      if (err) return cb(err)
+      s.api_order = api_order
+      if (api_order.status === 'rejected') {
+        if (api_order.reject_reason === 'post only') {
+          // trigger immediate price adjustment and re-order
+          msg('post-only ' + type + ' failed, re-ordering')
+          return cb(null, null)
         }
-        msg(type + ' order placed at ' + fc(order.price))
-        order.order_id = api_order.id
-        if (!order.time) {
-          order.orig_time = new Date(api_order.created_at).getTime()
+        else if (api_order.reject_reason === 'balance') {
+          // treat as a no-op.
+          msg('not enough balance for ' + type + ', aborting')
+          return cb(null, false)
         }
-        order.time = new Date(api_order.created_at).getTime()
-        order.local_time = new Date().getTime()
-        order.status = api_order.status
-        //console.log('\ncreated ' + order.status + ' ' + type + ' order: ' + fa(order.size) + ' at ' + fc(order.price) + ' (total ' + fc(n(order.price).multiply(order.size)) + ')\n')
-        function cancelOrder (do_reorder) {
-          msg('cancelling order')
-          s.exchange.cancelOrder({order_id: order.order_id, product_id: s.product_id}, function () {
-            function checkHold () {
-              s.exchange.getOrder({order_id: order.order_id, product_id: s.product_id}, function (err, api_order) {
-                if (api_order) {
-                  s.api_order = api_order
-                  if (api_order.filled_size) {
-                    order.remaining_size = n(order.size).subtract(api_order.filled_size).format('0.00000000')
-                  }
-                }
-                syncBalance(function () {
-                  let on_hold
-                  if (type === 'buy') on_hold = n(s.balance.currency).subtract(s.balance.currency_hold || 0).value() < n(order.price).multiply(order.remaining_size).value()
-                  else on_hold = n(s.balance.asset).subtract(s.balance.asset_hold || 0).value() < n(order.remaining_size).value()
-                  if (on_hold) {
-                    // wait a bit for settlement
-                    msg('funds on hold after cancel, waiting 5s')
-                    setTimeout(checkHold, conf.wait_for_settlement)
-                  }
-                  else {
-                    cb(null, do_reorder ? null : false)
-                  }
-                })
-              })
-            }
-            checkHold()
-          })
+        else if (api_order.reject_reason === 'price') {
+          // treat as a no-op.
+          msg('invalid price for ' + type + ', aborting')
+          return cb(null, false)
         }
-        function checkOrder () {
-          if (!s[type + '_order']) {
-            // signal switched, stop checking order
-            msg('signal switched during ' + type + ', aborting')
-            return cancelOrder(false)
-          }
-          s.exchange.getOrder({order_id: order.order_id, product_id: s.product_id}, function (err, api_order) {
-            if (err) return cb(err)
-            s.api_order = api_order
-            order.status = api_order.status
-            if (api_order.reject_reason) order.reject_reason = api_order.reject_reason
-            msg('order status: ' + order.status)
-            if (api_order.status === 'done') {
-              order.time = new Date(api_order.done_at).getTime()
-              order.price = api_order.price || order.price // Use actual price if possible. In market order the actual price (api_order.price) could be very different from trade price
-              executeOrder(order)
-              return syncBalance(function () {
-                cb(null, order)
-              })
-            }
-            if (order.status === 'rejected' && (order.reject_reason === 'post only' || api_order.reject_reason === 'post only')) {
-              msg('post-only ' + type + ' failed, re-ordering')
-              return cb(null, null)
-            }
-            if (order.status === 'rejected' && order.reject_reason === 'balance') {
-              msg('not enough balance for ' + type + ', aborting')
-              return cb(null, null)
-            }
-            if (new Date().getTime() - order.local_time >= so.order_adjust_time) {
-              getQuote(function (err, quote) {
-                if (err) {
-                  err.desc = 'could not execute ' + type + ': error fetching quote'
-                  return cb(err)
-                }
-                let marked_price
-                if (type === 'buy') {
-                  marked_price = n(quote.bid).subtract(n(quote.bid).multiply(so.markdown_buy_pct / 100)).format((so.currency_increment !== null) ? so.currency_increment : s.product.increment, Math.floor)
-                  if (n(order.price).value() < marked_price) {
-                    msg(marked_price + ' vs our ' + order.price)
-                    cancelOrder(true)
-                  }
-                  else {
-                    order.local_time = new Date().getTime()
-                    setTimeout(checkOrder, so.order_poll_time)
-                  }
-                }
-                else {
-                  marked_price = n(quote.ask).add(n(quote.ask).multiply(so.markup_sell_pct / 100)).format((so.currency_increment !== null) ? so.currency_increment : s.product.increment, Math.ceil)
-                  if (n(order.price).value() > marked_price) {
-                    msg(marked_price + ' vs our ' + order.price)
-                    cancelOrder(true)
-                  }
-                  else {
-                    order.local_time = new Date().getTime()
-                    setTimeout(checkOrder, so.order_poll_time)
-                  }
-                }
-              })
-            }
-            else {
-              setTimeout(checkOrder, so.order_poll_time)
-            }
-          })
-        }
-        setTimeout(checkOrder, so.order_poll_time)
-      })
-    }
+        err = new Error('\norder rejected')
+        err.order = api_order
+        return cb(err)
+      }
+      msg(type + ' order placed at ' + fc(order.price))
+      order.order_id = api_order.id
+      if (!order.time) {
+        order.orig_time = new Date(api_order.created_at).getTime()
+      }
+      order.time = new Date(api_order.created_at).getTime()
+      order.local_time = now()
+      order.status = api_order.status
+      //console.log('\ncreated ' + order.status + ' ' + type + ' order: ' + fa(order.size) + ' at ' + fc(order.price) + ' (total ' + fc(n(order.price).multiply(order.size)) + ')\n')
+
+      queueEvent(function() { checkOrder(order, type, cb) }, so.order_poll_time)
+    })
   }
 
   function getQuote (cb) {
-    if (so.mode === 'sim' || so.mode === 'train') {
-      return cb(null, {
-        bid: s.period.close,
-        ask: s.period.close
-      })
-    }
-    else {
-      s.exchange.getQuote({product_id: s.product_id}, function (err, quote) {
-        if (err) return cb(err)
-        s.quote = quote
-        cb(null, quote)
-      })
-    }
+    s.exchange.getQuote({product_id: s.product_id}, function (err, quote) {
+      if (err) return cb(err)
+      s.quote = quote
+      cb(null, quote)
+    })
   }
 
   // if s.signal
@@ -416,6 +334,7 @@ module.exports = function (s, conf) {
   // 8. if not filled after timer, repeat process
   // 9. if filled, record order stats
   function executeSignal (signal, _cb, size, is_reorder, is_taker) {
+
     let price
     delete s[(signal === 'buy' ? 'sell' : 'buy') + '_order']
     s.last_signal = signal
@@ -458,36 +377,32 @@ module.exports = function (s, conf) {
           return cb(err)
         }
         if (signal === 'buy') {
-          price = n(quote.bid).subtract(n(quote.bid).multiply(so.markdown_buy_pct / 100)).format(s.product.increment, Math.floor)
+          price = nextBuyForQuote(s, quote)
           if (!size) {
-            if (so.mode === 'live' || so.mode === 'paper') {
-              let buy_pct = so.buy_pct
-              if(so.buy_max_amt){ // account for held assets as buy_max
-                let adjusted_buy_max_amt = n(so.buy_max_amt).subtract(s.asset_capital).value()
-                let buy_max_as_pct = n(adjusted_buy_max_amt).divide(s.balance.currency).multiply(100).value()
-                buy_pct = buy_max_as_pct
-              }else{ // account for held assets as %
-                let held_pct = n(s.asset_capital).divide(s.balance.currency).multiply(100).value()
-                let to_buy_pct = n(so.buy_pct).subtract(held_pct).value()
-                buy_pct = to_buy_pct
-              }
-              if (so.order_type === 'maker' && (buy_pct + s.exchange.takerFee < 100 || !s.exchange.makerBuy100Workaround)) {
-                fee = s.exchange.makerFee
-              } else {
-                fee = s.exchange.takerFee
-              }
-              trade_balance = n(s.balance.currency).divide(100).multiply(buy_pct)
-              tradeable_balance = n(s.balance.currency).divide(100 + fee).multiply(buy_pct)
-              expected_fee = n(trade_balance).subtract(tradeable_balance).format('0.00000000', Math.ceil) // round up as the exchange will too
-              if (buy_pct + fee < 100) {
-                size = n(tradeable_balance).divide(price).format('0.00000000')
-              } else {
-                size = n(trade_balance).subtract(expected_fee).divide(price).format('0.00000000')
-              }
-              msg('preparing buy order over ' + fa(size) + ' of ' + fc(tradeable_balance) + ' (' + buy_pct + '%) tradeable balance with a expected fee of ' + fc(expected_fee) + ' (' + fee + '%)')
-            } else {
-              size = n(s.balance.currency).multiply(so.buy_pct).divide(100).divide(price).format('0.00000000')
+            let buy_pct = so.buy_pct
+            if(so.buy_max_amt){ // account for held assets as buy_max
+              let adjusted_buy_max_amt = n(so.buy_max_amt).subtract(s.asset_capital).value()
+              let buy_max_as_pct = n(adjusted_buy_max_amt).divide(s.balance.currency).multiply(100).value()
+              buy_pct = buy_max_as_pct
+            }else{ // account for held assets as %
+              let held_pct = n(s.asset_capital).divide(s.balance.currency).multiply(100).value()
+              let to_buy_pct = n(so.buy_pct).subtract(held_pct).value()
+              buy_pct = to_buy_pct
             }
+            if (so.order_type === 'maker' && (buy_pct + s.exchange.takerFee < 100 || !s.exchange.makerBuy100Workaround)) {
+              fee = s.exchange.makerFee
+            } else {
+              fee = s.exchange.takerFee
+            }
+            trade_balance = n(s.balance.currency).divide(100).multiply(buy_pct)
+            tradeable_balance = n(s.balance.currency).divide(100 + fee).multiply(buy_pct)
+            expected_fee = n(trade_balance).subtract(tradeable_balance).format('0.00000000', Math.ceil) // round up as the exchange will too
+            if (buy_pct + fee < 100) {
+              size = n(tradeable_balance).divide(price).format('0.00000000')
+            } else {
+              size = n(trade_balance).subtract(expected_fee).divide(price).format('0.00000000')
+            }
+            msg('preparing buy order over ' + fa(size) + ' of ' + fc(tradeable_balance) + ' (' + buy_pct + '%) tradeable balance with a expected fee of ' + fc(expected_fee) + ' (' + fee + '%)')
           }
           if ((s.product.min_size && Number(size) >= Number(s.product.min_size)) || ('min_total' in s.product && s.product.min_total && n(size).multiply(price).value() >= Number(s.product.min_total))) {
             if (s.product.max_size && Number(size) > Number(s.product.max_size)) {
@@ -533,7 +448,7 @@ module.exports = function (s, conf) {
           }
         }
         else if (signal === 'sell') {
-          price = n(quote.ask).add(n(quote.ask).multiply(so.markup_sell_pct / 100)).format(s.product.increment, Math.ceil)
+          price = nextSellForQuote(s, quote)
           if (!size) {
             size = n(s.balance.asset).multiply(so.sell_pct / 100).format('0.00000000')
           }
@@ -617,142 +532,111 @@ module.exports = function (s, conf) {
     }
   }
 
-  function executeOrder (trade) {
+  function executeOrder (trade, type) {
     let price, fee = 0
     if (!so.order_type) {
       so.order_type = 'maker'
     }
 
+    // If order is cancelled, but on the exchange it completed, we need to recover it here
+    if (type === 'buy')
+      s.buy_order = trade
+    else if (type === 'sell')
+      s.sell_order = trade
+
+
     if (s.buy_order) {
-      if (so.mode === 'live' || trade.price <= Number(s.buy_order.price)) {
-        price = s.buy_order.price
-        if (so.order_type === 'maker') {
-          if (s.exchange.makerFee) {
-            fee = n(s.buy_order.size).multiply(s.exchange.makerFee / 100).value()
-          }
+      price = s.buy_order.price
+      if (so.order_type === 'maker') {
+        if (s.exchange.makerFee) {
+          fee = n(s.buy_order.size).multiply(s.exchange.makerFee / 100).value()
         }
-        if (so.order_type === 'taker') {
-          if (s.exchange.takerFee) {
-            fee = n(s.buy_order.size).multiply(s.exchange.takerFee / 100).value()
-          }
-        }
-        if (so.mode !== 'live') {
-          s.balance.asset = n(s.balance.asset).add(s.buy_order.size).format('0.00000000')
-          if (so.order_type === 'maker') {
-            price = n(s.buy_order.price).add(n(s.buy_order.price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
-            if (s.exchange.makerFee) {
-              s.balance.asset = n(s.balance.asset).subtract(fee).format('0.00000000')
-            }
-          }
-          if (so.order_type === 'taker') {
-            if (s.exchange.takerFee) {
-              s.balance.asset = n(s.balance.asset).subtract(fee).format('0.00000000')
-            }
-          }
-          let total = n(price).multiply(s.buy_order.size)
-          s.balance.currency = n(s.balance.currency).subtract(total).format('0.00000000')
-        }
-        s.action = 'bought'
-        let my_trade = {
-          order_id: trade.order_id,
-          time: trade.time,
-          execution_time: trade.time - s.buy_order.orig_time,
-          slippage: n(price).subtract(s.buy_order.orig_price).divide(s.buy_order.orig_price).value(),
-          type: 'buy',
-          size: s.buy_order.orig_size,
-          fee: fee,
-          price: price,
-          order_type: so.order_type || 'taker',
-          profit: s.last_sell_price && (s.last_sell_price - price) / s.last_sell_price,
-          cancel_after: so.cancel_after || 'day'
-        }
-        s.my_trades.push(my_trade)
-        if (so.stats) {
-          let order_complete = '\nbuy order completed at ' + moment(trade.time).format('YYYY-MM-DD HH:mm:ss') + ':\n\n' + fa(my_trade.size) + ' at ' + fc(my_trade.price) + '\ntotal ' + fc(my_trade.size * my_trade.price) + '\n' + n(my_trade.slippage).format('0.0000%') + ' slippage (orig. price ' + fc(s.buy_order.orig_price) + ')\nexecution: ' + moment.duration(my_trade.execution_time).humanize() + '\n'
-          console.log((order_complete).cyan)
-          pushMessage('Buy ' + s.exchange.name.toUpperCase(), order_complete)
-        }
-        s.last_buy_price = my_trade.price
-        delete s.buy_order
-        delete s.buy_stop
-        delete s.sell_stop
-        if (so.sell_stop_pct) {
-          s.sell_stop = n(price).subtract(n(price).multiply(so.sell_stop_pct / 100)).value()
-        }
-        delete s.profit_stop
-        delete s.profit_stop_high
       }
+      if (so.order_type === 'taker') {
+        if (s.exchange.takerFee) {
+          fee = n(s.buy_order.size).multiply(s.exchange.takerFee / 100).value()
+        }
+      }
+      s.action = 'bought'
+      let my_trade = {
+        order_id: trade.order_id,
+        time: trade.time,
+        execution_time: trade.time - s.buy_order.orig_time,
+        slippage: n(price).subtract(s.buy_order.orig_price).divide(s.buy_order.orig_price).value(),
+        type: 'buy',
+        size: s.buy_order.orig_size,
+        fee: fee,
+        price: price,
+        order_type: so.order_type || 'taker',
+        profit: s.last_sell_price && (s.last_sell_price - price) / s.last_sell_price,
+        cancel_after: so.cancel_after || 'day'
+      }
+      s.my_trades.push(my_trade)
+      if (so.stats) {
+        let order_complete = '\nbuy order completed at ' + moment(trade.time).format('YYYY-MM-DD HH:mm:ss') + ':\n\n' + fa(my_trade.size) + ' at ' + fc(my_trade.price) + '\ntotal ' + fc(my_trade.size * my_trade.price) + '\n' + n(my_trade.slippage).format('0.0000%') + ' slippage (orig. price ' + fc(s.buy_order.orig_price) + ')\nexecution: ' + moment.duration(my_trade.execution_time).humanize() + '\n'
+        console.log((order_complete).cyan)
+        pushMessage('Buy ' + s.exchange.name.toUpperCase(), order_complete)
+      }
+      s.last_buy_price = my_trade.price
+      delete s.buy_order
+      delete s.buy_stop
+      delete s.sell_stop
+      if (so.sell_stop_pct) {
+        s.sell_stop = n(price).subtract(n(price).multiply(so.sell_stop_pct / 100)).value()
+      }
+      delete s.profit_stop
+      delete s.profit_stop_high
+      eventBus.emit('orderExecuted', 'buy')
     }
     else if (s.sell_order) {
-      if (so.mode === 'live' || trade.price >= s.sell_order.price) {
-        price = s.sell_order.price
-        if (so.order_type === 'maker') {
-          if (s.exchange.makerFee) {
-            fee = n(s.sell_order.size).multiply(s.exchange.makerFee / 100).multiply(price).value()
-          }
+      price = s.sell_order.price
+      if (so.order_type === 'maker') {
+        if (s.exchange.makerFee) {
+          fee = n(s.sell_order.size).multiply(s.exchange.makerFee / 100).multiply(price).value()
         }
-        if (so.order_type === 'taker') {
-          if (s.exchange.takerFee) {
-            fee = n(s.sell_order.size).multiply(s.exchange.takerFee / 100).multiply(price).value()
-          }
-        }
-        if (so.mode !== 'live') {
-          s.balance.asset = n(s.balance.asset).subtract(s.sell_order.size).value()
-          if (so.order_type === 'maker') {
-            price = n(s.sell_order.price).subtract(n(s.sell_order.price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
-            if (s.exchange.makerFee) {
-              fee = n(s.sell_order.size).multiply(s.exchange.makerFee / 100).multiply(price).value()
-              s.balance.currency = n(s.balance.currency).subtract(fee).format('0.00000000')
-            }
-          }
-          if (so.order_type === 'taker') {
-            if (s.exchange.takerFee) {
-              s.balance.currency = n(s.balance.currency).subtract(fee).format('0.00000000')
-            }
-          }
-          let total = n(price).multiply(s.sell_order.size)
-          s.balance.currency = n(s.balance.currency).add(total).value()
-        }
-        s.action = 'sold'
-        let my_trade = {
-          order_id: trade.order_id,
-          time: trade.time,
-          execution_time: trade.time - s.sell_order.orig_time,
-          slippage: n(s.sell_order.orig_price).subtract(price).divide(price).value(),
-          type: 'sell',
-          size: s.sell_order.orig_size,
-          fee: fee,
-          price: price,
-          order_type: so.order_type,
-          profit: s.last_buy_price && (price - s.last_buy_price) / s.last_buy_price
-        }
-        s.my_trades.push(my_trade)
-        if (so.stats) {
-          let order_complete = '\nsell order completed at ' + moment(trade.time).format('YYYY-MM-DD HH:mm:ss') + ':\n\n' + fa(my_trade.size) + ' at ' + fc(my_trade.price) + '\ntotal ' + fc(my_trade.size * my_trade.price) + '\n' + n(my_trade.slippage).format('0.0000%') + ' slippage (orig. price ' + fc(s.sell_order.orig_price) + ')\nexecution: ' + moment.duration(my_trade.execution_time).humanize() + '\n'
-          console.log((order_complete).cyan)
-          pushMessage('Sell ' + s.exchange.name.toUpperCase(), order_complete)
-        }
-        s.last_sell_price = my_trade.price
-        delete s.sell_order
-        delete s.buy_stop
-        if (so.buy_stop_pct) {
-          s.buy_stop = n(price).add(n(price).multiply(so.buy_stop_pct / 100)).value()
-        }
-        delete s.sell_stop
-        delete s.profit_stop
-        delete s.profit_stop_high
       }
+      if (so.order_type === 'taker') {
+        if (s.exchange.takerFee) {
+          fee = n(s.sell_order.size).multiply(s.exchange.takerFee / 100).multiply(price).value()
+        }
+      }
+      s.action = 'sold'
+      let my_trade = {
+        order_id: trade.order_id,
+        time: trade.time,
+        execution_time: trade.time - s.sell_order.orig_time,
+        slippage: n(s.sell_order.orig_price).subtract(price).divide(price).value(),
+        type: 'sell',
+        size: s.sell_order.orig_size,
+        fee: fee,
+        price: price,
+        order_type: so.order_type,
+        profit: s.last_buy_price && (price - s.last_buy_price) / s.last_buy_price
+      }
+      s.my_trades.push(my_trade)
+      if (so.stats) {
+        let order_complete = '\nsell order completed at ' + moment(trade.time).format('YYYY-MM-DD HH:mm:ss') + ':\n\n' + fa(my_trade.size) + ' at ' + fc(my_trade.price) + '\ntotal ' + fc(my_trade.size * my_trade.price) + '\n' + n(my_trade.slippage).format('0.0000%') + ' slippage (orig. price ' + fc(s.sell_order.orig_price) + ')\nexecution: ' + moment.duration(my_trade.execution_time).humanize() + '\n'
+        console.log((order_complete).cyan)
+        pushMessage('Sell ' + s.exchange.name.toUpperCase(), order_complete)
+      }
+      s.last_sell_price = my_trade.price
+      delete s.sell_order
+      delete s.buy_stop
+      if (so.buy_stop_pct) {
+        s.buy_stop = n(price).add(n(price).multiply(so.buy_stop_pct / 100)).value()
+      }
+      delete s.sell_stop
+      delete s.profit_stop
+      delete s.profit_stop_high
+      eventBus.emit('orderExecuted', 'sell')
     }
   }
 
-  function adjustBid (trade) {
-    if (so.mode === 'live') return
-    if (s.buy_order && trade.time - s.buy_order.time >= so.order_adjust_time) {
-      executeSignal('buy', null, null, true)
-    }
-    else if (s.sell_order && trade.time - s.sell_order.time >= so.order_adjust_time) {
-      executeSignal('sell', null, null, true)
-    }
+  function now () {
+    if (so.mode === 'live')
+      return new Date().getTime()
+    else
+      return s.exchange.getTime()
   }
 
   function writeReport (is_progress, blink_off) {
@@ -864,6 +748,9 @@ module.exports = function (s, conf) {
   function withOnPeriod (trade, period_id, cb) {
     updatePeriod(trade)
     if (!s.in_preroll) {
+      if (so.mode === 'sim')
+        s.exchange.processTrade(trade)
+
       if (so.mode !== 'live' && !s.start_capital) {
         s.start_capital = 0
         s.start_price = trade.price
@@ -876,19 +763,157 @@ module.exports = function (s, conf) {
       }
       if (!so.manual) {
         executeStop()
+        tickCheckOrder(trade.time)
         if (s.signal) {
           executeSignal(s.signal)
           s.signal = null
         }
       }
-      if (so.mode !== 'live') {
-        adjustBid(trade)
-        executeOrder(trade)
-      }
     }
     s.last_period_id = period_id
     cb()
-  } 
+  }
+
+  // Instead of using setTimeout, this gives a consistent way between sim and live
+  // to manage calling functions that need to happen in the future
+  var eventQueue = []
+  function queueEvent(func, duration) {
+    eventQueue.push({func: func, time: lastTickCheckOrder + duration})
+  }
+  var lastTickCheckOrder = null
+  function tickCheckOrder(time) {
+    if (!lastTickCheckOrder) {
+      lastTickCheckOrder = time
+      return
+    }
+
+    for (let i = 0, len = eventQueue.length; i < len; i++) {
+      let func_data = eventQueue[i]
+      let func = func_data.func
+      let func_time = func_data.time
+
+      if (time > func_time) {
+
+        func.call()
+
+        eventQueue.splice(i, 1)
+        i--
+        len--
+      }
+    }
+    lastTickCheckOrder = time
+  }
+
+  function cancelOrder (order, type, do_reorder, cb) {
+    s.exchange.cancelOrder({order_id: order.order_id, product_id: s.product_id}, function () {
+      function checkHold (do_reorder, cb) {
+        s.exchange.getOrder({order_id: order.order_id, product_id: s.product_id}, function (err, api_order) {
+          if (api_order) {
+            if (api_order.status === 'done') {
+              order.time = new Date(api_order.done_at).getTime()
+              order.price = api_order.price || order.price // Use actual price if possible. In market order the actual price (api_order.price) could be very different from trade price
+              msg('cancel failed, order done, executing')
+              executeOrder(order, type)
+              return syncBalance(function () {
+                cb(null, order)
+              })
+            }
+
+            s.api_order = api_order
+            if (api_order.filled_size) {
+              order.remaining_size = n(order.size).subtract(api_order.filled_size).format('0.00000000')
+            }
+          }
+          syncBalance(function () {
+            let on_hold
+            if (type === 'buy') on_hold = n(s.balance.currency).subtract(s.balance.currency_hold || 0).value() < n(order.price).multiply(order.remaining_size).value()
+            else on_hold = n(s.balance.asset).subtract(s.balance.asset_hold || 0).value() < n(order.remaining_size).value()
+
+            if (on_hold && s.balance.currency_hold > 0) {
+              // wait a bit for settlement
+              msg('funds on hold after cancel, waiting 5s')
+              queueEvent(function() { checkHold(do_reorder, cb) }, conf.wait_for_settlement)
+            }
+            else {
+              cb(null, do_reorder ? null : false)
+            }
+          })
+        })
+      }
+      checkHold(do_reorder, cb)
+    })
+  }
+  function checkOrder (order, type, cb) {
+    if (!s[type + '_order']) {
+      // signal switched, stop checking order
+      msg('signal switched during ' + type + ', aborting')
+      return cancelOrder(order, type, false, cb)
+    }
+    s.exchange.getOrder({order_id: order.order_id, product_id: s.product_id}, function (err, api_order) {
+      if (err) return cb(err)
+      s.api_order = api_order
+      order.status = api_order.status
+      if (api_order.reject_reason) order.reject_reason = api_order.reject_reason
+      if (api_order.status === 'done') {
+        order.time = new Date(api_order.done_at).getTime()
+        order.price = api_order.price || order.price // Use actual price if possible. In market order the actual price (api_order.price) could be very different from trade price
+        executeOrder(order, type)
+        return syncBalance(function () {
+          cb(null, order)
+        })
+      }
+      if (order.status === 'rejected' && (order.reject_reason === 'post only' || api_order.reject_reason === 'post only')) {
+        msg('post-only ' + type + ' failed, re-ordering')
+        return cb(null, null)
+      }
+      if (order.status === 'rejected' && order.reject_reason === 'balance') {
+        msg('not enough balance for ' + type + ', aborting')
+        return cb(null, null)
+      }
+      if (now() - order.local_time >= so.order_adjust_time) {
+        getQuote(function (err, quote) {
+          if (err) {
+            err.desc = 'could not execute ' + type + ': error fetching quote'
+            return cb(err)
+          }
+          let marked_price
+          if (type === 'buy') {
+            marked_price = nextBuyForQuote(s, quote)
+            if (so.exact_buy_orders && n(order.price).value() != marked_price) {
+              msg(marked_price + ' vs! our ' + order.price)
+              cancelOrder(order, type, true, cb)
+            }
+            else if (n(order.price).value() < marked_price) {
+              msg(marked_price + ' vs our ' + order.price)
+              cancelOrder(order, type, true, cb)
+            }
+            else {
+              order.local_time = lastTickCheckOrder
+              queueEvent(function() { checkOrder(order, type, cb) }, so.order_poll_time)
+            }
+          }
+          else {
+            marked_price = nextSellForQuote(s, quote)
+            if (so.exact_sell_orders && n(order.price).value() != marked_price) {
+              msg(marked_price + ' vs! our ' + order.price)
+              cancelOrder(order, type, true, cb)
+            }
+            else if (n(order.price).value() > marked_price) {
+              msg(marked_price + ' vs our ' + order.price)
+              cancelOrder(order, type, true, cb)
+            }
+            else {
+              order.local_time = lastTickCheckOrder
+              queueEvent(function() { checkOrder(order, type, cb) }, so.order_poll_time)
+            }
+          }
+        })
+      }
+      else {
+        queueEvent(function() { checkOrder(order, type, cb) }, so.order_poll_time)
+      }
+    })
+  }
 
   var q = async.queue(function({trade, is_preroll}, callback){
     onTrade(trade, is_preroll, callback)
@@ -933,7 +958,7 @@ module.exports = function (s, conf) {
       withOnPeriod(trade, period_id, cb)
     }
   }
-  
+
   function onTrades(trades, is_preroll, cb) {
     if (_.isFunction(is_preroll)) {
       cb = is_preroll


### PR DESCRIPTION
I would like approval from @DeviaVir @defkev and @krystophv before this one gets accepted, mostly to make sure I didn't break any of their recent changes.

Fair warning, this WILL change sim results from what people are used to and that will probably scare them, but that's the point. Plenty of people complain that sim vs live is quite different, so I set out to close that gap as much as possible.

Current unstable sim:
<img width="1402" alt="sim" src="https://user-images.githubusercontent.com/20549/36403637-2db4f2d6-15b4-11e8-83fe-ed797b31788d.png">

My output from live:
<img width="1404" alt="live" src="https://user-images.githubusercontent.com/20549/36403638-2dc16372-15b4-11e8-83c5-956261978a16.png">

Sim with my PR in place:
<img width="1399" alt="sim2" src="https://user-images.githubusercontent.com/20549/36403639-2dcf4eb0-15b4-11e8-9e8b-d3a4bf47e924.png">

You can see the new version is MUCH more in line with reality. The way I did this was by implementing a "sim" exchange. I moved as much `if (mode === 'live')` portions of engine.js as I could and abstracted them away into the sim exchange.

I also implemented an `eventQueue` to mimic the effect of `setTimeout` in a way that would translate to sim, so that we can get more similar results to the `conf.wait_for_settlement` and `so.order_poll_time` settings that live uses.

Next steps:

1. Make the sim exchange do something with an abstraction of the `eventQueue` so that we can simulate network delay (like 150ms?) on its commands.
2. Make the sim exchange compare not only trade price, but trade size, in order to allow sim to process partial orders. Right now partial orders in live totally screw me up, but I can't test them in sim. That needs to be possible.
3. Figure out why my candles from live don't look exactly like my candles from sim. I have no good leads there, I just know it's a problem and I can't figure out why.