### PR TITLE
Revamp Auto Backtester

### DIFF
--- a/extensions/strategies/bollinger/strategy.js
+++ b/extensions/strategies/bollinger/strategy.js
@@ -1,6 +1,7 @@
 var z = require('zero-fill')
   , n = require('numbro')
   , bollinger = require('../../../lib/bollinger')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'bollinger',
@@ -58,6 +59,24 @@ module.exports = {
       cols.push('         ')
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    bollinger_size: Phenotypes.Range(1, 40),
+    bollinger_time: Phenotypes.RangeFloat(1,6),
+    bollinger_upper_bound_pct: Phenotypes.RangeFloat(-1, 30),
+    bollinger_lower_bound_pct: Phenotypes.RangeFloat(-1, 30)
   }
 }
 

--- a/extensions/strategies/cci_srsi/strategy.js
+++ b/extensions/strategies/cci_srsi/strategy.js
@@ -3,6 +3,7 @@ let z = require('zero-fill')
   , ema = require('../../../lib/ema')
   , srsi = require('../../../lib/srsi')
   , cci = require('../../../lib/cci')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'cci_srsi',
@@ -103,6 +104,32 @@ module.exports = {
       cols.push('         ')
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 200),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    ema_acc: Phenotypes.RangeFloat(0, 0.5),
+    cci_periods: Phenotypes.Range(1, 200),
+    rsi_periods: Phenotypes.Range(1, 200),
+    srsi_periods: Phenotypes.Range(1, 200),
+    srsi_k: Phenotypes.Range(1, 50),
+    srsi_d: Phenotypes.Range(1, 50),
+    oversold_rsi: Phenotypes.Range(1, 100),
+    overbought_rsi: Phenotypes.Range(1, 100),
+    oversold_cci: Phenotypes.Range(-100, 100),
+    overbought_cci: Phenotypes.Range(1, 100),
+    constant: Phenotypes.RangeFloat(0.001, 0.05)
   }
 }
 

--- a/extensions/strategies/dema/strategy.js
+++ b/extensions/strategies/dema/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , rsi = require('../../../lib/rsi')
   , ema = require('../../../lib/ema')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'dema',
@@ -79,6 +80,27 @@ module.exports = {
       cols.push('         ')
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 200),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    ema_short_period: Phenotypes.Range(1, 20),
+    ema_long_period: Phenotypes.Range(20, 100),
+    up_trend_threshold: Phenotypes.Range(0, 50),
+    down_trend_threshold: Phenotypes.Range(0, 50),
+    overbought_rsi_periods: Phenotypes.Range(1, 50),
+    overbought_rsi: Phenotypes.Range(20, 100)
   }
 }
 

--- a/extensions/strategies/forex_analytics/strategy.js
+++ b/extensions/strategies/forex_analytics/strategy.js
@@ -24,14 +24,14 @@ module.exports =  {
       } else {
         modelfile = path.resolve(__dirname, '../../../', s.options.modelfile)
       }
-        
+
       if (fs.existsSync(modelfile)) {
         model = require(modelfile)
       } else {
         console.error('Modelfile ' + modelfile + ' does not exist.')
-        process.exit(1)          
+        process.exit(1)
       }
-        
+
       if (s.options.period !== model.period) {
         console.error(('Error: Period in model training was ' + model.period + ', now you specified ' + s.options.period + '.').red)
         process.exit(1)
@@ -55,7 +55,7 @@ module.exports =  {
         time: s.period.time / 1000
       }
       candlesticks.unshift(candlestick)
-        
+
       s.lookback.slice(0, s.lookback.length).map(function (period) {
         var candlestick = {
           open: period.open,
@@ -66,12 +66,12 @@ module.exports =  {
         }
         candlesticks.unshift(candlestick)
       })
-        
+
       var result = analytics.getMarketStatus(candlesticks, {'strategy': model.strategy})
       if (result.shouldSell) {
         s.signal = 'sell'
       } else if (result.shouldBuy) {
-        s.signal = 'buy'          
+        s.signal = 'buy'
       }
     }
 
@@ -81,6 +81,8 @@ module.exports =  {
   onReport: function () {
     var cols = []
     return cols
-  }
+  },
+
+  phenotypes: null
 }
 

--- a/extensions/strategies/macd/strategy.js
+++ b/extensions/strategies/macd/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , ema = require('../../../lib/ema')
   , rsi = require('../../../lib/rsi')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'macd',
@@ -30,7 +31,7 @@ module.exports = {
         if (s.options.mode === 'sim' && s.options.verbose) console.log(('\noverbought at ' + s.period.overbought_rsi + ' RSI, preparing to sold\n').cyan)
       }
     }
-    
+
     // compute MACD
     ema(s, 'ema_short', s.options.ema_short_period)
     ema(s, 'ema_long', s.options.ema_long_period)
@@ -42,7 +43,7 @@ module.exports = {
       }
     }
   },
-  
+
   onPeriod: function (s, cb) {
     if (!s.in_preroll && typeof s.period.overbought_rsi === 'number') {
       if (s.overbought) {
@@ -51,7 +52,7 @@ module.exports = {
         s.signal = 'sell'
         return cb()
       }
-  
+
     }
 
     if (typeof s.period.macd_histogram === 'number' && typeof s.lookback[0].macd_histogram === 'number') {
@@ -83,6 +84,28 @@ module.exports = {
       cols.push('         ')
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 200),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    ema_short_period: Phenotypes.Range(1, 20),
+    ema_long_period: Phenotypes.Range(20, 100),
+    signal_period: Phenotypes.Range(1, 20),
+    up_trend_threshold: Phenotypes.Range(0, 50),
+    down_trend_threshold: Phenotypes.Range(0, 50),
+    overbought_rsi_periods: Phenotypes.Range(1, 50),
+    overbought_rsi: Phenotypes.Range(20, 100)
   }
 }
 

--- a/extensions/strategies/momentum/strategy.js
+++ b/extensions/strategies/momentum/strategy.js
@@ -1,6 +1,7 @@
 let z = require('zero-fill')
   , n = require('numbro')
   , momentum = require('../../../lib/momentum')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'momentum',
@@ -46,6 +47,22 @@ module.exports = {
       cols.push(' '.repeat(5))
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 2500),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    momentum_size: Phenotypes.Range(1,20)
   }
 }
 

--- a/extensions/strategies/neural/strategy.js
+++ b/extensions/strategies/neural/strategy.js
@@ -1,9 +1,11 @@
-var convnetjs = require('convnetjs')
-var z = require('zero-fill')
-var n = require('numbro')
-var math = require('mathjs')
+let convnetjs = require('convnetjs')
+  , z = require('zero-fill')
+  , n = require('numbro')
+  , math = require('mathjs')
+  , ema = require('../../../lib/ema')
+  , Phenotypes = require('../../../lib/phenotype')
 const cluster = require('cluster')
-var ema = require('../../../lib/ema')
+
 // the below line starts you at 0 threads
 global.forks = 0
 // the below line is for calculating the last mean vs the now mean.
@@ -110,5 +112,27 @@ module.exports = {
     cols.push(z(8, n(global.meanp).format('0.000000000'), ' ')[global.meanp > global.mean ? 'green' : 'red'])
     return cols
   },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 200),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    neurons_1: Phenotypes.Range(1, 200),
+    activation_1_type: Phenotypes.ListOption(['sigmoid', 'tanh', 'relu']),
+    depth: Phenotypes.Range(1, 100),
+    min_predict: Phenotypes.Range(1, 100),
+    momentum: Phenotypes.Range(0, 100),
+    decay: Phenotypes.Range(1, 10),
+    learns: Phenotypes.Range(1, 200)
+  }
 }
 

--- a/extensions/strategies/rsi/strategy.js
+++ b/extensions/strategies/rsi/strategy.js
@@ -1,6 +1,7 @@
 var z = require('zero-fill')
   , n = require('numbro')
   , rsi = require('../../../lib/rsi')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'rsi',
@@ -69,6 +70,27 @@ module.exports = {
       cols.push(z(4, n(s.period.rsi).format('0'), ' ')[color])
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 200),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    rsi_periods: Phenotypes.Range(1, 200),
+    oversold_rsi: Phenotypes.Range(1, 100),
+    overbought_rsi: Phenotypes.Range(1, 100),
+    rsi_recover: Phenotypes.Range(1, 100),
+    rsi_drop: Phenotypes.Range(0, 100),
+    rsi_divisor: Phenotypes.Range(1, 10)
   }
 }
 

--- a/extensions/strategies/sar/strategy.js
+++ b/extensions/strategies/sar/strategy.js
@@ -1,5 +1,6 @@
 var z = require('zero-fill')
   , n = require('numbro')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports =  {
   name: 'sar',
@@ -90,6 +91,23 @@ module.exports =  {
       cols.push(z(8, n(s.sar).subtract(s.period.close).divide(s.period.close).format('0.00%'), ' ').grey)
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(2, 100),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    sar_af: Phenotypes.RangeFloat(0.01, 1.0),
+    sar_max_af: Phenotypes.RangeFloat(0.01, 1.0)
   }
 }
 

--- a/extensions/strategies/speed/strategy.js
+++ b/extensions/strategies/speed/strategy.js
@@ -1,7 +1,8 @@
 var z = require('zero-fill')
   , n = require('numbro')
   , ema = require('../../../lib/ema')
-  
+  , Phenotypes = require('../../../lib/phenotype')
+
 module.exports = {
   name: 'speed',
   description: 'Trade when % change from last two 1m periods is higher than average.',
@@ -51,6 +52,23 @@ module.exports = {
       cols.push(z(8, n(s.period.baseline).format('0.0000'), ' ').grey)
     }
     return cols
+  },
+
+  speed: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 100),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    baseline_periods: Phenotypes.Range(1, 5000),
+    trigger_factor: Phenotypes.RangeFloat(0.1, 10)
   }
 }
 

--- a/extensions/strategies/srsi_macd/strategy.js
+++ b/extensions/strategies/srsi_macd/strategy.js
@@ -2,6 +2,7 @@ let z = require('zero-fill')
   , n = require('numbro')
   , srsi = require('../../../lib/srsi')
   , ema = require('../../../lib/ema')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'srsi_macd',
