### PR TITLE
fix Poloniex `getOrder`

### DIFF
--- a/extensions/exchanges/poloniex/exchange.js
+++ b/extensions/exchanges/poloniex/exchange.js
@@ -255,16 +255,15 @@ module.exports = function container (conf) {
             if (api_order.orderNumber == opts.order_id) active = true
           })
         }
-        if (!active) {
-          order.status = 'done'
-          order.done_at = new Date().getTime()
-          return cb(null, order)
-        }
         client.returnOrderTrades(opts.order_id, function (err, body) {
           if (typeof body === 'string' || !body) {
             return retry('getOrder', args)
           }
           if (err || body.error || !body.forEach) return cb(null, order)
+          if (body.length === 0 && !active) {
+            order.status = 'cancelled'
+            return cb(null, order)
+          }
           order.filled_size = '0'
           body.forEach(function (trade) {
             order.filled_size = n(order.filled_size).add(trade.amount).format('0.00000000')


### PR DESCRIPTION
- remove invalid `done` status based on assumption that if order is not in active orders list - it is done
- add `cancel` status based on order not in active orders and no trades

fixes #1453 