### PR TITLE
Fix : Initialize fail in paper mode.

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -773,7 +773,7 @@ module.exports = function (s, conf) {
   }
 
   function withOnPeriod (trade, period_id, cb) {
-    if (!clock && so.mode !== 'live') clock = lolex.install({ shouldAdvanceTime: false, now: trade.time })
+    if (!clock && so.mode !== 'live' && so.mode !== 'paper') clock = lolex.install({ shouldAdvanceTime: false, now: trade.time })
 
     updatePeriod(trade)
     if (!s.in_preroll) {


### PR DESCRIPTION
I found current version can't use paper mode.
I investigated that engine.update() is stall in initialize.
It fixed when omit a setting of clock in paper mode in lib/engine.js.

This issue is side effect of #1456 "Add Lolex for better simming of timing ".

fail log: [fail_paper_mode.txt](https://github.com/DeviaVir/zenbot/files/1801586/fail_paper_mode.txt)
 use version : vanilla 7dc71d0
