### PR TITLE
Add Lolex for better simming of timing

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -11,7 +11,9 @@ let tb = require('timebucket')
   , notify = require('./notify')
   , rsi = require('./rsi')
   , async = require('async')
+  , lolex = require('lolex')
 
+let clock
 let nice_errors = new RegExp(/(slippage protection|loss protection)/)
 
 module.exports = function (s, conf) {
@@ -108,12 +110,7 @@ module.exports = function (s, conf) {
 
   function msg (str) {
     if (so.debug) {
-      if (lastTickCheckOrder) {
-        console.error('\n' + moment(lastTickCheckOrder).format('YYYY-MM-DD HH:mm:ss') + ' - ' + str)
-      }
-      else {
-        console.error('\n' + moment().format('YYYY-MM-DD HH:mm:ss') + ' - ' + str)
-      }
+      console.error('\n' + moment().format('YYYY-MM-DD HH:mm:ss') + ' - ' + str)
     }
   }
 
@@ -321,7 +318,7 @@ module.exports = function (s, conf) {
       order.status = api_order.status
       //console.log('\ncreated ' + order.status + ' ' + type + ' order: ' + fa(order.size) + ' at ' + fc(order.price) + ' (total ' + fc(n(order.price).multiply(order.size)) + ')\n')
 
-      queueEvent(function() { checkOrder(order, type, cb) }, so.order_poll_time)
+      setTimeout(function() { checkOrder(order, type, cb) }, so.order_poll_time)
     })
   }
 
@@ -662,10 +659,7 @@ module.exports = function (s, conf) {
   }
 
   function now () {
-    if (so.mode === 'live')
-      return new Date().getTime()
-    else
-      return s.exchange.getTime()
+    return new Date().getTime()
   }
 
   function writeReport (is_progress, blink_off) {
@@ -775,6 +769,8 @@ module.exports = function (s, conf) {
   }
 
   function withOnPeriod (trade, period_id, cb) {
+    if (!clock && so.mode !== 'live') clock = lolex.install({ shouldAdvanceTime: false, now: trade.time })
+
     updatePeriod(trade)
     if (!s.in_preroll) {
       if (so.mode !== 'live')
@@ -792,7 +788,18 @@ module.exports = function (s, conf) {
       }
       if (!so.manual) {
         executeStop()
-        tickCheckOrder(trade.time)
+
+        if (clock) {
+          var diff = trade.time - now()
+
+          // Allow some catch-up if trades are too far apart. Don't want all calls happening at the same time
+          while (diff > 5000) {
+            clock.tick(5000)
+            diff -= 5000
+          }
+          clock.tick(diff)
+        }
+
         if (s.signal) {
           executeSignal(s.signal)
           s.signal = null
@@ -801,36 +808,6 @@ module.exports = function (s, conf) {
     }
     s.last_period_id = period_id
     cb()
-  }
-
-  // Instead of using setTimeout, this gives a consistent way between sim and live
-  // to manage calling functions that need to happen in the future
-  var eventQueue = []
-  function queueEvent(func, duration) {
-    eventQueue.push({func: func, time: lastTickCheckOrder + duration})
-  }
-  var lastTickCheckOrder = null
-  function tickCheckOrder(time) {
-    if (!lastTickCheckOrder) {
-      lastTickCheckOrder = time
-      return
-    }
-
-    for (let i = 0, len = eventQueue.length; i < len; i++) {
-      let func_data = eventQueue[i]
-      let func = func_data.func
-      let func_time = func_data.time
-
-      if (time > func_time) {
-
-        func.call()
-
-        eventQueue.splice(i, 1)
-        i--
-        len--
-      }
-    }
-    lastTickCheckOrder = time
   }
 
   function cancelOrder (order, type, do_reorder, cb) {
@@ -861,7 +838,7 @@ module.exports = function (s, conf) {
             if (on_hold && s.balance.currency_hold > 0) {
               // wait a bit for settlement
               msg('funds on hold after cancel, waiting 5s')
-              queueEvent(function() { checkHold(do_reorder, cb) }, conf.wait_for_settlement)
+              setTimeout(function() { checkHold(do_reorder, cb) }, conf.wait_for_settlement)
             }
             else {
               cb(null, do_reorder ? null : false)
@@ -917,8 +894,8 @@ module.exports = function (s, conf) {
               cancelOrder(order, type, true, cb)
             }
             else {
-              order.local_time = lastTickCheckOrder
-              queueEvent(function() { checkOrder(order, type, cb) }, so.order_poll_time)
+              order.local_time = now()
+              setTimeout(function() { checkOrder(order, type, cb) }, so.order_poll_time)
             }
           }
           else {
@@ -932,14 +909,14 @@ module.exports = function (s, conf) {
               cancelOrder(order, type, true, cb)
             }
             else {
-              order.local_time = lastTickCheckOrder
-              queueEvent(function() { checkOrder(order, type, cb) }, so.order_poll_time)
+              order.local_time = now()
+              setTimeout(function() { checkOrder(order, type, cb) }, so.order_poll_time)
             }
           }
         })
       }
       else {
-        queueEvent(function() { checkOrder(order, type, cb) }, so.order_poll_time)
+        setTimeout(function() { checkOrder(order, type, cb) }, so.order_poll_time)
       }
     })
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7826,6 +7826,11 @@
         }
       }
     },
+    "lolex": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "kraken-api": "^1.0.0",
     "lint-staged": "^7.0.0",
     "lodash": "^4.17.4",
+    "lolex": "^2.3.2",
     "mathjs": "^4.0.0",
     "micro-request": "^666.0.10",
     "mime": "^2.2.0",
@@ -102,10 +103,10 @@
     "uuid": "^3.1.0",
     "waypoints": "^4.0.1",
     "webpack": "^4.0.0",
+    "webpack-cli": "^2.0.9",
     "wexnz": "^0.1.3",
     "ws": "^4.0.0",
-    "zero-fill": "^2.2.3",
-    "webpack-cli": "^2.0.9"
+    "zero-fill": "^2.2.3"
   },
   "devDependencies": {
     "eslint": "^4.7.1",


### PR DESCRIPTION
Recently I added an `eventQueue` to replace `setTimeout` because I thought it would give us better control of timing. However, while that works for the engine, it doesn't abstract well to other parts of the app that need asynchronous timing, like the sim exchange. I found the `lolex` gem which can take over native time calls, and now we can bring back `setTimeout` and have fully fast-forwardable asynchronous timing for our sims. Hooray!

I also implemented a 100ms latency to all sim exchange calls. After adding this, my sim vs live comparison have gotten MUCH closer together. Now when I debug one side having a missing or extra trade from the other, I can account for it by realizing that the order adjust happened some number of seconds later or earlier. This is of course impossible to make equivalent since network speeds are never consistent or predictable, but I think this is as close as the sim will ever get to matching live. I'm really happy with the state of sim vs live now.