@@ -75,6 +76,31 @@ module.exports = {
       cols.push('         ')
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 200),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    rsi_periods: Phenotypes.Range(1, 200),
+    srsi_periods: Phenotypes.Range(1, 200),
+    srsi_k: Phenotypes.Range(1, 50),
+    srsi_d: Phenotypes.Range(1, 50),
+    oversold_rsi: Phenotypes.Range(1, 100),
+    overbought_rsi: Phenotypes.Range(1, 100),
+    ema_short_period: Phenotypes.Range(1, 20),
+    ema_long_period: Phenotypes.Range(20, 100),
+    signal_period: Phenotypes.Range(1, 20),
+    up_trend_threshold: Phenotypes.Range(0, 20),
+    down_trend_threshold: Phenotypes.Range(0, 20)
   }
 }
-

--- a/extensions/strategies/stddev/strategy.js
+++ b/extensions/strategies/stddev/strategy.js
@@ -1,7 +1,8 @@
 var z = require('zero-fill')
-var stats = require('stats-lite')
-var math = require('mathjs')
-var ema = require('../../../lib/ema')
+  , stats = require('stats-lite')
+  , math = require('mathjs')
+  , ema = require('../../../lib/ema')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'stddev',
@@ -32,7 +33,7 @@ module.exports = {
     if (s.sig1 === 'Down') {
       s.signal = 'sell'
     }
-    else if (s.sig0 === 'Up' && s.sig1 === 'Up') {   
+    else if (s.sig0 === 'Up' && s.sig1 === 'Up') {
       s.signal = 'buy'
     }
     cb()
@@ -42,5 +43,23 @@ module.exports = {
     cols.push(z(s.signal, ' ')[s.signal === false ? 'red' : 'green'])
     return cols
   },
+
+  phenotypes: {
+    // -- common
+    // reference in extensions is given in ms have not heard of an exchange that supports 500ms thru api so setting min at 1 second
+    period_length: Phenotypes.RangePeriod(1, 7200, 's'),
+    min_periods: Phenotypes.Range(1, 2500),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    trendtrades_1: Phenotypes.Range(2, 20),
+    trendtrades_2: Phenotypes.Range(4, 100)
+  }
 }
 

--- a/extensions/strategies/ta_ema/strategy.js
+++ b/extensions/strategies/ta_ema/strategy.js
@@ -3,6 +3,7 @@ var z = require('zero-fill')
   , ta_ema = require('../../../lib/ta_ema')
   , rsi = require('../../../lib/rsi')
   , stddev = require('../../../lib/stddev')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'ta_ema',
@@ -104,6 +105,24 @@ module.exports = {
       }
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 100),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    trend_ema: Phenotypes.Range(1, 40),
+    oversold_rsi_periods: Phenotypes.Range(5, 50),
+    oversold_rsi: Phenotypes.Range(20, 100)
   }
 }
 

--- a/extensions/strategies/ta_macd/strategy.js
+++ b/extensions/strategies/ta_macd/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , rsi = require('../../../lib/rsi')
   , ta_macd = require('../../../lib/ta_macd')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'ta_macd',
@@ -87,5 +88,28 @@ module.exports = {
       cols.push('         ')
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 200),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    // have to be minimum 2 because talib will throw an "TA_BAD_PARAM" error
+    ema_short_period: Phenotypes.Range(2, 20),
+    ema_long_period: Phenotypes.Range(20, 100),
+    signal_period: Phenotypes.Range(1, 20),
+    up_trend_threshold: Phenotypes.Range(0, 50),
+    down_trend_threshold: Phenotypes.Range(0, 50),
+    overbought_rsi_periods: Phenotypes.Range(1, 50),
+    overbought_rsi: Phenotypes.Range(20, 100)
   }
 }

--- a/extensions/strategies/ta_macd_ext/strategy.js
+++ b/extensions/strategies/ta_macd_ext/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , rsi = require('../../../lib/rsi')
   , ta_macd_ext = require('../../../lib/ta_macd_ext')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'ta_macd_ext',
@@ -118,5 +119,31 @@ module.exports = {
     }
     return cols
   },
+
+  ta_macd_ext: {
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 104),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // have to be minimum 2 because talib will throw an "TA_BAD_PARAM" error
+    ema_short_period: Phenotypes.Range(2, 20),
+    ema_long_period: Phenotypes.Range(20, 100),
+    signal_period: Phenotypes.Range(1, 20),
+    fast_ma_type: Phenotypes.RangeMaType(),
+    slow_ma_type: Phenotypes.RangeMaType(),
+    signal_ma_type: Phenotypes.RangeMaType(),
+    default_ma_type: Phenotypes.RangeMaType(),
+    //    this.option('default_ma_type', 'set default ma_type for fast, slow and signal. You are able to overwrite single types separately (fast_ma_type, slow_ma_type, signal_ma_type)', String, 'SMA')
+    up_trend_threshold: Phenotypes.Range(0, 50),
+    down_trend_threshold: Phenotypes.Range(0, 50),
+    overbought_rsi_periods: Phenotypes.Range(1, 50),
+    overbought_rsi: Phenotypes.Range(20, 100)
+  }
 }
 

--- a/extensions/strategies/ta_ppo/strategy.js
+++ b/extensions/strategies/ta_ppo/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , rsi = require('../../../lib/rsi')
   , ta_ppo = require('../../../lib/ta_ppo')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'ta_ppo',
@@ -82,6 +83,26 @@ module.exports = {
     }
 
     return cols
+  },
+
+  phenotypes: {
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 104),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // have to be minimum 2 because talib will throw an "TA_BAD_PARAM" error
+    ema_short_period: Phenotypes.Range(2, 20),
+    ema_long_period: Phenotypes.Range(20, 100),
+    signal_period: Phenotypes.Range(1, 20),
+    ma_type: Phenotypes.RangeMaType(),
+    overbought_rsi_periods: Phenotypes.Range(1, 50),
+    overbought_rsi: Phenotypes.Range(20, 100)
   }
 }
 

--- a/extensions/strategies/ta_trix/strategy.js
+++ b/extensions/strategies/ta_trix/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , rsi = require('../../../lib/rsi')
   , ta_trix = require('../../../lib/ta_trix')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'ta_trix',
@@ -79,6 +80,22 @@ module.exports = {
     }
 
     return cols
+  },
+
+  phenotypes: {
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 104),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    timeperiod: Phenotypes.Range(1,60),
+    overbought_rsi_periods: Phenotypes.Range(1, 50),
+    overbought_rsi: Phenotypes.Range(20, 100)
   }
 }
 

--- a/extensions/strategies/ta_ultosc/strategy.js
+++ b/extensions/strategies/ta_ultosc/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , rsi = require('../../../lib/rsi')
   , ultosc = require('../../../lib/ta_ultosc')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'ta_ultosc',
@@ -128,6 +129,25 @@ module.exports = {
     }
 
     return cols
+  },
+
+  phenotypes: {
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 104),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    signal: Phenotypes.ListOption(['simple', 'low', 'trend']),
+    timeperiod1: Phenotypes.Range(1,50),
+    timeperiod2: Phenotypes.Range(1,50),
+    timeperiod3: Phenotypes.Range(1,50),
+    overbought_rsi_periods: Phenotypes.Range(1, 50),
+    overbought_rsi: Phenotypes.Range(20, 100)
   }
 }
 

--- a/extensions/strategies/trend_bollinger/strategy.js
+++ b/extensions/strategies/trend_bollinger/strategy.js
@@ -1,6 +1,7 @@
 var z = require('zero-fill')
   , n = require('numbro')
   , bollinger = require('../../../lib/bollinger')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'trend_bollinger',
@@ -84,6 +85,24 @@ module.exports = {
       cols.push('         ')
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    bollinger_size: Phenotypes.Range(1, 40),
+    bollinger_time: Phenotypes.RangeFloat(1,6),
+    bollinger_upper_bound_pct: Phenotypes.RangeFloat(-1, 30),
+    bollinger_lower_bound_pct: Phenotypes.RangeFloat(-1, 30)
   }
 }
 

--- a/extensions/strategies/trend_ema/strategy.js
+++ b/extensions/strategies/trend_ema/strategy.js
@@ -1,8 +1,9 @@
-var z = require('zero-fill'),
-  n = require('numbro'),
-  ema = require('../../../lib/ema'),
-  rsi = require('../../../lib/rsi'),
-  stddev = require('../../../lib/stddev')
+var z = require('zero-fill')
+  , n = require('numbro')
+  , ema = require('../../../lib/ema')
+  , rsi = require('../../../lib/rsi')
+  , stddev = require('../../../lib/stddev')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'trend_ema',
@@ -90,6 +91,24 @@ module.exports = {
       }
     }
     return cols
-  }
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 100),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    trend_ema: Phenotypes.Range(1, 40),
+    oversold_rsi_periods: Phenotypes.Range(5, 50),
+    oversold_rsi: Phenotypes.Range(20, 100)
+  },
 }
 

--- a/extensions/strategies/trendline/strategy.js
+++ b/extensions/strategies/trendline/strategy.js
@@ -1,10 +1,12 @@
-var math = require('mathjs')
-var trend = require('trend')
-var z = require('zero-fill')
-var n = require('numbro')
+let math = require('mathjs')
+  , trend = require('trend')
+  , z = require('zero-fill')
+  , n = require('numbro')
+  , stats = require('stats-lite')
+  , ema = require('../../../lib/ema')
+  , Phenotypes = require('../../../lib/phenotype')
 var oldgrowth = 1
-var stats = require('stats-lite')
-var ema = require('../../../lib/ema')
+
 module.exports = {
   name: 'trendline',
   description: 'Calculate a trendline and trade when trend is positive vs negative.',
@@ -101,4 +103,23 @@ module.exports = {
     cols.push(z(8, n(s.options.markup_sell_pct).format('0.00000000'), ' ')[s.accel === true ? 'green' : 'red'])
     return cols
   },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 400, 'm'),
+    min_periods: Phenotypes.Range(1, 200),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    lastpoints: Phenotypes.Range(20, 500),
+    avgpoints: Phenotypes.Range(300, 3000),
+    lastpoints2: Phenotypes.Range(5, 300),
+    avgpoints2: Phenotypes.Range(50, 1000),
+  }
 }

