### PR TITLE
getCursor can be different per exchange

### DIFF
--- a/commands/balance.js
+++ b/commands/balance.js
@@ -17,7 +17,6 @@ module.exports = function (program, conf) {
     .action(function (selector, cmd) {
       var s = {options: minimist(process.argv)}
       s.selector = objectifySelector(selector || conf.selector)
-      s.exchange = require(`../extensions/exchanges/${s.selector.exchange_id}/exchange`)(conf)
       s.product_id = s.selector.product_id
       s.asset = s.selector.asset
       s.currency = s.selector.currency

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -80,13 +80,7 @@ module.exports = function (program, conf) {
       so.stats = !cmd.disable_stats
       so.mode = so.paper ? 'paper' : 'live'
 
-      so.selector = objectifySelector(selector || conf.selector)
-      s.exchange = require(`../extensions/exchanges/${so.selector.exchange_id}/exchange`)(conf)
-      if (!s.exchange) {
-        console.error('cannot trade ' + so.selector.normalized + ': exchange not implemented')
-        process.exit(1)
-
-      }
+      so.selector = objectifySelector(selector || conf.selector)      
       var engine = engineFactory(s, conf)
       var collectionServiceInstance = collectionService(conf)
 

--- a/extensions/exchanges/sim/exchange.js
+++ b/extensions/exchanges/sim/exchange.js
@@ -1,6 +1,6 @@
 let path = require('path')
   , n = require('numbro')
-  , _ = require('underscore')
+  , _ = require('lodash')
 
 
 module.exports = function sim (conf, s) {
@@ -117,9 +117,7 @@ module.exports = function sim (conf, s) {
       cb(null, order)
     },
 
-    getCursor: function (trade) {
-      return (trade.time || trade)
-    },
+    getCursor: real_exchange.getCursor,
 
     getTime: function() {
       return now

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -31,6 +31,10 @@ module.exports = function (s, conf) {
   else if (so.mode === 'paper') {
     s.exchange = require(path.resolve(__dirname, '../extensions/exchanges/sim/exchange'))(conf, s)
   }
+  if (!s.exchange) {
+    console.error('cannot trade ' + so.selector.normalized + ': exchange not implemented')
+    process.exit(1)
+  }
   s.product_id = so.selector.product_id
   s.asset = so.selector.asset
   s.currency = so.selector.currency
@@ -374,6 +378,7 @@ module.exports = function (s, conf) {
         msg('error getting balance')
       }
       getQuote(function (err, quote) {
+        let reorder_pct, fee, trade_balance, tradeable_balance, expected_fee
         if (err) {
           err.desc = 'could not execute ' + signal + ': error fetching quote'
           return cb(err)


### PR DESCRIPTION
In `--paper` mode, the current `sim` exchange is broken for `GDAX` due to the fact that, for whatever reason, the GDAX exchange was implemented using the trade ID as the cursor instead of the time, thus when the exchange looks internally for new trades, it's comparing the wrong number to determine if the trades are new or not. This will point the `sim` exchange's `getCursor` function directly to the real exchange's function. 

Additionally, attempts to simplify matters a little bit by not creating a configured exchange instance in specific command files that also create an `engine` instance, as `engine` will create an exchange instance.

(and again adding the variable definitions that were preventing me from committing `engine` because of eslint errors... not sure how people can commit files with eslint problems still - probably need to add linting checks to Travis)