### PR TITLE
Small tweak to make getQuote in sim a bit more realistic

### DIFF
--- a/extensions/exchanges/sim/exchange.js
+++ b/extensions/exchanges/sim/exchange.js
@@ -15,6 +15,7 @@ module.exports = function sim (conf, s) {
   var last_order_id = 1001
   var orders = {}
   var openOrders = {}
+  var last_trade
 
   var exchange = {
     name: 'sim',
@@ -44,10 +45,18 @@ module.exports = function sim (conf, s) {
         return real_exchange.getQuote(opts, cb)
       }
       else {
-        return cb(null, {
-          bid: s.period.close,
-          ask: s.period.close
-        })
+        if (last_trade) {
+          return cb(null, {
+            bid: last_trade.price,
+            ask: last_trade.price
+          })
+        }
+        else {
+          return cb(null, {
+            bid: s.period.close,
+            ask: s.period.close
+          })
+        }
       }
     },
 
@@ -124,6 +133,7 @@ module.exports = function sim (conf, s) {
     },
 
     processTrade: function(trade) {
+      last_trade = trade
       now = trade.time
 
       _.each(openOrders, function(order, order_id) {


### PR DESCRIPTION
Right now `getQuote` gets called by the engine many times a minute. To be more precise, it gets call every `order_adjust_time` milliseconds. However, right now the sim exchange just returns the last period close for the `getQuote` value which is constant per-period. This change pulls from the last trade value. While this is not the same as the REAL `ask` or `bid` from `getQuote`, currently Zenbot doesn't store this kind of orderbook data so faking it this way is the best we can do. Still not perfect, but hopefully a bit more realistic than last period close.