--- a/extensions/strategies/trust_distrust/strategy.js
+++ b/extensions/strategies/trust_distrust/strategy.js
@@ -1,5 +1,6 @@
 var z = require('zero-fill')
   , n = require('numbro')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'trust_distrust',
@@ -131,6 +132,27 @@ module.exports = {
     cols.push(z(8, n(s.period.high).format('0.0000'), ' ')[color])
     cols.push(z(8, n(s.trust_distrust_start).format('0.0000'), ' ').grey)
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 100),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    sell_threshold: Phenotypes.Range(1, 100),
+    sell_threshold_max: Phenotypes.Range0(1, 100),
+    sell_min: Phenotypes.Range(1, 100),
+    buy_threshold: Phenotypes.Range(1, 100),
+    buy_threshold_max: Phenotypes.Range0(1, 100),
+    greed: Phenotypes.Range(1, 100)
   }
 }
 

--- a/extensions/strategies/wavetrend/strategy.js
+++ b/extensions/strategies/wavetrend/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , wto = require('../../../lib/wto')
   , ema = require('../../../lib/ema')
+  , Phenotypes = require('../../../lib/phenotype')
 
 module.exports = {
   name: 'wavetrend',
@@ -168,6 +169,28 @@ module.exports = {
       cols.push('         ')
     }
     return cols
+  },
+
+  phenotypes: {
+    // -- common
+    period_length: Phenotypes.RangePeriod(1, 120, 'm'),
+    min_periods: Phenotypes.Range(1, 200),
+    markdown_buy_pct: Phenotypes.RangeFloat(-1, 5),
+    markup_sell_pct: Phenotypes.RangeFloat(-1, 5),
+    order_type: Phenotypes.ListOption(['maker', 'taker']),
+    sell_stop_pct: Phenotypes.Range0(1, 50),
+    buy_stop_pct: Phenotypes.Range0(1, 50),
+    profit_stop_enable_pct: Phenotypes.Range0(1, 20),
+    profit_stop_pct: Phenotypes.Range(1,20),
+
+    // -- strategy
+    wavetrend_channel_length: Phenotypes.Range(1,20),
+    wavetrend_average_length: Phenotypes.Range(1,42),
+    wavetrend_overbought_1: Phenotypes.Range(1, 100),
+    wavetrend_overbought_2: Phenotypes.Range(1,100),
+    wavetrend_oversold_1: Phenotypes.Range(-100,0),
+    wavetrend_oversold_2: Phenotypes.Range(-100,0),
+    wavetrend_trends: Phenotypes.ListOption([true, false])
   }
 }
 

