### PR TITLE
Ensure results with negative vsBuyHold don't get backward fitness

### DIFF
--- a/scripts/genetic_backtester/phenotype.js
+++ b/scripts/genetic_backtester/phenotype.js
@@ -45,8 +45,8 @@ module.exports = {
         let items = ['simple', 'low', 'trend']
         let index = Math.floor(Math.random() * items.length)
         r[k] = items[index]
-      } 
-      
+      }
+
     }
     return r
   },
@@ -78,8 +78,8 @@ module.exports = {
 
   fitness: function(phenotype) {
     if (typeof phenotype.sim === 'undefined') return 0
-    
-    var vsBuyHoldRate = (phenotype.sim.vsBuyHold / 50)
+
+    var vsBuyHoldRate = ( (phenotype.sim.vsBuyHold + 100) / 50)
     var wlRatio = phenotype.sim.wins / phenotype.sim.losses
     if(isNaN(wlRatio)) { // zero trades will result in 0/0 which is NaN
       wlRatio = 1


### PR DESCRIPTION
If you have 2 Darwin results that perform worse than `vsBuyHold`, previous fitness calculation will weight them backwards, meaning the one that makes less money will have the higher fitness. This happens because vsBuyHold is a negative number. Being a percentage, simply adding 100 ensures it will never be negative but still preserves the ordering of results, and solves the reverse order problem of results that aren't as good as `vsBuyHold`. Thanks to @krystophv for leading me to this.