### PR TITLE
Fixed calc buy_pct when used buy_max_amt

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -405,8 +405,10 @@ module.exports = function (s, conf) {
             }
             if (so.buy_max_amt) { // account for held assets as buy_max
               let adjusted_buy_max_amt = n(so.buy_max_amt).subtract(s.asset_capital).value()
-              let buy_max_as_pct = n(adjusted_buy_max_amt).divide(s.balance.currency).multiply(100).value()
-              buy_pct = buy_max_as_pct
+              if(adjusted_buy_max_amt < s.balance.currency){
+                let buy_max_as_pct = n(adjusted_buy_max_amt).divide(s.balance.currency).multiply(100).value()
+                buy_pct = buy_max_as_pct
+              }    
             } else { // account for held assets as %
               let held_pct = n(s.asset_capital).divide(s.balance.currency).multiply(100).value()
               let to_buy_pct = n(buy_pct).subtract(held_pct).value()


### PR DESCRIPTION
@DeviaVir 
I can be wrong. But there is not correct logic. 
Example: 
buy_max_amt = 500 
100 is in assets
200 is in currency

So leaving currency for buying is 500 - 100 = 400
But you have only 200
In old code you will get `buy_pct = 200%` and you will not be able to place order.

I think simple condition will work to check if we really have enough currency for buying