--- a/lib/backtester.js
+++ b/lib/backtester.js
@@ -1,0 +1,573 @@
+let _ = require('lodash')
+  , moment = require('moment')
+  , argv = require('yargs').argv
+  , tb = require('timebucket')
+  , readline = require('readline')
+  , z = require('zero-fill')
+  , n = require('numbro')
+  , shell = require('shelljs')
+  , StripAnsi = require('strip-ansi')
+  , path = require('path')
+  , fs = require('fs')
+  , roundp = require('round-precision')
+  , Phenotypes = require('./phenotype')
+
+
+const spawn = require('child_process').spawn
+
+let simArgs, simTotalCount, parallelLimit, writeFile
+
+let processOutput = function (output,taskStrategyName, pheno) {
+  let selector = pheno.selector || pheno.exchangeMarketPair
+  let tFileName = path.resolve(__dirname, '..', 'simulations','sim_'+taskStrategyName.replace('_','')+'_'+ selector.toLowerCase().replace('_','')+'_'+pheno.backtester_generation+'.json')
+  let simulationResults
+
+  let params
+  let endBalance
+  let buyHold
+  let vsBuyHold
+  //let wlMatch
+  //let errMatch
+  let wins
+  let losses
+  let errorRate
+  let days
+  let start
+  let end
+  // This can retrieve the results from 2 different places.  It defaults to reading it from the json file
+  // but if no file is found it will fall back to the older metheod of scraping the output of the sim process
+  // stdio scraping to be removed after full verification of functionality.
+  // todo: see above comment
+  if (fs.existsSync(tFileName))
+  {
+    let jsonBuffer
+    jsonBuffer = fs.readFileSync(tFileName,{encoding:'utf8'})
+    simulationResults = JSON.parse(jsonBuffer)
+    fs.unlinkSync(tFileName)
+  }
+
+  // If somehow the sim file failed to write, this will most often recover it by parsing the last output
+  if (typeof(simulationResults) !== 'object'  ) {
+    // Find everything between the first { and last }
+    outputArray = output.split("{")
+    outputArray.shift();
+    output = outputArray.join('{')
+
+    outputArray = output.split("}")
+    outputArray.pop();
+    output = outputArray.join('}')
+
+    simulationResults = JSON.parse(`{${output}}`)
+  }
+
+  if (typeof(simulationResults) === 'object') {
+    params = simulationResults
+    endBalance = simulationResults.simresults.currency
+    buyHold = simulationResults.simresults.buy_hold
+    vsBuyHold = simulationResults.simresults.vs_buy_hold
+    //wlMatch = (simulationResults.simresults.total_sells - simulationResults.simresults.total_losses) +'/'+ simulationResults.simresults.total_losses
+    wins          = simulationResults.simresults.total_sells - simulationResults.simresults.total_losses
+    losses        = simulationResults.simresults.total_losses
+    errorRate     = simulationResults.simresults.total_losses / simulationResults.simresults.total_sells
+    days = parseInt(simulationResults.days)
+    start = parseInt(simulationResults.start)
+    end = parseInt(simulationResults.end || null)
+  }
+  else {
+    console.log(`Couldn't find simulationResults for ${pheno.backtester_generation}`)
+    // this should return a general bad result but not throw an error
+    // our job here is to use the result.  not diagnose an error at this point so a failing sim should just be ignored.
+    // idea here is to make the fitness of this calculation as bad as possible so darwin won't use the combonation of parameters again.
+    // todo:  make the result its own object, and in this function just set the values don't define the result here.
+    return {
+      params: 'module.exports = {}',
+      endBalance: 0,
+      buyHold: 0,
+      vsBuyHold: 0,
+      wins: 0,
+      losses: -1,
+      errorRate: 100,
+      days: 0,
+      period_length: 0,
+      min_periods: 0,
+      markdown_buy_pct: 0,
+      markup_sell_pct: 0,
+      order_type: 'maker',
+      wlRatio: 'Infinity',
+      roi: -1000,
+      selector: params.selector,
+      strategy: params.strategy,
+      frequency: 0
+    }
+  }
+
+  if (typeof params === 'undefined') {
+    console.log('busted params')
+    console.log(`output: ${JSON.stringify(output)}`)
+    console.log(`simulationResults: ${JSON.stringify(simulationResults)}`)
+  }
+
+  let roi
+  if  (params.currency_capital == 0.0)
+  {
+    roi = roundp(endBalance, 3 )
+  }
+  else
+  {
+    roi = roundp(((endBalance - params.currency_capital) / params.currency_capital) * 100, 3 )
+  }
+
+  //todo: figure out what this is trying to do.
+  let r = params
+  delete r.asset_capital
+  delete r.buy_pct
+  delete r.currency_capital
+  delete r.days
+  delete r.mode
+  delete r.order_adjust_time
+  delete r.population
+  delete r.population_data
+  delete r.sell_pct
+  delete r.start
+  delete r.end
+  delete r.stats
+  delete r.use_strategies
+  delete r.verbose
+  delete r.simresults
+  r.selector = r.selector.normalized
+
+  if (start) {
+    r.start = moment(start).format('YYYYMMDDHHmm')
+  }
+  if (end) {
+    r.end = moment(end).format('YYYYMMDDHHmm')
+  }
+  if (!start && !end && params.days) {
+    r.days = params.days
+  }
+  if (!days) {
+    days = parseInt(argv.days, 10)
+  }
+  if (!days || days < 1) days = 1
+
+  let results = {
+    params: 'module.exports = ' + JSON.stringify(r),
+    endBalance: parseFloat(endBalance),
+    buyHold: parseFloat(buyHold),
+    vsBuyHold: parseFloat(vsBuyHold) || vsBuyHold,
+    wins: wins,
+    losses: losses,
+    errorRate: parseFloat(errorRate),
+    days: days,
+    period_length: params.period_length,
+    min_periods: params.min_periods,
+    markdown_buy_pct: params.markdown_buy_pct,
+    markup_sell_pct: params.markup_sell_pct,
+    order_type: params.order_type,
+    wlRatio: losses > 0 ? roundp(wins / losses, 3) : 'Infinity',
+    roi: roi,
+    selector: params.selector,
+    strategy: params.strategy,
+    frequency: roundp((wins + losses) / days, 3)
+  }
+
+
+
+  return results
+}
+
+let runUpdate = function (days, selector) {
+  let zenbot_cmd = process.platform === 'win32' ? 'zenbot.bat' : './zenbot.sh'
+  let command = `${zenbot_cmd} backfill --days=${days} ${selector}`
+  console.log('Backfilling (might take some time) ...')
+  console.log(command)
+
+  shell.exec(command, {
+    silent: true,
+    async: false
+  })
+}
+
+let ensureDirectoryExistence = function(filePath) {
+  var dirname = path.dirname(filePath)
+  if (fs.existsSync(dirname)) {
+    return true
+  }
+  ensureDirectoryExistence(dirname)
+  fs.mkdirSync(dirname)
+}
+
+let monitor = {
+  periodDurations: [],
+  phenotypes: [],
+
+  distanceOfTimeInWords: (timeA, timeB) => {
+    var hourDiff = timeA.diff(timeB, 'hours')
+    let minDiff = 0
+    if (hourDiff == 0) {
+      minDiff = timeA.diff(timeB, 'minutes')
+      var secDiff = timeA.clone().subtract(minDiff, 'minutes').diff(timeB, 'seconds')
+      return `${minDiff}m ${secDiff}s`
+    }
+    else {
+      minDiff = timeA.clone().subtract(hourDiff, 'hours').diff(timeB, 'minutes')
+      return `${hourDiff}h ${minDiff}m`
+    }
+  },
+
+  actualRange: function(so) {
+    // Adapted from sim.js logic to similarly figure out how much time is being processed
+    if (so.start) {
+      so.start = moment(so.start, 'YYYYMMDDHHmm')
+      if (so.days && !so.end) {
+        so.end = so.start.clone().add(so.days, 'days')
+      }
+    }
+    if (so.end) {
+      so.end = moment(so.end, 'YYYYMMDDHHmm')
+      if (so.days && !so.start) {
+        so.start = so.end.clone().subtract(so.days, 'days')
+      }
+    }
+    if (!so.start && so.days) {
+      so.start = moment().subtract(so.days, 'days')
+    }
+
+    if (so.days && !so.end) {
+      so.end = so.start.clone().add(so.days, 'days')
+    }
+
+    if (so.start && so.end) {
+      var actualStart = moment( tb(so.start.valueOf()).resize(so.period_length).subtract(so.min_periods + 2).toMilliseconds() )
+      return {
+        start: actualStart,
+        end: so.end
+      }
+    }
+
+    return { start: so.start, end: so.end }
+  },
+
+  reportStatus: function() {
+    var genCompleted = 0
+    // var genTotal = 0
+
+    var simsDone = 0
+    var simsActive = 0
+    var simsErrored = 0
+    var simsAll = simTotalCount
+    var simsRemaining = simsAll
+    // var self = this
+    // console.log(`simsAll: ${simsAll}, this.phenotypes: ${this.phenotypes.length}`);
+
+    readline.clearLine(process.stdout)
+    readline.cursorTo(process.stdout, 0)
+
+    var inProgress = []
+    var inProgressStr = []
+
+    var slowestP = null
+    var slowestEta = null
+
+    var bestP = null
+    var bestBalance = null
+
+    this.phenotypes.forEach(function(p) {
+      if ('sim' in p) {
+        if (Object.keys(p.sim).length === 0) {
+          simsActive++
+          inProgress.push(p)
+        }
+        else {
+          simsDone++
+
+          if (!p.command || !p.command.result)
+            simsErrored++
+
+          if (p.command) {
+            let balance = p.command.result.endBalance
+
+            if (bestP == null || bestBalance < balance) {
+              bestP = p
+              bestBalance = balance
+            }
+            else if (bestP && bestBalance == balance && bestP.command.iteration > p.command.iteration) {
+              // Always pick the earliest one so it doesn't look like the number is jumping all over the place
+              bestP = p
+              bestBalance = balance
+            }
+          }
+        }
+        simsRemaining--
+      }
+
+    })
+
+    var homeStretchMode = simsActive < (parallelLimit-1) && simsRemaining == 0
+
+    inProgress.forEach(function(p) {
+      var c = p.command
+
+      var currentTime
+      if (c.currentTimeString) currentTime = moment(c.currentTimeString, 'YYYY-MM-DD HH:mm:ss')
+      if (currentTime && currentTime.isBefore(c.queryStart)) c.queryStart = currentTime
+      // console.log(`${c.iteration} currentTime: ${currentTime}, queryStart: ${c.queryStart}, queryEnd: ${c.queryEnd}, current: ${c.currentTimeString}`);
+
+      // var timeSoFar = moment().diff(c.startTime);
+      // console.log(`remaining: ${time} - ${timeSoFar} = ${time - timeSoFar}`);
+      // timeLeft += time - timeSoFar;
+      if (currentTime && c.queryStart && c.queryEnd) {
+        var totalTime = c.queryEnd.diff(c.queryStart)
+
+        // 2018-01-25 06:18:00
+        var progress = currentTime.diff(c.queryStart)
+
+        // console.log(`totalTime: ${totalTime} vs progress: ${progress}`);
+        var percentage = Math.min(progress/totalTime, 1)
+        genCompleted += percentage
+
+        var now = moment()
+        var timeElapsed = now.diff(c.startTime)
+        // console.log(`startTime: ${c.startTime}, timeElapsed: ${timeElapsed}, adding: ${timeElapsed / percentage}ms`);
+        var eta = c.startTime.clone().add(timeElapsed / percentage, 'milliseconds')
+
+        if (slowestP == null || slowestEta.isBefore(eta)) {
+          slowestP = p
+          slowestEta = eta
+        }
+
+        if (homeStretchMode)
+          inProgressStr.push(`${(c.iteration + ':').gray} ${(percentage*100).toFixed(1)}% ETA: ${monitor.distanceOfTimeInWords(eta, now)}`)
+        else
+          inProgressStr.push(`${(c.iteration + ':').gray} ${(percentage*100).toFixed(1)}%`)
+      }
+    })
+
+
+    // timeLeft /= simsActive; // how many run at one time
+    if (inProgressStr.length > 0) {
+      // process.stdout.write("\u001b[1000D") // Move left
+      process.stdout.write('\u001b[1A')
+      readline.clearLine(process.stdout)
+      readline.cursorTo(process.stdout, 0)
+
+      process.stdout.write(inProgressStr.join(', '))
+      process.stdout.write('\n')
+    }
+
+
+    var percentage = ((simsDone + genCompleted)/simsAll * 100).toFixed(1)
+    // z(8, n(s.period.trend_ema_rate).format('0.0000'), ' ')[color]
+    process.stdout.write(`Done: ${simsDone.toString().green}, Active: ${simsActive.toString().yellow}, Remaining: ${simsRemaining.toString().gray}, `)
+    if (simsErrored > 0)
+      process.stdout.write(`Errored: ${simsErrored.toString().red}, `)
+
+    process.stdout.write(`Completion: ${z(5, (n(percentage).format('0.0') + '%'), ' ').green} `)
+
+    let bestBColor = 'gray'
+
+    if (bestP) {
+      if (argv.currency_capital) {
+        let cc = parseFloat(argv.currency_capital)
+        if (cc < 0.1)
+          bestBColor = 'green'
+        else if (cc > bestBalance)
+          bestBColor = 'red'
+        else
+          bestBColor = 'yellow'
+      }
+    }
+
+    let bestBalanceString = z(5, n(bestBalance || 0).format('0.0000'), ' ')[bestBColor]
+    process.stdout.write(`Best Balance(${(bestP ? bestP.command.iteration.toString() : '?')[bestBColor]}): ${bestBalanceString}`)
+
+    if (inProgressStr.length > 0) {
+      if (!homeStretchMode)
+        process.stdout.write(`, Slowest(${slowestP.command.iteration.toString().yellow}) ETA: ${monitor.distanceOfTimeInWords(slowestEta, moment()).yellow}`)
+    }
+  },
+
+  reset: function() {
+    this.phenotypes.length = 0
+  },
+
+  start: function() {
+    process.stdout.write('\n\n')
+    this.generationStarted = moment()
+
+    this.reportInterval = setInterval(() => {
+      this.reportStatus()
+    }, 1000)
+  },
+
+  stop: function(label) {
+    this.generationEnded = moment()
+    clearInterval(this.reportInterval)
+    var timeStr = this.distanceOfTimeInWords(this.generationEnded, this.generationStarted)
+    console.log(`\n\n${label} completed at ${this.generationEnded.format('YYYY-MM-DD HH:mm:ss')}, took ${timeStr}, results saved to:`)
+  }
+}
+
+module.exports = {
+
+  init: function(options) {
+    simArgs = options.simArgs
+    simTotalCount = options.simTotalCount
+    parallelLimit = options.parallelLimit
+    writeFile = options.writeFile
+  },
+
+  deLint: function() {
+    //Clean up any generation files left over in the simulation directory
+    //they will be overwritten, but best not to confuse the issue.
+    //if it fails.   doesn't matter they will be overwritten anyways. not need to halt the system.
+    try {
+      let tDirName = path.resolve(__dirname, '..', 'simulations')
+      let tFileName = 'sim_'
+      let files = fs.readdirSync(tDirName)
+
+      for(let i = 0; i < files.length; i++) {
+        if (files[i].lastIndexOf(tFileName) == 0) {
+          let filePath = path.resolve(__dirname, '..', 'simulations',files[i] )
+          fs.unlinkSync(filePath)
+        }
+
+      }
+    } catch (err) {
+      console.log('error deleting lint from prior run')
+    }
+  },
+
+  writeFileAndFolder: function(filePath, data) {
+    ensureDirectoryExistence(filePath)
+    fs.writeFileSync(filePath, data)
+  },
+
+  ensureBackfill: function() {
+    let days = argv.days
+    if (!days) {
+      if (argv.start) {
+        var start = moment(argv.start, 'YYYYMMDDHHmm')
+        days = Math.max(1, moment().diff(start, 'days'))
+      }
+      else {
+        var end = moment(argv.end, 'YYYYMMDDHHmm')
+        days = moment().diff(end, 'days') + 1
+      }
+    }
+    runUpdate(days, argv.selector)
+  },
+
+  buildCommand: function(taskStrategyName, phenotype, filename) {
+    var cmdArgs = Object.assign({}, phenotype)
+    cmdArgs.strategy = taskStrategyName
+    Object.assign(cmdArgs, simArgs)
+
+    var selector = cmdArgs.selector
+    delete cmdArgs.selector
+    delete cmdArgs.exchangeMarketPair
+    delete cmdArgs.sim
+    delete cmdArgs.command
+    delete cmdArgs.help
+    delete cmdArgs.version
+
+    if (argv.include_html)
+      cmdArgs.filename = filename
+
+    if (argv.silent)
+      cmdArgs.silent = true
+
+    cmdArgs.backtester_generation = phenotype.backtester_generation
+
+    let zenbot_cmd = process.platform === 'win32' ? 'zenbot.bat' : './zenbot.sh'
+    let command = `${zenbot_cmd} sim ${selector}`
+
+    for (const [ key, value ] of Object.entries(cmdArgs)) {
+      if(_.isBoolean(value)){
+        command += ` --${value ? '' : 'no-'}${key}`
+      } else {
+        command += ` --${key}=${value}`
+      }
+    }
+
+    var actualRange = monitor.actualRange({
+      start: cmdArgs.start, end: cmdArgs.end, days: cmdArgs.days,
+      period_length: cmdArgs.period_length, min_periods: (cmdArgs.min_periods || 1)
+    })
+
+    return {
+      commandString: command,
+      queryStart: actualRange.start,
+      queryEnd: actualRange.end
+    }
+  },
+
+  runCommand: (taskStrategyName, phenotype, command, cb) => {
+    // console.log(`[ ${command.iteration}/${populationSize * selectedStrategies.length} ] ${command.commandString}`)
+
+    var self = this
+    phenotype['sim'] = {}
+    phenotype['command'] = command
+
+    command.startTime = moment()
+    var cmdArgs = command.commandString.split(' ')
+    var cmdName = cmdArgs.shift()
+    const proc = spawn(cmdName, cmdArgs)
+    var endData = ''
+
+    proc.on('exit', () => {
+      let result = null
+      let stdout = endData.toString()
+      try {
+        result = processOutput(stdout,taskStrategyName,phenotype)
+
+        command.endTime = moment()
+        command.result = result
+
+        writeFile(command.iteration, JSON.stringify(command))
+
+        phenotype['sim'] = result
+        result['fitness'] = Phenotypes.fitness(phenotype)
+
+        monitor.reportStatus()
+
+      } catch (err) {
+        console.log(`Bad output detected on sim ${command.iteration} while running:`)
+        console.log(command.commandString)
+        console.log(err.toString())
+        console.log(stdout)
+        console.log(err.stack)
+      }
+
+      cb(null, result)
+    })
+    proc.stdout.on('data', (data) => {
+      if (data.length > 500) {
+        endData = data
+        // console.log(`${command.iteration}: ${data}`)
+      }
+      else {
+        var str = StripAnsi(data.toString()), lines = str.split(/(\r?\n)/g)
+        for (var i=0; i<lines.length; i++) {
+          var line = lines[i]
+          // console.log(`${command.iteration}: ${line}`)
+          if (line.indexOf('-') == 4 && line.indexOf(':') == 13) {
+            var timeStr = line.slice(0, 20)
+            command.currentTimeString = timeStr
+            // console.log(`${command.iteration}: ${command.currentTimeString}`)
+          }
+        }
+
+      }
+    })
+  },
+
+  startMonitor: () => monitor.start(),
+  stopMonitor: (label) => monitor.stop(label),
+  resetMonitor: () => monitor.reset(),
+  reportStatus: () => monitor.reportStatus(),
+  trackPhenotype: function(phenotype) {
+    monitor.phenotypes.push(phenotype)
+  }
+
+}

