### PR TITLE
More reorder fixes

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -282,6 +282,7 @@ module.exports = function (s, conf) {
     order.price = opts.price
     order.size = opts.size
     order.fee = opts.fee
+    order.remaining_size = opts.size
 
     order.product_id = s.product_id
     order.post_only = conf.post_only
@@ -343,7 +344,7 @@ module.exports = function (s, conf) {
   // 8. if not filled after timer, repeat process
   // 9. if filled, record order stats
   function executeSignal (signal, _cb, size, is_reorder, is_taker) {
-    let price, fee, buy_pct, sell_pct
+    let price, expected_fee, buy_pct, sell_pct
     delete s[(signal === 'buy' ? 'sell' : 'buy') + '_order']
     s.last_signal = signal
     if (!is_reorder && s[signal + '_order']) {
@@ -387,7 +388,7 @@ module.exports = function (s, conf) {
         }
         if (is_reorder && s[signal + '_order']) {
           if (signal === 'buy') {
-            reorder_pct = n(size).multiply(s.buy_order.price).divide(s.balance.currency).multiply(100).add(s.buy_order.fee)
+            reorder_pct = n(size).multiply(s.buy_order.price).add(s.buy_order.fee).divide(s.balance.currency).multiply(100)
           } else {
             reorder_pct = n(size).divide(s.balance.asset).multiply(100)
           }
@@ -528,7 +529,7 @@ module.exports = function (s, conf) {
       placeOrder(signal, {
         size: size,
         price: price,
-        fee: fee || null,
+        fee: expected_fee || null,
         is_taker: is_taker,
         cancel_after: so.cancel_after || 'day'
       }, function (err, order) {


### PR DESCRIPTION
* Use expected_fee (in currency) instead of percentage to size reorder_pct closer to the origin size
* Update remaining_size on reorder to prevent second (and consecutive) reorder(s) from using the initial size

Takes care of https://github.com/DeviaVir/zenbot/pull/1443#issuecomment-369734511

More info here https://github.com/DeviaVir/zenbot/pull/1443#issuecomment-369776377