### PR TITLE
Completely rework --buy_max_amt

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ zenbot trade --help
     --asset_capital <amount>          for paper trading, amount of start capital in asset
     --avg_slippage_pct <pct>          avg. amount of slippage to apply to paper trades
     --buy_pct <pct>                   buy with this % of currency balance
-    --buy_max_amt <amt>               buy with up to this amount of currency balance
+    --deposit <amt>                   absolute initial capital (in currency) at the bots disposal (previously --buy_max_amt)
     --sell_pct <pct>                  sell with this % of asset balance
     --markdown_buy_pct <pct>          % to mark down buy price
     --markup_sell_pct <pct>           % to mark up sell price

--- a/commands/sim.js
+++ b/commands/sim.js
@@ -125,7 +125,7 @@ module.exports = function (program, conf) {
             time: s.period.time
           })
         }
-        s.balance.currency = n(s.balance.currency).add(n(s.period.close).multiply(s.balance.asset)).format('0.00000000')
+        s.balance.currency = n(s.net_currency).add(n(s.period.close).multiply(s.balance.asset)).format('0.00000000')
 
         s.balance.asset = 0
         s.lookback.unshift(s.period)

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -30,7 +30,7 @@ module.exports = function (program, conf) {
     .option('--asset_capital <amount>', 'for paper trading, amount of start capital in asset', Number, conf.asset_capital)
     .option('--avg_slippage_pct <pct>', 'avg. amount of slippage to apply to paper trades', Number, conf.avg_slippage_pct)
     .option('--buy_pct <pct>', 'buy with this % of currency balance', Number, conf.buy_pct)
-    .option('--buy_max_amt <amt>', 'buy with up to this amount of currency balance', Number, conf.buy_max_amt)
+    .option('--deposit <amt>', 'absolute initial capital (in currency) at the bots disposal (previously --buy_max_amt)', Number, conf.deposit)
     .option('--sell_pct <pct>', 'sell with this % of asset balance', Number, conf.sell_pct)
     .option('--markdown_buy_pct <pct>', '% to mark down buy price', Number, conf.markdown_buy_pct)
     .option('--markup_sell_pct <pct>', '% to mark up sell price', Number, conf.markup_sell_pct)
@@ -80,6 +80,10 @@ module.exports = function (program, conf) {
       so.debug = cmd.debug
       so.stats = !cmd.disable_stats
       so.mode = so.paper ? 'paper' : 'live'
+      if (so.buy_max_amt) {
+        console.log(('--buy_max_amt is deprecated, use --deposit instead!\n').red)
+        so.deposit = so.buy_max_amt
+      }
 
       so.selector = objectifySelector(selector || conf.selector)      
       var engine = engineFactory(s, conf)

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -574,7 +574,7 @@ module.exports = function (program, conf) {
                 start_price: session.orig_price,
               }
               b._id = b.id
-              b.consolidated = n(s.balance.asset).multiply(s.period.close).add(s.net_currency).value()
+              b.consolidated = n(s.balance.asset).multiply(s.period.close).add(s.balance.currency).value()
               b.profit = (b.consolidated - session.orig_capital) / session.orig_capital
               b.buy_hold = s.period.close * (session.orig_capital / session.orig_price)
               b.buy_hold_profit = (b.buy_hold - session.orig_capital) / session.orig_capital

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -446,7 +446,7 @@ module.exports = function (program, conf) {
                   if (err) throw err
                   var prev_session = prev_sessions[0]
                   if (prev_session && !cmd.reset_profit) {
-                    if (prev_session.orig_capital && prev_session.orig_price && ((so.mode === 'paper' && !raw_opts.currency_capital && !raw_opts.asset_capital) || (so.mode === 'live' && prev_session.balance.asset == s.balance.asset && prev_session.balance.currency == s.balance.currency))) {
+                    if (prev_session.orig_capital && prev_session.orig_price && prev_session.deposit === so.deposit && ((so.mode === 'paper' && !raw_opts.currency_capital && !raw_opts.asset_capital) || (so.mode === 'live' && prev_session.balance.asset == s.balance.asset && prev_session.balance.currency == s.balance.currency))) {
                       s.orig_capital = session.orig_capital = prev_session.orig_capital
                       s.orig_price = session.orig_price = prev_session.orig_price
                       if (so.mode === 'paper') {
@@ -558,6 +558,7 @@ module.exports = function (program, conf) {
             session.start_capital = s.start_capital
             session.start_price = s.start_price
             session.num_trades = s.my_trades.length
+            if (so.deposit) session.deposit = so.deposit
             if (!session.orig_capital) session.orig_capital = s.start_capital
             if (!session.orig_price) session.orig_price = s.start_price
             if (s.period) {

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -151,7 +151,7 @@ module.exports = function (program, conf) {
 
       /* Implementing statistical Exit */
       function printTrade (quit, dump, statsonly = false) {
-        var tmp_balance = n(s.balance.currency).add(n(s.period.close).multiply(s.balance.asset)).format('0.00000000')
+        var tmp_balance = n(s.net_currency).add(n(s.period.close).multiply(s.balance.asset)).format('0.00000000')
         if (quit) {
           if (s.my_trades.length) {
             s.my_trades.push({
@@ -278,7 +278,7 @@ module.exports = function (program, conf) {
         if(!shouldSaveStats) return
 
         var output_lines = []
-        var tmp_balance = n(s.balance.currency).add(n(s.period.close).multiply(s.balance.asset)).format('0.00000000')
+        var tmp_balance = n(s.net_currency).add(n(s.period.close).multiply(s.balance.asset)).format('0.00000000')
 
         var profit = s.start_capital ? n(tmp_balance).subtract(s.start_capital).divide(s.start_capital) : n(0)
         output_lines.push('last balance: ' + n(tmp_balance).format('0.00000000').yellow + ' (' + profit.format('0.00%') + ')')
@@ -574,7 +574,7 @@ module.exports = function (program, conf) {
                 start_price: session.orig_price,
               }
               b._id = b.id
-              b.consolidated = n(s.balance.asset).multiply(s.period.close).add(s.balance.currency).value()
+              b.consolidated = n(s.balance.asset).multiply(s.period.close).add(s.net_currency).value()
               b.profit = (b.consolidated - session.orig_capital) / session.orig_capital
               b.buy_hold = s.period.close * (session.orig_capital / session.orig_price)
               b.buy_hold_profit = (b.buy_hold - session.orig_capital) / session.orig_capital

--- a/extensions/exchanges/sim/exchange.js
+++ b/extensions/exchanges/sim/exchange.js
@@ -52,6 +52,7 @@ module.exports = function sim (conf, s) {
 
     getBalance: function (opts, cb) {
       setTimeout(function() {
+        s.sim_asset = balance.asset
         return cb(null, balance)
       }, latency)
     },

--- a/extensions/exchanges/sim/exchange.js
+++ b/extensions/exchanges/sim/exchange.js
@@ -10,7 +10,7 @@ module.exports = function sim (conf, s) {
   let real_exchange = require(path.resolve(__dirname, `../${exchange_id}/exchange`))(conf)
 
   var now
-  var balance = { asset: so.asset_capital, currency: so.currency_capital, asset_hold: 0, currency_hold: 0, deposit: 0 }
+  var balance = { asset: so.asset_capital, currency: so.currency_capital, asset_hold: 0, currency_hold: 0 }
 
   var last_order_id = 1001
   var orders = {}
@@ -87,8 +87,8 @@ module.exports = function sim (conf, s) {
 
     buy: function (opts, cb) {
       setTimeout(function() {
-        if (debug) console.log(`buying ${opts.size * opts.price} vs on hold: ${balance.deposit} - ${balance.currency_hold} = ${balance.deposit - balance.currency_hold}`)
-        if (opts.size * opts.price > (balance.deposit - balance.currency_hold)) {
+        if (debug) console.log(`buying ${opts.size * opts.price} vs on hold: ${balance.currency} - ${balance.currency_hold} = ${balance.currency - balance.currency_hold}`)
+        if (opts.size * opts.price > (balance.currency - balance.currency_hold)) {
           if (debug) console.log('nope')
           return cb(null, { status: 'rejected', reject_reason: 'balance'})
         }
@@ -235,7 +235,6 @@ module.exports = function sim (conf, s) {
 
     let total = n(price).multiply(size)
     balance.currency = n(balance.currency).subtract(total).format('0.00000000')
-    balance.deposit = n(balance.deposit).subtract(total).format('0.00000000')
 
     // Process existing order size changes
     let order = buy_order
@@ -277,19 +276,16 @@ module.exports = function sim (conf, s) {
       if (exchange.makerFee) {
         fee = n(size).multiply(exchange.makerFee / 100).multiply(price).value()
         balance.currency = n(balance.currency).subtract(fee).format('0.00000000')
-        balance.deposit = n(balance.deposit).subtract(fee).format('0.00000000')
       }
     }
     else if (so.order_type === 'taker') {
       if (exchange.takerFee) {
         balance.currency = n(balance.currency).subtract(fee).format('0.00000000')
-        balance.deposit = n(balance.deposit).subtract(fee).format('0.00000000')
       }
     }
 
     let total = n(price).multiply(size)
     balance.currency = n(balance.currency).add(total).format('0.00000000')
-    balance.deposit = n(balance.deposit).add(total).format('0.00000000')
 
     // Process existing order size changes
     let order = sell_order

--- a/extensions/output/api.js
+++ b/extensions/output/api.js
@@ -33,6 +33,7 @@ module.exports = function api () {
 
     app.get('/', function (req, res) {
       app.locals.moment = moment
+      app.locals.deposit = tradeObject.options.deposit
       let datas = JSON.parse(JSON.stringify(objectWithoutKey(tradeObject, 'options'))) // deep copy to prevent alteration
       res.render('dashboard', datas)
     })

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -741,11 +741,11 @@ module.exports = function (s, conf) {
         let circulating = s.balance.currency > 0 ? n(s.balance.deposit).divide(s.balance.currency) : n(0)
         process.stdout.write(z(8, n(circulating).format('0.00%'), ' ').grey)
       }
-      let consolidated = n(so.mode === 'sim' ? s.balance.currency : s.net_currency).add(n(s.period.close).multiply(s.balance.asset)).value()
-      let profit = (consolidated - orig_capital) / orig_capital
+      let consolidated = n(s.net_currency).add(n(s.balance.asset).multiply(s.period.close))
+      let profit = n(consolidated).divide(orig_capital).subtract(1).value()
       process.stdout.write(z(8, formatPercent(profit), ' ')[profit >= 0 ? 'green' : 'red'])
-      let buy_hold = s.period.close * (orig_capital / orig_price)
-      let over_buy_hold_pct = (consolidated - buy_hold) / buy_hold
+      let buy_hold = n(orig_capital).divide(orig_price).multiply(s.period.close)
+      let over_buy_hold_pct = n(consolidated).divide(buy_hold).subtract(1).value()
       process.stdout.write(z(8, formatPercent(over_buy_hold_pct), ' ')[over_buy_hold_pct >= 0 ? 'green' : 'red'])
     }
     if (!is_progress) {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -212,22 +212,27 @@ module.exports = function (s, conf) {
   }
 
   function syncBalance (cb) {
+    let pre_asset = s.balance.asset
     s.exchange.getBalance({currency: s.currency, asset: s.asset}, function (err, balance) {
       if (err) return cb(err)
+      let diff_asset = n(pre_asset).subtract(balance.asset)
       s.balance = balance
       getQuote(function (err, quote) {
         if (err) return cb(err)
 
+        let post_currency = n(diff_asset).multiply(quote.ask)
         s.asset_capital = n(s.balance.asset).multiply(quote.ask).value()
         let deposit = so.deposit ? Math.max(0, n(so.deposit).subtract(s.asset_capital)) : s.balance.currency // zero on negative
-        s.balance.deposit = n(deposit < s.balance.currency ? deposit : s.balance.currency).format('0.00000000')
+        s.balance.deposit = n(deposit < s.balance.currency ? deposit : s.balance.currency).value()
         if (!s.start_capital) {
           s.start_price = n(quote.ask).value()
           s.start_capital = n(s.balance.deposit).add(n(s.balance.asset).multiply(quote.ask)).value()
+          s.net_currency = s.balance.deposit
           s.absolute_capital = n(s.balance.currency).add(n(s.balance.asset).multiply(quote.ask)).value()
 
           pushMessage('Balance ' + s.exchange.name.toUpperCase(), 'sync balance ' + s.absolute_capital + ' ' + s.currency  + '\n')
         }
+        s.net_currency = n(s.net_currency).add(post_currency).value()
 
         cb(null, { balance, quote })
       })
@@ -733,7 +738,7 @@ module.exports = function (s, conf) {
         let circulating = s.balance.currency > 0 ? n(s.balance.deposit).divide(s.balance.currency).format('0.00%') : '∞'
         process.stdout.write(z(8, circulating, ' ').grey)
       }
-      let consolidated = n(s.balance.deposit).add(n(s.period.close).multiply(s.balance.asset)).value()
+      let consolidated = n(so.mode === 'sim' ? s.balance.currency : s.net_currency).add(n(s.period.close).multiply(s.balance.asset)).value()
       let profit = (consolidated - orig_capital) / orig_capital
       process.stdout.write(z(8, formatPercent(profit), ' ')[profit >= 0 ? 'green' : 'red'])
       let buy_hold = s.period.close * (orig_capital / orig_price)
@@ -750,15 +755,17 @@ module.exports = function (s, conf) {
 
     updatePeriod(trade)
     if (!s.in_preroll) {
-      if (so.mode !== 'live') {
+      if (so.mode !== 'live')
         s.exchange.processTrade(trade)
 
-        s.asset_capital = n(s.balance.asset).multiply(trade.price).value()
-        let deposit = so.deposit ? Math.max(0, n(so.deposit).subtract(s.asset_capital)) : s.balance.currency // zero on negative
-        s.balance.deposit = n(deposit < s.balance.currency ? deposit : s.balance.currency).value()
-        if (!s.start_capital) {
-          s.start_price = trade.price
-          s.start_capital = n(s.balance.deposit).add(n(s.balance.asset).multiply(s.start_price)).value()
+      if (so.mode !== 'live' && !s.start_capital) {
+        s.start_capital = 0
+        s.start_price = trade.price
+        if (so.asset_capital) {
+          s.start_capital += so.asset_capital * s.start_price
+        }
+        if (so.currency_capital) {
+          s.start_capital += so.currency_capital
         }
       }
       if (!so.manual) {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -212,7 +212,7 @@ module.exports = function (s, conf) {
   }
 
   function syncBalance (cb) {
-    let pre_asset = s.balance.asset
+    let pre_asset = so.mode === 'sim' ? s.sim_asset : s.balance.asset
     s.exchange.getBalance({currency: s.currency, asset: s.asset}, function (err, balance) {
       if (err) return cb(err)
       let diff_asset = n(pre_asset).subtract(balance.asset)
@@ -226,12 +226,16 @@ module.exports = function (s, conf) {
         s.balance.deposit = n(deposit < s.balance.currency ? deposit : s.balance.currency).value()
         if (!s.start_capital) {
           s.start_price = n(quote.ask).value()
-          s.start_capital = n(so.deposit ? s.balance.deposit : s.balance.currency).add(n(s.balance.asset).multiply(quote.ask)).value()
+          s.start_capital = n(s.balance.deposit).add(s.asset_capital).value()
+          s.real_capital = n(s.balance.currency).add(s.asset_capital).value()
           s.net_currency = s.balance.deposit
 
-          pushMessage('Balance ' + s.exchange.name.toUpperCase(), 'sync balance ' + s.start_capital + ' ' + s.currency  + '\n')
+          if (so.mode !== 'sim') {
+            pushMessage('Balance ' + s.exchange.name.toUpperCase(), 'sync balance ' + s.real_capital + ' ' + s.currency  + '\n')
+          }
+        } else {
+          s.net_currency = n(s.net_currency).add(post_currency).value()
         }
-        s.net_currency = n(s.net_currency).add(post_currency).value()
 
         cb(null, { balance, quote })
       })
@@ -757,16 +761,6 @@ module.exports = function (s, conf) {
       if (so.mode !== 'live')
         s.exchange.processTrade(trade)
 
-      if (so.mode !== 'live' && !s.start_capital) {
-        s.start_capital = 0
-        s.start_price = trade.price
-        if (so.asset_capital) {
-          s.start_capital += so.asset_capital * s.start_price
-        }
-        if (so.currency_capital) {
-          s.start_capital += so.currency_capital
-        }
-      }
       if (!so.manual) {
         executeStop()
 

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -226,13 +226,12 @@ module.exports = function (s, conf) {
         s.balance.deposit = n(deposit < s.balance.currency ? deposit : s.balance.currency).value()
         if (!s.start_capital) {
           s.start_price = n(quote.ask).value()
-          s.start_capital = n(s.balance.deposit).add(n(s.balance.asset).multiply(quote.ask)).value()
+          s.start_capital = n(so.deposit ? s.balance.deposit : s.balance.currency).add(n(s.balance.asset).multiply(quote.ask)).value()
           s.net_currency = s.balance.deposit
-          s.absolute_capital = n(s.balance.currency).add(n(s.balance.asset).multiply(quote.ask)).value()
 
-          pushMessage('Balance ' + s.exchange.name.toUpperCase(), 'sync balance ' + s.absolute_capital + ' ' + s.currency  + '\n')
+          pushMessage('Balance ' + s.exchange.name.toUpperCase(), 'sync balance ' + s.start_capital + ' ' + s.currency  + '\n')
         }
-        s.net_currency = Math.max(0, n(s.net_currency).add(post_currency).value())
+        s.net_currency = n(s.net_currency).add(post_currency).value()
 
         cb(null, { balance, quote })
       })
@@ -735,8 +734,8 @@ module.exports = function (s, conf) {
         let currency_col = n(s.balance.currency).format(isFiat() ? '0.00' : '0.00000000') + ' ' + s.currency
         currency_col_width = Math.max(currency_col.length + 1, currency_col_width)
         process.stdout.write(z(currency_col_width, currency_col, ' ').green)
-        let circulating = s.balance.currency > 0 ? n(s.balance.deposit).divide(s.balance.currency).format('0.00%') : '∞'
-        process.stdout.write(z(8, circulating, ' ').grey)
+        let circulating = s.balance.currency > 0 ? n(s.balance.deposit).divide(s.balance.currency) : n(0)
+        process.stdout.write(z(8, n(circulating).format('0.00%'), ' ').grey)
       }
       let consolidated = n(so.mode === 'sim' ? s.balance.currency : s.net_currency).add(n(s.period.close).multiply(s.balance.asset)).value()
       let profit = (consolidated - orig_capital) / orig_capital

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -62,10 +62,10 @@ module.exports = function (s, conf) {
     s.exchange.setFees({asset: s.asset, currency: s.currency})
   }
   if (so.mode === 'sim' || so.mode === 'paper') {
-    s.balance = {asset: so.asset_capital, currency: so.currency_capital}
+    s.balance = {asset: so.asset_capital, currency: so.currency_capital, deposit: 0}
   }
   else {
-    s.balance = {asset: 0, currency: 0}
+    s.balance = {asset: 0, currency: 0, deposit: 0}
   }
 
   function memDump () {
@@ -85,6 +85,7 @@ module.exports = function (s, conf) {
   }
 
   let asset_col_width = 0
+  let deposit_col_width = 0
   let currency_col_width = 0
   s.lookback = []
   s.day_count = 1
@@ -217,14 +218,17 @@ module.exports = function (s, conf) {
       getQuote(function (err, quote) {
         if (err) return cb(err)
 
+        s.asset_capital = n(s.balance.asset).multiply(quote.ask).value()
+        let deposit = so.deposit ? Math.max(0, n(so.deposit).subtract(s.asset_capital)) : s.balance.currency // zero on negative
+        s.balance.deposit = n(deposit < s.balance.currency ? deposit : s.balance.currency).format('0.00000000')
         if (!s.start_capital) {
           s.start_price = n(quote.ask).value()
-          s.start_capital = n(s.balance.currency).add(n(s.balance.asset).multiply(quote.ask)).value()
+          s.start_capital = n(s.balance.deposit).add(n(s.balance.asset).multiply(quote.ask)).value()
+          s.absolute_capital = n(s.balance.currency).add(n(s.balance.asset).multiply(quote.ask)).value()
 
-          pushMessage('Balance ' + s.exchange.name.toUpperCase(), 'sync balance ' + s.start_capital + ' ' + s.currency  + '\n')
+          pushMessage('Balance ' + s.exchange.name.toUpperCase(), 'sync balance ' + s.absolute_capital + ' ' + s.currency  + '\n')
         }
 
-        s.asset_capital = n(s.balance.asset).multiply(quote.ask).value()
         cb(null, { balance, quote })
       })
     })
@@ -352,7 +356,7 @@ module.exports = function (s, conf) {
       }
       if (is_reorder && s[signal + '_order']) {
         if (signal === 'buy') {
-          reorder_pct = n(size).multiply(s.buy_order.price).add(s.buy_order.fee).divide(s.balance.currency).multiply(100)
+          reorder_pct = n(size).multiply(s.buy_order.price).add(s.buy_order.fee).divide(s.balance.deposit).multiply(100)
         } else {
           reorder_pct = n(size).divide(s.balance.asset).multiply(100)
         }
@@ -372,13 +376,6 @@ module.exports = function (s, conf) {
         } else {
           buy_pct = so.buy_pct
         }
-        if (so.buy_max_amt) { // account for held assets as buy_max
-          let adjusted_buy_max_amt = n(so.buy_max_amt).subtract(s.asset_capital).value()
-          if(adjusted_buy_max_amt < s.balance.currency){
-            let buy_max_as_pct = n(adjusted_buy_max_amt).divide(s.balance.currency).multiply(100).value()
-            buy_pct = buy_max_as_pct
-          }
-        }
         if (so.use_fee_asset) {
           fee = 0
         } else if (so.order_type === 'maker' && (buy_pct + s.exchange.takerFee < 100 || !s.exchange.makerBuy100Workaround)) {
@@ -386,8 +383,8 @@ module.exports = function (s, conf) {
         } else {
           fee = s.exchange.takerFee
         }
-        trade_balance = n(s.balance.currency).divide(100).multiply(buy_pct)
-        tradeable_balance = n(s.balance.currency).divide(100 + fee).multiply(buy_pct)
+        trade_balance = n(s.balance.deposit).divide(100).multiply(buy_pct)
+        tradeable_balance = n(s.balance.deposit).divide(100 + fee).multiply(buy_pct)
         expected_fee = n(trade_balance).subtract(tradeable_balance).format('0.00000000', Math.ceil) // round up as the exchange will too
         if (buy_pct + fee < 100) {
           size = n(tradeable_balance).divide(price).format(s.product.asset_increment ? s.product.asset_increment : '0.00000000')
@@ -416,8 +413,8 @@ module.exports = function (s, conf) {
                 return cb(err)
               }
             }
-            if (n(s.balance.currency).subtract(s.balance.currency_hold || 0).value() < n(price).multiply(size).value() && s.balance.currency_hold > 0) {
-              msg('buy delayed: ' + formatPercent(n(s.balance.currency_hold || 0).divide(s.balance.currency).value()) + ' of funds (' + formatCurrency(s.balance.currency_hold, s.currency) + ') on hold')
+            if (n(s.balance.deposit).subtract(s.balance.currency_hold || 0).value() < n(price).multiply(size).value() && s.balance.currency_hold > 0) {
+              msg('buy delayed: ' + formatPercent(n(s.balance.currency_hold || 0).divide(s.balance.deposit).value()) + ' of funds (' + formatCurrency(s.balance.currency_hold, s.currency) + ') on hold')
               return setTimeout(function () {
                 if (s.last_signal === signal) {
                   executeSignal(signal, cb, size, true)
@@ -726,10 +723,17 @@ module.exports = function (s, conf) {
       let asset_col = n(s.balance.asset).format(s.asset === 'BTC' ? '0.00000' : '0.00000000') + ' ' + s.asset
       asset_col_width = Math.max(asset_col.length + 1, asset_col_width)
       process.stdout.write(z(asset_col_width, asset_col, ' ').white)
-      let currency_col = n(s.balance.currency).format(isFiat() ? '0.00' : '0.00000000') + ' ' + s.currency
-      currency_col_width = Math.max(currency_col.length + 1, currency_col_width)
-      process.stdout.write(z(currency_col_width, currency_col, ' ').yellow)
-      let consolidated = n(s.balance.currency).add(n(s.period.close).multiply(s.balance.asset)).value()
+      let deposit_col = n(s.balance.deposit).format(isFiat() ? '0.00' : '0.00000000') + ' ' + s.currency
+      deposit_col_width = Math.max(deposit_col.length + 1, deposit_col_width)
+      process.stdout.write(z(deposit_col_width, deposit_col, ' ').yellow)
+      if (so.deposit) {
+        let currency_col = n(s.balance.currency).format(isFiat() ? '0.00' : '0.00000000') + ' ' + s.currency
+        currency_col_width = Math.max(currency_col.length + 1, currency_col_width)
+        process.stdout.write(z(currency_col_width, currency_col, ' ').green)
+        let circulating = s.balance.currency > 0 ? n(s.balance.deposit).divide(s.balance.currency).format('0.00%') : '∞'
+        process.stdout.write(z(8, circulating, ' ').grey)
+      }
+      let consolidated = n(s.balance.deposit).add(n(s.period.close).multiply(s.balance.asset)).value()
       let profit = (consolidated - orig_capital) / orig_capital
       process.stdout.write(z(8, formatPercent(profit), ' ')[profit >= 0 ? 'green' : 'red'])
       let buy_hold = s.period.close * (orig_capital / orig_price)
@@ -746,17 +750,15 @@ module.exports = function (s, conf) {
 
     updatePeriod(trade)
     if (!s.in_preroll) {
-      if (so.mode !== 'live')
+      if (so.mode !== 'live') {
         s.exchange.processTrade(trade)
 
-      if (so.mode !== 'live' && !s.start_capital) {
-        s.start_capital = 0
-        s.start_price = trade.price
-        if (so.asset_capital) {
-          s.start_capital += so.asset_capital * s.start_price
-        }
-        if (so.currency_capital) {
-          s.start_capital += so.currency_capital
+        s.asset_capital = n(s.balance.asset).multiply(trade.price).value()
+        let deposit = so.deposit ? Math.max(0, n(so.deposit).subtract(s.asset_capital)) : s.balance.currency // zero on negative
+        s.balance.deposit = n(deposit < s.balance.currency ? deposit : s.balance.currency).value()
+        if (!s.start_capital) {
+          s.start_price = trade.price
+          s.start_capital = n(s.balance.deposit).add(n(s.balance.asset).multiply(s.start_price)).value()
         }
       }
       if (!so.manual) {
@@ -805,7 +807,7 @@ module.exports = function (s, conf) {
           }
           syncBalance(function () {
             let on_hold
-            if (type === 'buy') on_hold = n(s.balance.currency).subtract(s.balance.currency_hold || 0).value() < n(order.price).multiply(order.remaining_size).value()
+            if (type === 'buy') on_hold = n(s.balance.deposit).subtract(s.balance.currency_hold || 0).value() < n(order.price).multiply(order.remaining_size).value()
             else on_hold = n(s.balance.asset).subtract(s.balance.asset_hold || 0).value() < n(order.remaining_size).value()
 
             if (on_hold && s.balance.currency_hold > 0) {
@@ -965,7 +967,7 @@ module.exports = function (s, conf) {
         z(10, 'VOL', ' ').grey,
         z(8, 'RSI', ' ').grey,
         z(32, 'ACTIONS', ' ').grey,
-        z(25, 'BAL', ' ').grey,
+        z(so.deposit ? 38 : 25, 'BAL', ' ').grey,
         z(22, 'PROFIT', ' ').grey
       ].join('') + '\n')
     },

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -232,7 +232,7 @@ module.exports = function (s, conf) {
 
           pushMessage('Balance ' + s.exchange.name.toUpperCase(), 'sync balance ' + s.absolute_capital + ' ' + s.currency  + '\n')
         }
-        s.net_currency = n(s.net_currency).add(post_currency).value()
+        s.net_currency = Math.max(0, n(s.net_currency).add(post_currency).value())
 
         cb(null, { balance, quote })
       })

--- a/templates/dashboard.ejs
+++ b/templates/dashboard.ejs
@@ -431,7 +431,7 @@
                                 <% }); %>
                                 <% } %>
                                 <% if (my_prev_trades) { %>
-                                <% my_prev_trades.forEach(function(trade){ %>
+                                <% my_prev_trades.reverse().forEach(function(trade){ %>
                                 <tr class="text-muted">
                                     <td><%= trade.type.toUpperCase() %></span></td>
                                     <td><%= new Intl.NumberFormat("en-US", {useGrouping: false, minimumFractionDigits: 8, maximumFractionDigits: 8}).format(trade.size) %> <%= asset.toUpperCase() %></td>

--- a/templates/dashboard.ejs
+++ b/templates/dashboard.ejs
@@ -97,19 +97,21 @@
                     <div class="white-box analytics-info">
                         <h3 class="box-title">Capital</h3>
                         <div class="row">
-                            <div class="col-lg-4 col-12">
+                            <div class="col-lg-<% if (typeof deposit != 'undefined') { %>4<% } else { %>6<% } %> col-12">
                                 <ul class="list-inline two-part">
                                     <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span class="text-purple">Asset</span></li>
                                     <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span><%= new Intl.NumberFormat("en-US", {useGrouping: false,  minimumFractionDigits: 2, maximumFractionDigits: 8}).format(balance.asset) %></span> <small><%= asset.toUpperCase() %></small></li>
                                 </ul>
                             </div>
+                            <% if (typeof deposit != "undefined") { %>
                             <div class="col-lg-4 col-12">
                                 <ul class="list-inline two-part">
                                     <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span class="text-purple">Deposit</span></li>
                                     <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span><%= new Intl.NumberFormat("en-US", {useGrouping: false,  minimumFractionDigits: 2, maximumFractionDigits: 8}).format(balance.deposit) %></span> <small><%= currency.toUpperCase() %></small></li>
                                 </ul>
                             </div>
-                            <div class="col-lg-4 col-12">
+                            <% } %>
+                            <div class="col-lg-<% if (typeof deposit != 'undefined') { %>4<% } else { %>6<% } %> col-12">
                                 <ul class="list-inline two-part">
                                     <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span class="text-purple">Currency</span></li>
                                     <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span><%= new Intl.NumberFormat("en-US", {useGrouping: false, minimumFractionDigits: 2, maximumFractionDigits: 8}).format(balance.currency) %></span> <small><%= currency.toUpperCase() %></small></li>

--- a/templates/dashboard.ejs
+++ b/templates/dashboard.ejs
@@ -431,7 +431,7 @@
                                 <% }); %>
                                 <% } %>
                                 <% if (my_prev_trades) { %>
-                                <% my_prev_trades.reverse().forEach(function(trade){ %>
+                                <% my_prev_trades.forEach(function(trade){ %>
                                 <tr class="text-muted">
                                     <td><%= trade.type.toUpperCase() %></span></td>
                                     <td><%= new Intl.NumberFormat("en-US", {useGrouping: false, minimumFractionDigits: 8, maximumFractionDigits: 8}).format(trade.size) %> <%= asset.toUpperCase() %></td>

--- a/templates/dashboard.ejs
+++ b/templates/dashboard.ejs
@@ -97,13 +97,19 @@
                     <div class="white-box analytics-info">
                         <h3 class="box-title">Capital</h3>
                         <div class="row">
-                            <div class="col-lg-6 col-12">
+                            <div class="col-lg-4 col-12">
                                 <ul class="list-inline two-part">
                                     <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span class="text-purple">Asset</span></li>
                                     <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span><%= new Intl.NumberFormat("en-US", {useGrouping: false,  minimumFractionDigits: 2, maximumFractionDigits: 8}).format(balance.asset) %></span> <small><%= asset.toUpperCase() %></small></li>
                                 </ul>
                             </div>
-                            <div class="col-lg-6 col-12">
+                            <div class="col-lg-4 col-12">
+                                <ul class="list-inline two-part">
+                                    <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span class="text-purple">Deposit</span></li>
+                                    <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span><%= new Intl.NumberFormat("en-US", {useGrouping: false,  minimumFractionDigits: 2, maximumFractionDigits: 8}).format(balance.deposit) %></span> <small><%= currency.toUpperCase() %></small></li>
+                                </ul>
+                            </div>
+                            <div class="col-lg-4 col-12">
                                 <ul class="list-inline two-part">
                                     <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span class="text-purple">Currency</span></li>
                                     <li class="text-left" style="display:inline"><i class="ti-arrow-up text-purple"></i> <span><%= new Intl.NumberFormat("en-US", {useGrouping: false, minimumFractionDigits: 2, maximumFractionDigits: 8}).format(balance.currency) %></span> <small><%= currency.toUpperCase() %></small></li>

--- a/test/lib/engine.test.js
+++ b/test/lib/engine.test.js
@@ -3,17 +3,17 @@ var EventEmitter = require('events')
 describe('Engine', function() {
   describe('executeSignal', function() {
     describe('when maker in live mode', function(){
-      describe('with buy_max set', function(){
-        it('and no held assets should use raw buy_max_amt', function(){
+      describe('with deposit set', function(){
+        it('and no held assets should use raw deposit', function(){
           // arrange
           var signal_type = 'buy'
           var currency_amount = 1.0
           var buy_pct = 50
-          var buy_max_amt = 0.25
+          var deposit = 0.25
           var order_type = 'maker'
           var held_asset = 0
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
@@ -21,16 +21,16 @@ describe('Engine', function() {
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })
-        it('and held assets should use adjusted buy_max_amt', function(){
+        it('and held assets should use adjusted deposit', function(){
           // arrange
           var signal_type = 'buy'
           var currency_amount = 3.0
           var buy_pct = 50
-          var buy_max_amt = 0.25
+          var deposit = 0.25
           var order_type = 'maker'
           var held_asset = 0.75
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
@@ -38,33 +38,33 @@ describe('Engine', function() {
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })
-        it('and held assets so large adjusted buy_max_amt is below order minimum should not place order', function(){
+        it('and held assets so large adjusted deposit is below order minimum should not place order', function(){
           // arrange
           var signal_type = 'buy'
           var currency_amount = 1.0
           var buy_pct = 50
-          var buy_max_amt = 0.25
+          var deposit = 0.25
           var order_type = 'maker'
           var held_asset = 2.0
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
           expect(buy_spy).not.toHaveBeenCalled()
         })
       })
-      describe('with no buy_max set', function(){
+      describe('with no deposit set', function(){
         it('and no held assets should use raw buy_pct', function(){
           // arrange
           var signal_type = 'buy'
           var currency_amount = 1.0
           var buy_pct = 50
-          var buy_max_amt = undefined
+          var deposit = undefined
           var order_type = 'maker'
           var held_asset = 0
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
@@ -79,11 +79,11 @@ describe('Engine', function() {
           var signal_type = 'buy'
           var currency_amount = 1.0
           var buy_pct = 50
-          var buy_max_amt = undefined
+          var deposit = undefined
           var order_type = 'maker'
           var held_asset = 0.5
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
@@ -96,11 +96,11 @@ describe('Engine', function() {
           var signal_type = 'buy'
           var currency_amount = 1.0
           var buy_pct = 50
-          var buy_max_amt = undefined
+          var deposit = undefined
           var order_type = 'maker'
           var held_asset = 10.25				
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
@@ -111,17 +111,17 @@ describe('Engine', function() {
     })
     
     describe('when taker in live mode', function(){
-      describe('with buy_max_amt set',function(){
-        it('and no held assets should use raw buy_max_amt', function(){
+      describe('with deposit set',function(){
+        it('and no held assets should use raw deposit', function(){
           // arrange
           var signal_type = 'buy'
           var currency_amount = 1
           var buy_pct = 50
-          var buy_max_amt = 0.25
+          var deposit = 0.25
           var order_type = 'taker'
           var held_asset = 0
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
@@ -130,16 +130,16 @@ describe('Engine', function() {
           expect(buyArgs.size).toBe(expected)
         })
         
-        it('and held assets should use adjusted buy_max_amt', function(){
+        it('and held assets should use adjusted deposit', function(){
           // arrange
           var signal_type = 'buy'
           var currency_amount = 3.0
           var buy_pct = 50
-          var buy_max_amt = 0.25
+          var deposit = 0.25
           var order_type = 'taker'
           var held_asset = 0.75
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
@@ -148,33 +148,33 @@ describe('Engine', function() {
           expect(buyArgs.size).toBe(expected)
         })
         
-        it('and held assets so large adjusted buy_max_amt is below order minimum should not place order', function(){
+        it('and held assets so large adjusted deposit is below order minimum should not place order', function(){
           // arrange
           var signal_type = 'buy'
           var currency_amount = 1.0
           var buy_pct = 50
-          var buy_max_amt = 0.25
+          var deposit = 0.25
           var order_type = 'taker'
           var held_asset = 2.0
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
           expect(buy_spy).not.toHaveBeenCalled()
         })
       })
-      describe('with no buy_max_amt set',function(){
-        it('with no buy_max_amt set and no held assets should use raw buy_pct', function(){
+      describe('with no deposit set',function(){
+        it('with no deposit set and no held assets should use raw buy_pct', function(){
           // arrange
           var signal_type = 'buy'
           var currency_amount = 1
           var buy_pct = 50
-          var buy_max_amt = undefined
+          var deposit = undefined
           var order_type = 'taker'
           var held_asset = 0
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
@@ -188,11 +188,11 @@ describe('Engine', function() {
           var signal_type = 'buy'
           var currency_amount = 1.0
           var buy_pct = 50
-          var buy_max_amt = undefined
+          var deposit = undefined
           var order_type = 'taker'
           var held_asset = 0.5				
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
@@ -205,11 +205,11 @@ describe('Engine', function() {
           var signal_type = 'buy'
           var currency_amount = 1.0
           var buy_pct = 50
-          var buy_max_amt = undefined
+          var deposit = undefined
           var order_type = 'taker'
           var held_asset = 5.25				
           var buy_spy = jasmine.createSpy('buy')
-          var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
+          var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
@@ -224,7 +224,7 @@ describe('Engine', function() {
 var mock = require('mock-require')
 var path = require('path')
 
-function createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy){	
+function createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy){	
   var fake_asset = 'test_asset'
   var fake_currency = 'BTC'
   var fake_exchange = 'test_exchange'
@@ -280,7 +280,7 @@ function createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_as
       mode:'live',
       order_type: order_type,
       buy_pct:buy_pct,
-      buy_max_amt:buy_max_amt
+      deposit:deposit
     }
   }
   var engine = require('../../lib/engine')

--- a/test/lib/engine.test.js
+++ b/test/lib/engine.test.js
@@ -24,17 +24,17 @@ describe('Engine', function() {
         it('and held assets should use adjusted deposit', function(){
           // arrange
           var signal_type = 'buy'
-          var currency_amount = 3.0
+          var currency_amount = 1.0
           var buy_pct = 50
           var deposit = 0.25
           var order_type = 'maker'
-          var held_asset = 0.75
+          var held_asset = 0.25
           var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
-          var expected = '1.85925185'
+          var expected = '1.23487623'
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })
@@ -133,17 +133,17 @@ describe('Engine', function() {
         it('and held assets should use adjusted deposit', function(){
           // arrange
           var signal_type = 'buy'
-          var currency_amount = 3.0
+          var currency_amount = 1.0
           var buy_pct = 50
           var deposit = 0.25
           var order_type = 'taker'
-          var held_asset = 0.75
+          var held_asset = 0.25
           var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, deposit, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
-          var expected = '1.85739631'
+          var expected = '1.23364382'
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })

--- a/test/lib/engine.test.js
+++ b/test/lib/engine.test.js
@@ -17,7 +17,7 @@ describe('Engine', function() {
           // act
           sut.executeSignal(signal_type)
           // assert
-          var expected = '2.77500277'
+          var expected = '1.38750138'
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })
@@ -125,7 +125,7 @@ describe('Engine', function() {
           // act
           sut.executeSignal(signal_type)
           // assert
-          var expected = '2.77223331'
+          var expected = '1.38611665'
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })


### PR DESCRIPTION
As much as i like the --buy_max_amt feature i was never a fan of how it was implemented, leave alone the naming being confusing at best as it simply doesn't just account for the amount the bot can buy but how much he is actually able to trade.

* Renames --buy_max_amt to --deposit for sake of clarification
* Using --buy_max_amt will still work but print a deprecated warning
* Instead of using --deposit to size buy orders use it to limit the balance available to the bot
* This allows us to use it together with --buy_pct
* --deposit will still account for asset held to calculate the available currency balance
* So if the asset held is covering --deposit the bot will have 0 currency (0% of currency balance) available, if not currency will be filled to the point it compensates for the difference (up to 100% of currency balance)
* If deposit is exceeding asset + currency the bot will also use 100% of currency balance held
* Deposit will be updated on each price change and new period to ensure the bot always only trades the amount as defined by --deposit
* Profit calculation will no longer go havoc ~~as long as currency balance doesn't fall below whats currently deposited into the bot~~
* If enabled this will add two new columns to the output displaying the total currency balance (in green) as well as how much percentage (gray) of currency balance (0 - 100%) is currently used by the bot
* Works in Live, Paper & Sim mode