--- a/lib/phenotype.js
+++ b/lib/phenotype.js
@@ -25,30 +25,47 @@ module.exports = {
         else r[k] = Math.round((Math.random() * (v.max - v.min + 1)/v.factor)*v.factor)
       } else if (v.type === 'float') {
         r[k] = (Math.random() * (v.max - v.min)) + v.min
-      } else if (v.type === 'makertaker') {
-        r[k] = (Math.random() > 0.5) ? 'maker' : 'taker'
-      } else if (v.type === 'sigmoidtanhrelu') {
-        let items = ['sigmoid', 'tanh', 'relu']
-        let index = Math.floor(Math.random() * items.length)
-        r[k] = items[index]
       } else if (v.type === 'period_length') {
         var s = Math.floor((Math.random() * (v.max - v.min + 1)) + v.min)
         r[k] = s + v.period_length
-      } else if (v.type === 'truefalse') {
-        r[k] = (Math.random() > 0.5) ? true : false
+      } else if (v.type === 'listOption') {
+        let index = Math.floor(Math.random() * v.options.length)
+        r[k] = v.options[index]
       }
-      else if (v.type === 'maType') {
-        let items = ['SMA', 'EMA', 'WMA', 'DEMA', 'TEMA', 'TRIMA', 'KAMA', 'MAMA', 'T3']
-        let index = Math.floor(Math.random() * items.length)
-        r[k] = items[index]
-      } else if (v.type === 'uscSignalType') {
-        let items = ['simple', 'low', 'trend']
-        let index = Math.floor(Math.random() * items.length)
-        r[k] = items[index]
-      } 
-      
+
     }
     return r
