### PR TITLE
wait till trade queue is drained before exiting engine

### DIFF
--- a/commands/sim.js
+++ b/commands/sim.js
@@ -268,6 +268,7 @@ module.exports = function (program, conf) {
               return getNext()
             }
             engine.exit(exitSim)
+            return
           } else {
             if (reversing) {
               cursor = lastTrade.orig_time

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -549,7 +549,9 @@ module.exports = function (program, conf) {
             }
             if (botStartTime && botStartTime - moment() < 0 ) {
               // Not sure if I should just handle exit code directly or thru printTrade.  Decided on printTrade being if code is added there for clean exits this can just take advantage of it.
-              printTrade(true)
+              engine.exit(() => {
+                printTrade(true)
+              })
             }
             session.updated = new Date().getTime()
             session.balance = s.balance

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -374,6 +374,7 @@ module.exports = function (s, conf) {
         msg('error getting balance')
       }
       getQuote(function (err, quote) {
+        let reorder_pct, fee, trade_balance, tradeable_balance, expected_fee
         if (err) {
           err.desc = 'could not execute ' + signal + ': error fetching quote'
           return cb(err)
@@ -395,11 +396,11 @@ module.exports = function (s, conf) {
             } else {
               buy_pct = so.buy_pct
             }
-            if(so.buy_max_amt){ // account for held assets as buy_max
+            if (so.buy_max_amt) { // account for held assets as buy_max
               let adjusted_buy_max_amt = n(so.buy_max_amt).subtract(s.asset_capital).value()
               let buy_max_as_pct = n(adjusted_buy_max_amt).divide(s.balance.currency).multiply(100).value()
               buy_pct = buy_max_as_pct
-            }else{ // account for held assets as %
+            } else { // account for held assets as %
               let held_pct = n(s.asset_capital).divide(s.balance.currency).multiply(100).value()
               let to_buy_pct = n(buy_pct).subtract(held_pct).value()
               buy_pct = to_buy_pct
@@ -935,12 +936,12 @@ module.exports = function (s, conf) {
     })
   }
 
-  var q = async.queue(function({trade, is_preroll}, callback){
+  var tradeProcessingQueue = async.queue(function({trade, is_preroll}, callback){
     onTrade(trade, is_preroll, callback)
   })
 
   function queueTrade(trade, is_preroll){
-    q.push({trade, is_preroll})
+    tradeProcessingQueue.push({trade, is_preroll})
   }
 
   function onTrade(trade, is_preroll, cb) {
@@ -1012,10 +1013,19 @@ module.exports = function (s, conf) {
     },
     update: onTrades,
     exit: function (cb) {
-      if(s.strategy.onExit) {
-        s.strategy.onExit.call( s.ctx, s )
+      if(tradeProcessingQueue.length()){
+        tradeProcessingQueue.drain = () => {
+          if(s.strategy.onExit) {
+            s.strategy.onExit.call( s.ctx, s )
+          }
+          cb()
+        }
+      } else {
+        if(s.strategy.onExit) {
+          s.strategy.onExit.call( s.ctx, s )
+        }
+        cb()
       }
-      cb()
     },
 
     executeSignal: executeSignal,


### PR DESCRIPTION
Currently the engine exit will allow exiting the process while there are still trades in the processing queue. This will check the queue and, if there are trades still in there (as is usually the case for strategies that require async onPeriod execution), then it will hook into the queue's `drain` callback which will execute after all trades have been processed.

Should resolve #1416 

Also a couple undefined variables and tiny formatting issues that it wouldn't let me commit till I fixed.