### PR TITLE
Live vs Sim broke paper mode, hopefully this fixes it

### DIFF
--- a/extensions/exchanges/sim/exchange.js
+++ b/extensions/exchanges/sim/exchange.js
@@ -27,7 +27,12 @@ module.exports = function sim (conf, s) {
     getProducts: real_exchange.getProducts,
 
     getTrades: function (opts, cb) {
-      return cb(null, [])
+      if (so.mode === 'paper') {
+        return real_exchange.getTrades(opts, cb)
+      }
+      else {
+        return cb(null, [])
+      }
     },
 
     getBalance: function (opts, cb) {
@@ -35,10 +40,15 @@ module.exports = function sim (conf, s) {
     },
 
     getQuote: function (opts, cb) {
-      return cb(null, {
-        bid: s.period.close,
-        ask: s.period.close
-      })
+      if (so.mode === 'paper') {
+        return real_exchange.getQuote(opts, cb)
+      }
+      else {
+        return cb(null, {
+          bid: s.period.close,
+          ask: s.period.close
+        })
+      }
     },
 
     cancelOrder: function (opts, cb) {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -21,12 +21,15 @@ module.exports = function (s, conf) {
 
   let so = s.options
   if(_.isUndefined(s.exchange)){
-    if (so.mode == 'sim') {
+    if (so.mode !== 'live') {
       s.exchange = require(path.resolve(__dirname, '../extensions/exchanges/sim/exchange'))(conf, s)
     }
     else {
       s.exchange = require(path.resolve(__dirname, `../extensions/exchanges/${so.selector.exchange_id}/exchange`))(conf)
     }
+  }
+  else if (so.mode === 'paper') {
+    s.exchange = require(path.resolve(__dirname, '../extensions/exchanges/sim/exchange'))(conf, s)
   }
   s.product_id = so.selector.product_id
   s.asset = so.selector.asset
@@ -633,7 +636,7 @@ module.exports = function (s, conf) {
   }
 
   function now () {
-    if (so.mode === 'live')
+    if (so.mode !== 'live')
       return new Date().getTime()
     else
       return s.exchange.getTime()
@@ -748,7 +751,7 @@ module.exports = function (s, conf) {
   function withOnPeriod (trade, period_id, cb) {
     updatePeriod(trade)
     if (!s.in_preroll) {
-      if (so.mode === 'sim')
+      if (so.mode !== 'live')
         s.exchange.processTrade(trade)
 
       if (so.mode !== 'live' && !s.start_capital) {


### PR DESCRIPTION
I don't ever use paper mode so I'm not 100% sure what I'm fixing, but it seems ok. In `unstable` right now running in paper mode is basically the same as running live mode, so it'll perform real trades. This fixes that.