+  },
+
+  range: function(v, step, stepSize) {
+    var scale = step / (stepSize - 1)
+
+    if (v.type === 'int') {
+      return Math.floor((scale * (v.max - v.min)) + v.min)
+    }
+    else if (v.type === 'int0') {
+      if (step == 0)
+        return 0
+
+      scale = (step-1) / (stepSize-2)
+      return Math.floor((scale * (v.max - v.min)) + v.min)
+    }
+    else if (v.type === 'intfactor') {
+      let val = Math.floor((scale * (v.max - v.min)) + v.min)
+      return Math.floor(val / v.factor) * v.factor
+    }
+    else if (v.type === 'float') {
+      return (scale * (v.max - v.min)) + v.min
+    }
+    else if (v.type === 'period_length') {
+      var s = Math.floor((scale * (v.max - v.min)) + v.min)
+      return s + v.period_length
+    }
+    else if (v.type === 'listOption') {
+      scale = step / stepSize
+      let index = Math.floor(scale * v.options.length)
+      return v.options[index]
+    }
   },
 
   mutation: function(oldPhenotype, strategy) {
@@ -78,7 +95,7 @@ module.exports = {
 
   fitness: function(phenotype) {
     if (typeof phenotype.sim === 'undefined') return 0
-    
+
     var vsBuyHoldRate = (phenotype.sim.vsBuyHold / 50)
     var wlRatio = phenotype.sim.wins / phenotype.sim.losses
     if(isNaN(wlRatio)) { // zero trades will result in 0/0 which is NaN
@@ -92,5 +109,69 @@ module.exports = {
   competition: function(phenotypeA, phenotypeB) {
     // TODO: Refer to geneticalgorithm documentation on how to improve this with diverstiy
     return module.exports.fitness(phenotypeA) >= module.exports.fitness(phenotypeB)
+  },
+
+  Range: function(min, max)  {
+    var r = {
+      type: 'int',
+      min: min,
+      max: max
+    }
+    return r
+  },
+
+  Range0: function(min, max)  {
+    var r = {
+      type: 'int0',
+      min: min,
+      max: max
+    }
+    return r
+  },
+
+  RangeFactor: function(min, max, factor)  {
+    var r = {
+      type: 'intfactor',
+      min: min,
+      max: max,
+      factor: factor
+    }
+    return r
+  },
+
+  RangeFloat: function(min, max)  {
+    var r = {
+      type: 'float',
+      min: min,
+      max: max
+    }
+    return r
+  },
+
+  RangePeriod: function(min, max, period_length)  {
+    var r = {
+      type: 'period_length',
+      min: min,
+      max: max,
+      period_length: period_length
+    }
+    return r
+  },
+
+  RangeMaType: function() {
+    var r = {
+      type: 'listOption',
+      options: ['SMA', 'EMA', 'WMA', 'DEMA', 'TEMA', 'TRIMA', 'KAMA', 'MAMA', 'T3']
+    }
+    return r
+  },
+
+  ListOption: function(options) {
+    var r ={
+      type: 'listOption',
+      options: options
+    }
+    return r
   }
+
 }

--- a/scripts/auto_backtester/backtester.js
+++ b/scripts/auto_backtester/backtester.js
@@ -1,351 +1,279 @@
 #!/usr/bin/env node
 
-/* Zenbot 4.04 Backtester v0.2
- * Ali Anari <ali@anari.io>
- * 05/30/2017
+/* Zenbot 4 Auto Backtester v2.0
+ * glennfu
  *
  * Usage: Pass in the same parameters as you would to "zenbot sim", EXCEPT for:
- * EMA Parameters: "trend_ema", "neutral_rate"
- * RSI Parameters: "oversold_rsi", "oversold_rsi_periods"
+ * 2 parameters you want to be backtested
  *
- * Example: ./backtester.js gdax.ETH-USD --days=10 --currency_capital=5
+ * Imagine you've just run:
+ *
+ *    ./scripts/genetic_backtester/darwin.js --days=1 --asset_capital=0 --currency_capital=500 --selector="binance.EOS-BTC" --population=20 --use_strategies=trend_ema
+ *
+ * and got the following result:
+ *
+ *    ./zenbot.sh sim binance.EOS-BTC --avg_slippage_pct=0.045 --buy_stop_pct=40 --markdown_buy_pct=0.37804270974174603 --markup_sell_pct=4.088646046027306 --max_buy_loss_pct=25 --max_sell_loss_pct=25 --max_slippage_pct=5 --min_periods=7 --neutral_rate=auto --order_poll_time=5000 --order_type=maker --oversold_rsi=78 --oversold_rsi_periods=15 --period=73m --period_length=73m --profit_stop_enable_pct=2 --profit_stop_pct=5 --rsi_periods=15 --sell_stop_pct=0 --strategy=trend_ema --trend_ema=4 --start=201802251900 --asset_capital=0 --currency_capital=500
+ *
+ * which performs like:
+ *     end balance: 500.34778000 (0.06%)
+ *     buy hold: 500.98047787 (0.19%)
+ *     vs. buy hold: -0.13%
+ *     2 trades over 3 days (avg 0.66 trades/day)
+ *     win/loss: 1/0
+ *     error rate: 0.00%
+ *
+ * To use the Auto Backtester, simply remove one or two parameters that are in strategies/trend_ema/strategy.js's phenotype definition.
+ * Let's remove `order_type` and `oversold_rsi`
+ *
+ *    ./zenbot.sh sim binance.EOS-BTC --avg_slippage_pct=0.045 --buy_stop_pct=40 --markdown_buy_pct=0.37804270974174603 --markup_sell_pct=4.088646046027306 --max_buy_loss_pct=25 --max_sell_loss_pct=25 --max_slippage_pct=5 --min_periods=7 --neutral_rate=auto --order_poll_time=5000 --oversold_rsi_periods=15 --period=73m --period_length=73m --profit_stop_enable_pct=2 --profit_stop_pct=5 --rsi_periods=15 --sell_stop_pct=0 --strategy=trend_ema --trend_ema=4 --start=201802251900 --asset_capital=0 --currency_capital=500
+ *
+ * Now pass this to backtester.js and add a step_size, like 10, and re-add days=1 from darwin
+ *
+ *    ./scripts/auto_backtester/backtester.js --step_size=10 --days=1 --selector=binance.EOS-BTC --avg_slippage_pct=0.045 --buy_stop_pct=40 --markdown_buy_pct=0.37804270974174603 --markup_sell_pct=4.088646046027306 --max_buy_loss_pct=25 --max_sell_loss_pct=25 --max_slippage_pct=5 --min_periods=7 --neutral_rate=auto --order_poll_time=5000 --oversold_rsi_periods=15 --period=73m --period_length=73m --profit_stop_enable_pct=2 --profit_stop_pct=5 --rsi_periods=15 --sell_stop_pct=0 --strategy=trend_ema --trend_ema=4 --start=201802251900 --asset_capital=0 --currency_capital=500
+ *
+ * See output:
+ *
+ *   Auto Backtest of order_type and oversold_rsi completed at 2018-02-27 15:43:28, took 0m 7s, results saved to:
+ *   simulations/auto_backtest_201802271543/results_auto_backtest_201802271543.csv
+ *
+ *
+ *   Best Result had order_type=taker and oversold_rsi=73
+ *   (trend_ema) Result Fitness 0.006083518953845421, VS Buy and Hold:   0.3% BuyAndHold Balance: 500.980477  End Balance: 502.504339, Wins/Losses 1/0, ROI 0.000000.
+ *   ./zenbot.sh sim binance.EOS-BTC --period_length=73m --min_periods=7 --markdown_buy_pct=0.37804270974174603 --markup_sell_pct=4.088646046027306 --order_type=taker --sell_stop_pct=0 --buy_stop_pct=40 --profit_stop_enable_pct=2 --profit_stop_pct=5 --trend_ema=4 --oversold_rsi_periods=15 --oversold_rsi=73 --backtester_generation=16 --strategy=trend_ema --days=1 --avg_slippage_pct=0.045 --max_buy_loss_pct=25 --max_sell_loss_pct=25 --max_slippage_pct=5 --neutral_rate=auto --order_poll_time=5000 --rsi_periods=15 --start=201802251900 --asset_capital=0 --currency_capital=500
+ *
+ * So you can see our vsBuyHold has gone from -0.13% to 0.30%, an improvement!
 */
 
-let shell     = require('shelljs')
-let parallel  = require('run-parallel-limit')
-let json2csv  = require('json2csv')
-let roundp    = require('round-precision')
-let fs        = require('fs')
-let path = require('path')
-
-let VERSION = 'Zenbot 4.04 Backtester v0.2'
+let Phenotypes = require('../../lib/phenotype')
+  , Backtester = require('../../lib/backtester')
+  , argv = require('yargs').argv
+  , moment = require('moment')
+  , path = require('path')
+  , parallel = require('run-parallel-limit')
+  , colors = require('colors')
+  , z = require('zero-fill')
+  , n = require('numbro')
+  , _ = require('underscore')
+  , json2csv = require('json2csv')
 
 let PARALLEL_LIMIT = (process.env.PARALLEL_LIMIT && +process.env.PARALLEL_LIMIT) || require('os').cpus().length
 
-let TREND_EMA_MIN = 20
-let TREND_EMA_MAX = 20
+simArgs = Object.assign({}, argv)
+if (simArgs.period)
+  simArgs.period_length = simArgs.period
+delete simArgs.period
+delete simArgs['$0'] // This comes in to argv all by itself
+delete simArgs['_']  // This comes in to argv all by itself
 
-let OVERSOLD_RSI_MIN = 20
-let OVERSOLD_RSI_MAX = 35
+let debug = simArgs.debug
+delete simArgs.debug
 
-let OVERSOLD_RSI_PERIODS_MIN = 15
-let OVERSOLD_RSI_PERIODS_MAX = 25
+if (simArgs.maxCores) {
+  if (simArgs.maxCores < 1)
+    PARALLEL_LIMIT = 1
+  else
+    PARALLEL_LIMIT = simArgs.maxCores
 
-let NEUTRAL_RATE_MIN = 10
-let NEUTRAL_RATE_MAX = 10
-
-let NEUTRAL_RATE_AUTO = false
-
-let countArr = []
-
-let range = (start, end, step) => {
-  if (!step) step = 1
-  var r = []
-  for (var i=start; i<=end; i+=step) {
-    r = r.concat(i)
-  }
-  return r
+  delete simArgs.maxCores
 }
 
-let product = args => {
-  if(!args.length)
-    return [[]]
-  var prod = product(args.slice(1)), r = []
-  args[0].forEach(function(x) {
-    prod.forEach(function(p) {
-      r.push([x].concat(p))
+let population_data = `auto_backtest_${moment().format('YYYYMMDDHHmm')}`
+let iterationCount = 0
+
+if (simArgs.help || !simArgs.selector || !simArgs.step_size || simArgs.step_size < 2) {
+  console.log('--strategy=<stragegy_name> only one strategy')
+  console.log('--step_size=<int>    number of sims for each parameter, minimum 2')
+  console.log('--maxCores=<int>    maximum processes to execute at a time default is # of cpu cores in system')
+  console.log('--selector=<exchange.marketPair>  ')
+  console.log('--asset_capital=<float>    amount coin to start sim with ')
+  console.log('--currency_capital=<float>  amount of capital/base currency to start sim with'),
+  console.log('--days=<int>  amount of days to use when backfilling')
+  console.log('--sort_results  add if you want results.csv sorted by fitness')
+  process.exit(0)
+}
+
+var timeCount = 0
+if (simArgs.days) timeCount++
+if (simArgs.start) timeCount++
+if (simArgs.end) timeCount++
+
+if (timeCount < 2) {
+  console.log('need at least 2 of: days, start, end')
+  process.exit(1)
+}
+
+function runAutoBacktester () {
+
+  let strategyName = simArgs.strategy
+  let strategyData = require(path.resolve(__dirname, `../../extensions/strategies/${strategyName}/strategy`))
+  let strategyPhenotypes = strategyData.phenotypes
+  if (!strategyPhenotypes) {
+    console.log(`No phenotypes definition found for strategy ${strategyName}`)
+    process.exit(1)
+  }
+
+  var pData = Object.assign({}, strategyPhenotypes)
+  var unsetKeys = []
+  Object.keys(strategyPhenotypes).forEach(function (key) {
+    if (key in simArgs) {
+      pData[key] = simArgs[key]
+    }
+    else {
+      unsetKeys.push(key)
+    }
+  })
+
+  if (unsetKeys.length > 2) {
+    console.log(`You omitted values for keys: ${unsetKeys.join(', ')}. You can have at most 2 unset keys`)
+    process.exit(1)
+  }
+  else if (unsetKeys.length <= 0) {
+    console.log(`You must omit at least one key in ${strategyName}'s phenotype for backtesting`)
+    process.exit(1)
+  }
+
+  console.log(`\n\n=== Running Auto Backtester on ${unsetKeys.join(' and ').blue} ===\n`)
+
+  Backtester.resetMonitor()
+  Backtester.ensureBackfill()
+
+  let step_size = simArgs.step_size
+  delete simArgs.step_size
+
+  let phenotypes = []
+
+  let step_size_1 = step_size
+    , step_size_2 = step_size
+    , key1 = unsetKeys[0]
+    , key2 = unsetKeys[1]
+    , p1 = strategyPhenotypes[key1]
+    , p2 = strategyPhenotypes[key2]
+
+  // If you're iterating through a set, do the whole set regardless of step_size
+  if (p1 && p1.type === 'listOption')
+    step_size_1 = p1.options.length
+  if (p2 && p2.type === 'listOption')
+    step_size_2 = p2.options.length
+
+  // If we have 2 keys, build all combinations of both, otherwise just loop through the 1 key values
+  if (unsetKeys.length == 2) {
+    for (let i = 0; i < step_size_1; i++) {
+      for (let j = 0; j < step_size_2; j++) {
+        var phenotype = Object.assign({}, pData)
+        phenotype[key1] = Phenotypes.range(p1, i, step_size_1)
+        phenotype[key2] = Phenotypes.range(p2, j, step_size_2)
+        phenotypes.push(phenotype)
+      }
+    }
+  }
+  else {
+    for (let i = 0; i < step_size_1; i++) {
+      var phenotype = Object.assign({}, pData)
+      phenotype[key1] = Phenotypes.range(p1, i, step_size_1)
+      phenotypes.push(phenotype)
+    }
+  }
+
+  if (debug)
+    console.log(`Running options:`)
+
+  // Remove duplicates in case something is screwy in combination with step_size higher than the number of options.
+  // No sense in re-running the same thing multiple times
+  phenotypes = _.uniq(phenotypes, function(p, key, a) {
+    if (debug)
+      console.log(`${key1}: ${p[key1]}, ${key2}: ${p[key2]}`) // print all combinations of options
+    return JSON.stringify(p);
+  });
+
+  Backtester.init({
+    simArgs: simArgs,
+    simTotalCount: phenotypes.length,
+    parallelLimit: PARALLEL_LIMIT,
+    writeFile: writeSimDataFile
+  })
+
+  let tasks = phenotypes.map(phenotype => {
+
+    return cb => {
+      phenotype.backtester_generation = iterationCount
+      phenotype.selector = argv.selector
+      Backtester.trackPhenotype(phenotype)
+
+      var command = Backtester.buildCommand(strategyName, phenotype, `simulations/${population_data}/sim_${iterationCount}_result.html`)
+      command.iteration = iterationCount
+      writeSimDataFile(iterationCount, JSON.stringify(command))
+
+      iterationCount++
+      Backtester.runCommand(strategyName, phenotype, command, cb)
+    }
+  })
+
+  Backtester.startMonitor()
+
+  parallel(tasks, PARALLEL_LIMIT, (err, results) => {
+    Backtester.stopMonitor(`Auto Backtest of ${unsetKeys.join(' and ').blue}`)
+
+    results = results.filter(function(r) {
+      return !!r
     })
-  })
-  return r
-}
 
-let objectProduct = obj => {
-  var keys = Object.keys(obj),
-    values = keys.map(function(x) { return obj[x] })
+    if (argv.sort_results)
+      results.sort((a, b) => (Number(a.fitness) < Number(b.fitness)) ? 1 : ((Number(b.fitness) < Number(a.fitness)) ? -1 : 0))
 
-  return product(values).map(function(p) {
-    var e = {}
-    keys.forEach(function(k, n) { e[k] = p[n] })
-    return e
-  })
-}
+    // console.log(`results(${results.length}): ${JSON.stringify(results)}`)
 
-let runCommand = (strategy, exchangeMarketPair,strategyName, cb) => {
-  countArr.push(1)
-  let strategyArgs = {
-    cci_srsi: `--cci_periods=${strategy.rsi_periods} --rsi_periods=${strategy.srsi_periods} --srsi_periods=${strategy.srsi_periods} --srsi_k=${strategy.srsi_k} --srsi_d=${strategy.srsi_d} --oversold_rsi=${strategy.oversold_rsi} --overbought_rsi=${strategy.overbought_rsi} --oversold_cci=${strategy.oversold_cci} --overbought_cci=${strategy.overbought_cci} --constant=${strategy.constant}`,
-    srsi_macd: `--rsi_periods=${strategy.rsi_periods} --srsi_periods=${strategy.srsi_periods} --srsi_k=${strategy.srsi_k} --srsi_d=${strategy.srsi_d} --oversold_rsi=${strategy.oversold_rsi} --overbought_rsi=${strategy.overbought_rsi} --ema_short_period=${strategy.ema_short_period} --ema_long_period=${strategy.ema_long_period} --signal_period=${strategy.signal_period} --up_trend_threshold=${strategy.up_trend_threshold} --down_trend_threshold=${strategy.down_trend_threshold}`,
-    macd: `--ema_short_period=${strategy.ema_short_period} --ema_long_period=${strategy.ema_long_period} --signal_period=${strategy.signal_period} --up_trend_threshold=${strategy.up_trend_threshold} --down_trend_threshold=${strategy.down_trend_threshold} --overbought_rsi_periods=${strategy.overbought_rsi_periods} --overbought_rsi=${strategy.overbought_rsi}`,
-    rsi: `--rsi_periods=${strategy.rsi_periods} --oversold_rsi=${strategy.oversold_rsi} --overbought_rsi=${strategy.overbought_rsi} --rsi_recover=${strategy.rsi_recover} --rsi_drop=${strategy.rsi_drop} --rsi_divisor=${strategy.rsi_divisor}`,
-    sar: `--sar_af=${strategy.sar_af} --sar_max_af=${strategy.sar_max_af}`,
-    speed: `--baseline_periods=${strategy.baseline_periods} --trigger_factor=${strategy.trigger_factor}`,
-    trend_ema: `--trend_ema=${strategy.trend_ema} --oversold_rsi=${strategy.oversold_rsi} --oversold_rsi_periods=${strategy.oversold_rsi_periods} --neutral_rate=${strategy.neutral_rate}`
-  }
-  let zenbot_cmd = process.platform === 'win32' ? 'zenbot.bat' : './zenbot.sh' // Use 'win32' for 64 bit windows too
-  let localGen = countArr.length
-  strategy.backtester_generation = localGen
+    results.forEach(function(result) {
+      let it = result.params.match(/backtester_generation\":(\d+),/)
+      let phenotype = phenotypes[parseInt(it[1], 10)]
+      result.commandString = phenotype.command.commandString
 
-  let command = `${zenbot_cmd} sim ${simArgs} ${strategyArgs[strategyName]} --period_length=${strategy.period_length}  --min_periods=${strategy.min_periods} --backtester_generation=${localGen}`
-  console.log(`[ ${localGen}/${strategies[strategyName].length} ] ${command}`)
+      unsetKeys.forEach(function(key) {
+        result[key] = phenotype[key]
+      })
+      // console.log(`it: ${JSON.stringify(it)}`)
+    })
 
-  shell.exec(command, {silent:true, async:true}, (code, stdout, stderr) => {
-    if (code) {
-      console.error(command)
-      console.error(stderr)
-      return cb(null, null)
-    }
-    cb(null, processOutput(stdout,localGen,strategyName, exchangeMarketPair))
-  })
-}
+    let fieldsGeneral = unsetKeys.slice(0)
+    let fieldNamesGeneral = unsetKeys.slice(0)
 
-let processOutput = (output,generation,strategyName, exchangeMarketPair) => {
-  
-  let tFileName = path.resolve(__dirname, '..','..', 'simulations','sim_'+strategyName.replace('_','')+'_'+exchangeMarketPair.replace(' ','')+'_'+generation+'.json')
-  let simulationResults
-  if (fs.existsSync(tFileName))
-  {
-    let jsonBuffer
-    jsonBuffer = fs.readFileSync(tFileName,{encoding:'utf8'})
-    simulationResults = JSON.parse(jsonBuffer)
-    fs.unlinkSync(tFileName)
-  }
+    fieldsGeneral = fieldsGeneral.concat(['selector', 'fitness', 'vsBuyHold', 'wlRatio', 'frequency', 'strategy', 'order_type', 'endBalance', 'buyHold', 'wins', 'losses', 'period_length', 'min_periods', 'days', 'commandString'])
+    fieldNamesGeneral = fieldNamesGeneral.concat(['Selector', 'Fitness', 'VS Buy Hold (%)', 'Win/Loss Ratio', '# Trades/Day', 'Strategy', 'Order Type', 'Ending Balance ($)', 'Buy Hold ($)', '# Wins', '# Losses', 'Period', 'Min Periods', '# Days', 'Command'])
 
-  let endBalance    = simulationResults.simresults.currency
-  let buyHold       = simulationResults.simresults.buy_hold
-  let vsBuyHold     = simulationResults.simresults.vs_buy_hold
-  let wins          = simulationResults.simresults.total_sells
-  let losses        = simulationResults.simresults.total_losses
-  let errorRate     = simulationResults.simresults.total_losses / simulationResults.simresults.total_sells
-  let days          = parseInt(simulationResults.days)
-  let roi = roundp(
-    ((endBalance - simulationResults.currency_capital) / simulationResults.currency_capital) * 100,
-    3
-  )
+    let dataCSV = json2csv({
+      data: results,
+      fields: fieldsGeneral,
+      fieldNames: fieldNamesGeneral
+    })
+    let csvFileName = `simulations/${population_data}/results_${population_data}.csv` // MS Word whines about opening multiple files of the same name
+    console.log(csvFileName)
+    Backtester.writeFileAndFolder(csvFileName, dataCSV)
 
-  return {
-    params:             JSON.stringify(simulationResults),
-    endBalance:         parseFloat(endBalance),
-    buyHold:            parseFloat(buyHold),
-    vsBuyHold:          parseFloat(vsBuyHold),
-    wins:               wins,
-    losses:             losses,
-    errorRate:          parseFloat(errorRate),
 
-    // cci_srsi
-    cciPeriods:         simulationResults.cci_periods,
-    rsiPeriods:         simulationResults.rsi_periods,
-    srsiPeriods:        simulationResults.srsi_periods,
-    srsiK:              simulationResults.srsi_k,
-    srsiD:              simulationResults.srsi_d,
-    oversoldRsi:        simulationResults.oversold_rsi,
-    overboughtRsi:      simulationResults.overbought_rsi,
-    oversoldCci:        simulationResults.oversold_cci,
-    overboughtCci:      simulationResults.overbought_cci,
-    constant:           simulationResults.consant,
+    // If we didn't sort them before, definitely sort them now to get the best one
+    if (!argv.sort_results)
+      results.sort((a, b) => (Number(a.fitness) < Number(b.fitness)) ? 1 : ((Number(b.fitness) < Number(a.fitness)) ? -1 : 0))
+    let best = results[0]
 
-    // srsi_macd
-    //rsiPeriods:         simulationResults.rsi_periods,
-    //srsiPeriods:        simulationResults.srsi_periods,
-    //srsiK:              simulationResults.srsi_k,
-    //srsiD:              simulationResults.srsi_d,
-    //oversoldRsi:        simulationResults.oversold_rsi,
-    //overboughtRsi:      simulationResults.overbought_rsi,
-    emaShortPeriod:     simulationResults.ema_short_period,
-    emaLongPeriod:      simulationResults.ema_long_period,
-    signalPeriod:       simulationResults.signal_period,
-    upTrendThreshold:   simulationResults.up_trend_threshold,
-    downTrendThreshold: simulationResults.down_trend_threshold,
+    // Display best of the generation
+    let best_string = []
+    unsetKeys.forEach(function(key) {
+      best_string.push(`${key}=${best[key]}`)
+    })
+    console.log(`\n\nBest Result had ${best_string.join(' and ').green}`)
 
-    // macd
-    //emaShortPeriod:     simulationResults.ema_short_period,
-    //emaLongPeriod:      simulationResults.ema_long_period,
-    //signalPeriod:       simulationResults.signal_period,
-    //upTrendThreshold:   simulationResults.up_trend_threshold,
-    //downTrendThreshold: simulationResults.down_trend_threshold,
-    overboughtRsiPeriods: simulationResults.overbought_rsi_periods,
-    //overboughtRsi:      simulationResults.overbought_rsi,
-
-    // rsi
-    //rsiPeriods:         simulationResults.rsi_periods,
-    //oversoldRsi:        simulationResults.oversold_rsi,
-    //overboughtRsi:      simulationResults.overbought_rsi,
-    rsiRecover:         simulationResults.rsi_recover,
-    rsiDrop:            simulationResults.rsi_drop,
-    rsiDivsor:          simulationResults.rsi_divisor,
-
-    // sar
-    sarAf:              simulationResults.sar_af,
-    sarMaxAf:           simulationResults.sar_max_af,
-
-    // speed
-    baselinePeriods:   simulationResults.baseline_periods,
-    triggerFactor:     simulationResults.trigger_factor,
-
-    // trend_ema
-    trendEma:           simulationResults.trend_ema,
-    neutralRate:        simulationResults.neutral_rate,
-    oversoldRsiPeriods: simulationResults.oversold_rsi_periods,
-    //oversoldRsi:        simulationResults.oversold_rsi,
-
-    days:               days,
-    period_length:       simulationResults.period_length,
-    min_periods:        simulationResults.min_periods,
-    roi:                roi,
-    wlRatio:            losses > 0 ? roundp(wins / losses, 3) : 'Infinity',
-    frequency:          roundp((wins + losses) / days, 3)
-  }
-}
-
-let strategies = {
-  cci_srsi: objectProduct({
-    period_length: ['20m'],
-    min_periods: [52, 200],
-    rsi_periods: [14, 20],
-    srsi_periods: [14, 20],
-    srsi_k: [3, 9],
-    srsi_d: [3, 9],
-    oversold_rsi: [22],
-    overbought_rsi: [85],
-    oversold_cci: [-90],
-    overbought_cci: [140],
-    constant: [0.015]
-  }),
-  srsi_macd: objectProduct({
-    period_length: ['30m'],
-    min_periods: [52, 200],
-    rsi_periods: [14, 20],
-    srsi_periods: [14, 20],
-    srsi_k: [3, 9],
-    srsi_d: [3, 9],
-    oversold_rsi: [18],
-    overbought_rsi: [82],
-    ema_short_period: [12, 24],
-    ema_long_period: [26, 200],
-    signal_period: [9, 14],
-    up_trend_threshold: [0],
-    down_trend_threshold: [0]
-  }),
-  macd: objectProduct({
-    period_length: ['1h'],
-    min_periods: [52],
-    ema_short_period: range(10, 15),
-    ema_long_period: range(20, 30),
-    signal_period: range(9, 9),
-    up_trend_threshold: range(0, 0),
-    down_trend_threshold: range(0, 0),
-    overbought_rsi_periods: range(15, 25),
-    overbought_rsi: range(70, 70)
-  }),
-  rsi: objectProduct({
-    period_length: ['2m'],
-    min_periods: [52],
-    rsi_periods: range(10, 30),
-    oversold_rsi: range(20, 35),
-    overbought_rsi: range(82, 82),
-    rsi_recover: range(3, 3),
-    rsi_drop: range(0, 0),
-    rsi_divisor: range(2, 2)
-  }),
-  sar: objectProduct({
-    period_length: ['2m'],
-    min_periods: [52],
-    sar_af: range(0.01, 0.055, 0.005),
-    sar_max_af: range(0.1, 0.55, 0.05)
-  }),
-  speed: objectProduct({
-    period_length: ['1m'],
-    min_periods: [52],
-    baseline_periods: range(1000, 5000, 200),
-    trigger_factor: range(1.0, 2.0, 0.1)
-  }),
-  trend_ema: objectProduct({
-    period_length: ['2m'],
-    min_periods: [52],
-    trend_ema: range(TREND_EMA_MIN, TREND_EMA_MAX),
-    neutral_rate: (NEUTRAL_RATE_AUTO ? new Array('auto') : []).concat(range(NEUTRAL_RATE_MIN, NEUTRAL_RATE_MAX).map(r => r / 100)),
-    oversold_rsi_periods: range(OVERSOLD_RSI_PERIODS_MIN, OVERSOLD_RSI_PERIODS_MAX),
-    oversold_rsi: range(OVERSOLD_RSI_MIN, OVERSOLD_RSI_MAX)
-  })
-}
-
-let args = process.argv
-let exchangeMarketPair = args[2].toLowerCase()
-args.shift()
-args.shift()
-let simArgs = args.join(' ')
-let strategyName = 'trend_ema'
-if (args.indexOf('--strategy') !== -1) {
-  strategyName = args[args.indexOf('--strategy') + 1]
-}
-
-let tasks = strategies[strategyName].map(strategy => {
-  return cb => {
-    runCommand(strategy,exchangeMarketPair,strategyName.toLowerCase(), cb)
-  }
-})
-
-console.log(`\n--==${VERSION}==--`)
-console.log(new Date().toUTCString())
-console.log(`\nBacktesting [${strategies[strategyName].length}] iterations for strategy ${strategyName}...\n`)
-
-//Clean up any generation files left over in the simulation directory
-//they will be overwritten, but best not to confuse the issue.
-//if it fails.   doesn't matter they will be overwritten anyways. not need to halt the system.
-try
-{
-  let tDirName = path.resolve(__dirname, '..','..', 'simulations')
-  let tFileName = 'sim_'
-  let files = fs.readdirSync(tDirName)
-
-  for(let i = 0; i < files.length; i++)
-  {
-    if (files[i].lastIndexOf(tFileName) == 0)
-    {
-      let filePath = path.resolve(__dirname, '..','..', 'simulations',files[i] )
-      fs.unlinkSync(filePath)
-    }
-
-  }
-} catch (err)
-{
-  console.log('error deleting lint from prior run')
-}
-
-parallel(tasks, PARALLEL_LIMIT, (err, results) => {
-  console.log('\nBacktesting complete, saving results...')
-  results = results.filter(function (r) {
-    return !!r
-  })
-  results.sort((a,b) => (a.roi < b.roi) ? 1 : ((b.roi < a.roi) ? -1 : 0))
-  let fileName = `backtesting_${Math.round(+new Date()/1000)}.csv`
-  let filedsGeneral = ['roi', 'vsBuyHold', 'errorRate', 'wlRatio', 'frequency', 'endBalance', 'buyHold', 'wins', 'losses', 'period', 'min_periods', 'days']
-  let filedNamesGeneral = ['ROI (%)', 'VS Buy Hold (%)', 'Error Rate (%)', 'Win/Loss Ratio', '# Trades/Day', 'Ending Balance ($)', 'Buy Hold ($)', '# Wins', '# Losses', 'Period', 'Min Periods', '# Days']
-  let fields = {
-    cci_srsi: filedsGeneral.concat(['cciPeriods', 'rsiPeriods', 'srsiPeriods', 'srsiK', 'srsiD', 'oversoldRsi', 'overboughtRsi', 'oversoldCci', 'overboughtCci', 'Constant', 'params']),
-    srsi_macd: filedsGeneral.concat(['rsiPeriods', 'srsiPeriods', 'srsiK', 'srsiD', 'oversoldRsi', 'overboughtRsi', 'emaShortPeriod', 'emaLongPeriod', 'signalPeriod', 'upTrendThreshold', 'downTrendThreshold', 'params']),
-    macd: filedsGeneral.concat([ 'emaShortPeriod', 'emaLongPeriod', 'signalPeriod', 'upTrendThreshold', 'downTrendThreshold', 'overboughtRsiPeriods', 'overboughtRsi', 'params']),
-    rsi: filedsGeneral.concat(['rsiPeriods', 'oversoldRsi', 'overboughtRsi', 'rsiRecover', 'rsiDrop', 'rsiDivsor', 'params']),
-    sar: filedsGeneral.concat(['sarAf', 'sarMaxAf', 'params']),
-    speed: filedsGeneral.concat(['baselinePeriods', 'triggerFactor', 'params']),
-    trend_ema: filedsGeneral.concat(['trendEma', 'neutralRate', 'oversoldRsiPeriods', 'oversoldRsi', 'params'])
-  }
-  let fieldNames = {
-    cci_srsi: filedNamesGeneral.concat(['CCI Periods', 'RSI Periods', 'SRSI Periods', 'SRSI K', 'SRSI D', 'Oversold RSI', 'Overbought RSI', 'Oversold CCI', 'Overbought CCI', 'Constant', 'Full Parameters']),
-    srsi_macd: filedNamesGeneral.concat(['RSI Periods', 'SRSI Periods', 'SRSI K', 'SRSI D', 'Oversold RSI', 'Overbought RSI', 'EMA Short Period', 'EMA Long Period', 'Signal Period', 'Up Trend Threshold', 'Down Trend Threshold', 'Full Parameters']),
-    macd: filedNamesGeneral.concat(['EMA Short Period', 'EMA Long Period', 'Signal Period', 'Up Trend Threshold', 'Down Trend Threshold', 'Overbought Rsi Periods', 'Overbought Rsi', 'Full Parameters']),
-    rsi: filedNamesGeneral.concat(['RSI Periods', 'Oversold RSI', 'Overbought RSI', 'RSI Recover', 'RSI Drop', 'RSI Divisor', 'Full Parameters']),
-    sar: filedNamesGeneral.concat(['SAR AF', 'SAR MAX AF', 'Full Parameters']),
-    speed: filedNamesGeneral.concat(['Baseline Periods', 'Trigger Factor', 'Full Parameters']),
-    trend_ema: filedNamesGeneral.concat(['Trend EMA', 'Neutral Rate', 'Oversold RSI Periods', 'Oversold RSI', 'Full Parameters'])
-  }
-  let csv = json2csv({
-    data: results,
-    fields: fields[strategyName],
-    fieldNames: fieldNames[strategyName]
+    console.log(`(${best.strategy}) Result Fitness ${best.fitness}, VS Buy and Hold: ${z(5, (n(best.vsBuyHold).format('0.0') + '%'), ' ').yellow} BuyAndHold Balance: ${z(5, (n(best.buyHold).format('0.000000')), ' ').yellow}  End Balance: ${z(5, (n(best.endBalance).format('0.000000')), ' ').yellow}, Wins/Losses ${best.wins}/${best.losses}, ROI ${z(5, (n(results.roi).format('0.000000') ), ' ').yellow}.`)
+    console.log(best.commandString + '\n')
   })
 
-  fs.writeFile(fileName, csv, err => {
-    if (err) throw err
-    console.log(`\nResults successfully saved to ${fileName}!\n`)
-  })
-})
+}
+
+let writeSimDataFile = (iteration, data) => {
+  let jsonFileName = `simulations/${population_data}/sim_${iteration}.json`
+  Backtester.writeFileAndFolder(jsonFileName, data)
+}
+
+
+Backtester.deLint()
+runAutoBacktester()
+
+


### PR DESCRIPTION
I wanted to use the Auto Backtester, and saw it's super outdated. I abstracted the recent changes I did to Darwin and shared them with the Auto Backtester. In order to accommodate that restructuring, I've moved the definition of `phenotype` to the individual strategies. Now Darwin and the Auto Backtester can both pull from the same definition of value ranges.

**As a result, anyone with custom strategies will need to implement the `phenotype` function in order to enable backtesting for their strategy.**

I put notes at the top of the file to explain, but in general, you do very much like you'd do to convert a sim command to a darwin command, giving you:

`./scripts/auto_backtester/backtester.js --selector=binance.ABC-ZYX --rest=1 --of=2 --args=3`

Then you add `step_size` to your liking, such as 10, and then remove 1 or 2 parameters that you want unlocked for backtesting. Assuming those parameters have ranges defined in your strategy's phenotype, it'll step through them in even intervals testing all combinations. In the end you're given a CSV, much like you would with Darwin, with a bit of extra clarity in the columns for the fields you chose.