### PR TITLE
CEXIO: Fix buy maker size calculation

### DIFF
--- a/extensions/exchanges/cexio/exchange.js
+++ b/extensions/exchanges/cexio/exchange.js
@@ -66,6 +66,7 @@ module.exports = function cexio (conf) {
     makerFee: 0.16,
     takerFee: 0.25,
     dynamicFees: true,
+    makerBuy100Workaround: true,
 
     getProducts: function () {
       return require('./products.json')

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -471,7 +471,11 @@ module.exports = function (s, conf) {
                 let to_buy_pct = n(so.buy_pct).subtract(held_pct).value()
                 buy_pct = to_buy_pct
               }
-              fee = so.order_type === 'maker' ? s.exchange.makerFee : s.exchange.takerFee
+              if (so.order_type === 'taker' || buy_pct === 100 && s.exchange.makerBuy100Workaround) {
+                fee = s.exchange.takerFee
+              } else {
+                fee = s.exchange.makerFee
+              }
               trade_balance = n(s.balance.currency).divide(100).multiply(buy_pct)
               tradeable_balance = n(s.balance.currency).divide(100 + fee).multiply(buy_pct)
               expected_fee = n(trade_balance).subtract(tradeable_balance).format('0.00000000', Math.ceil) // round up as the exchange will too
@@ -480,7 +484,7 @@ module.exports = function (s, conf) {
               } else {
                 size = n(trade_balance).subtract(expected_fee).divide(price).format('0.00000000')
               }
-              msg('preparing buy order over ' + fa(size) + ' which equals to ' + buy_pct + '% of our ' + fc(tradeable_balance) + ' tradeable balance with a expected fee of ' + fc(expected_fee))
+              msg('preparing buy order over ' + fa(size) + ' of ' + fc(tradeable_balance) + ' (' + buy_pct + '%) tradeable balance with a expected fee of ' + fc(expected_fee) + ' (' + fee + '%)')
             } else {
               size = n(s.balance.currency).multiply(so.buy_pct).divide(100).divide(price).format('0.00000000')
             }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -471,7 +471,7 @@ module.exports = function (s, conf) {
                 let to_buy_pct = n(so.buy_pct).subtract(held_pct).value()
                 buy_pct = to_buy_pct
               }
-              if (so.order_type === 'taker' || buy_pct === 100 && s.exchange.makerBuy100Workaround) {
+              if (so.order_type === 'taker' || buy_pct + s.exchange.takerFee <= 100 && s.exchange.makerBuy100Workaround) {
                 fee = s.exchange.takerFee
               } else {
                 fee = s.exchange.makerFee

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -471,10 +471,10 @@ module.exports = function (s, conf) {
                 let to_buy_pct = n(so.buy_pct).subtract(held_pct).value()
                 buy_pct = to_buy_pct
               }
-              if (so.order_type === 'taker' || buy_pct + s.exchange.takerFee <= 100 && s.exchange.makerBuy100Workaround) {
-                fee = s.exchange.takerFee
-              } else {
+              if (so.order_type === 'maker' && (buy_pct + s.exchange.takerFee < 100 || !s.exchange.makerBuy100Workaround)) {
                 fee = s.exchange.makerFee
+              } else {
+                fee = s.exchange.takerFee
               }
               trade_balance = n(s.balance.currency).divide(100).multiply(buy_pct)
               tradeable_balance = n(s.balance.currency).divide(100 + fee).multiply(buy_pct)


### PR DESCRIPTION
Closes already closed #923

CEXIO (at least) always expects the taker fee will submitting a buy order which causes a `ìnsufficient funds` error if buy_pct (+ makerFee) is greater than or equal to 100% - takerFee

To workaround this "limitation" we will use the taker fee for the buy order size calculation if `buy_pct = 100`

Note that this has no impact on the actual fee paid if the order gets filled, its just to get the order accepted.

This is an exchange specific workaround, so if you suspect that other exchanges have the same "problem" try adding `makerBuy100Workaround: true` to the exchange object in exchange.js