### PR TITLE
Resize order on reorder

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -334,8 +334,7 @@ module.exports = function (s, conf) {
   // 8. if not filled after timer, repeat process
   // 9. if filled, record order stats
   function executeSignal (signal, _cb, size, is_reorder, is_taker) {
-
-    let price
+    let price, buy_pct, sell_pct
     delete s[(signal === 'buy' ? 'sell' : 'buy') + '_order']
     s.last_signal = signal
     if (!is_reorder && s[signal + '_order']) {
@@ -376,17 +375,30 @@ module.exports = function (s, conf) {
           err.desc = 'could not execute ' + signal + ': error fetching quote'
           return cb(err)
         }
+        if (is_reorder && s[signal + '_order']) {
+          if (signal === 'buy') {
+            reorder_pct = n(size).multiply(s.buy_order.price).divide(s.balance.currency).multiply(100).add(fee)
+          } else {
+            reorder_pct = n(size).divide(s.balance.asset).multiply(100)
+          }
+          msg('price changed, resizing order, ' + reorder_pct + '% remain')
+          size = null
+        }
         if (signal === 'buy') {
           price = nextBuyForQuote(s, quote)
           if (!size) {
-            let buy_pct = so.buy_pct
+            if (is_reorder) {
+              buy_pct = reorder_pct
+            } else {
+              buy_pct = so.buy_pct
+            }
             if(so.buy_max_amt){ // account for held assets as buy_max
               let adjusted_buy_max_amt = n(so.buy_max_amt).subtract(s.asset_capital).value()
               let buy_max_as_pct = n(adjusted_buy_max_amt).divide(s.balance.currency).multiply(100).value()
               buy_pct = buy_max_as_pct
             }else{ // account for held assets as %
               let held_pct = n(s.asset_capital).divide(s.balance.currency).multiply(100).value()
-              let to_buy_pct = n(so.buy_pct).subtract(held_pct).value()
+              let to_buy_pct = n(buy_pct).subtract(held_pct).value()
               buy_pct = to_buy_pct
             }
             if (so.order_type === 'maker' && (buy_pct + s.exchange.takerFee < 100 || !s.exchange.makerBuy100Workaround)) {
@@ -402,12 +414,12 @@ module.exports = function (s, conf) {
             } else {
               size = n(trade_balance).subtract(expected_fee).divide(price).format('0.00000000')
             }
-            msg('preparing buy order over ' + fa(size) + ' of ' + fc(tradeable_balance) + ' (' + buy_pct + '%) tradeable balance with a expected fee of ' + fc(expected_fee) + ' (' + fee + '%)')
           }
           if ((s.product.min_size && Number(size) >= Number(s.product.min_size)) || ('min_total' in s.product && s.product.min_total && n(size).multiply(price).value() >= Number(s.product.min_total))) {
             if (s.product.max_size && Number(size) > Number(s.product.max_size)) {
               size = s.product.max_size
             }
+            msg('preparing buy order over ' + fa(size) + ' of ' + fc(tradeable_balance) + ' (' + buy_pct + '%) tradeable balance with a expected fee of ' + fc(expected_fee) + ' (' + fee + '%)')
             if (!s.last_sell_price && s.my_prev_trades.length) {
               var prev_sells = s.my_prev_trades.filter(trade => trade.type === 'sell')
               if (prev_sells.length) {
@@ -450,7 +462,12 @@ module.exports = function (s, conf) {
         else if (signal === 'sell') {
           price = nextSellForQuote(s, quote)
           if (!size) {
-            size = n(s.balance.asset).multiply(so.sell_pct / 100).format('0.00000000')
+            if (is_reorder) {
+              sell_pct = reorder_pct
+            } else {
+              sell_pct = so.sell_pct
+            }
+            size = n(s.balance.asset).multiply(sell_pct / 100).format('0.00000000')
           }
           if ((s.product.min_size && Number(size) >= Number(s.product.min_size)) || (s.product.min_total && n(size).multiply(price).value() >= Number(s.product.min_total))) {
             if (s.product.max_size && Number(size) > Number(s.product.max_size)) {


### PR DESCRIPTION
Instead of reordering using the same size (which doesn't make sense) calculate the (remaining) size (in percent) of the order and use it as `buy|sell_pct`

This should fix a fair ammount of "insufficient funds" errors people have been reporting.

e.g. #1223 #1315 & #1392 and possible even one of thus older ones including #699 #820 #876 #900 & #910