### PR TITLE
moving formatting to own module

### DIFF
--- a/commands/balance.js
+++ b/commands/balance.js
@@ -3,8 +3,8 @@ var minimist = require('minimist')
   // eslint-disable-next-line no-unused-vars
   , colors = require('colors')
   , moment = require('moment')
-  , engineFactory = require('../lib/engine')
   , objectifySelector = require('../lib/objectify-selector')
+  , { formatCurrency } = require('../lib/format')
 
 module.exports = function (program, conf) {
   program
@@ -32,14 +32,13 @@ module.exports = function (program, conf) {
       so.selector = s.selector
       so.debug = cmd.debug
       so.mode = 'live'
-      var engine = engineFactory(s, conf)
       function balance () {
         s.exchange.getBalance(s, function (err, balance) {
           if (err) throw err
           s.exchange.getQuote(s, function (err, quote) {
             if (err) throw err
             
-            var bal = moment().format('YYYY-MM-DD HH:mm:ss').grey + ' ' + engine.formatCurrency(quote.ask, true, true, false) + ' ' + (s.product_id).grey + '\n'
+            var bal = moment().format('YYYY-MM-DD HH:mm:ss').grey + ' ' + formatCurrency(quote.ask, s.currency, true, true, false) + ' ' + (s.product_id).grey + '\n'
             bal += moment().format('YYYY-MM-DD HH:mm:ss').grey + ' Asset: '.grey + balance.asset.white + ' Available: '.grey + n(balance.asset).subtract(balance.asset_hold).value().toString().yellow + '\n'
             bal += moment().format('YYYY-MM-DD HH:mm:ss').grey + ' Asset Value: '.grey + n(balance.asset).multiply(quote.ask).value().toString().white + '\n'
             bal += moment().format('YYYY-MM-DD HH:mm:ss').grey + ' Currency: '.grey + balance.currency.white + ' Available: '.grey + n(balance.currency).subtract(balance.currency_hold).value().toString().yellow + '\n'

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -12,6 +12,7 @@ let tb = require('timebucket')
   , rsi = require('./rsi')
   , async = require('async')
   , lolex = require('lolex')
+  , { formatAsset, formatPercent, formatCurrency } = require('./format')
 
 let clock
 let nice_errors = new RegExp(/(slippage protection|loss protection)/)
@@ -122,41 +123,8 @@ module.exports = function (s, conf) {
     }
   }
 
-  function fa (amt) {
-    return n(amt).format('0.00000000') + ' ' + s.asset
-  }
-
-  function isFiat () {
+  function isFiat() {
     return !s.currency.match(/^BTC|ETH|XMR|USDT$/)
-  }
-
-  let max_fc_width = 0
-  function fc (amt, omit_currency, color_trick, do_pad) {
-    let str
-    let fstr
-    amt > 999 ? fstr = '0.00' :
-      amt > 99 ? fstr = '0.000' :
-        amt > 9 ? fstr = '0.0000' :
-          amt > 0.9 ? fstr = '0.00000' :
-            amt > 0.09 ? fstr = '0.000000' :
-              amt > 0.009 ? fstr = '0.0000000' :
-                fstr = '0.00000000'
-    str = n(amt).format(fstr)
-    if (do_pad) {
-      max_fc_width = Math.max(max_fc_width, str.length)
-      str = ' '.repeat(max_fc_width - str.length) + str
-    }
-    if (color_trick) {
-      str = str
-        .replace(/^(.*\.)(.*?)(0*)$/, function (_, m1, m2, m3) {
-          return m1.cyan + m2.yellow + m3.grey
-        })
-    }
-    return str + (omit_currency ? '' : ' ' + s.currency)
-  }
-
-  function pct (ratio) {
-    return (ratio >= 0 ? '+' : '') + n(ratio).format('0.00%')
   }
 
   function initBuffer (trade) {
@@ -181,6 +149,7 @@ module.exports = function (s, conf) {
     else
       return n(quote.bid).subtract(n(quote.bid).multiply(s.options.markdown_buy_pct / 100)).format(s.product.increment, Math.floor)
   }
+
   function nextSellForQuote(s, quote) {
     if (s.next_sell_price)
       return n(s.next_sell_price).format(s.product.increment, Math.ceil)
@@ -216,7 +185,7 @@ module.exports = function (s, conf) {
         if (last_trade.type === 'buy') {
           if (do_sell_stop && s.sell_stop && s.period.close < s.sell_stop) {
             stop_signal = 'sell'
-            console.log(('\nsell stop triggered at ' + pct(s.last_trade_worth) + ' trade worth\n').red)
+            console.log(('\nsell stop triggered at ' + formatPercent(s.last_trade_worth) + ' trade worth\n').red)
           }
           else if (so.profit_stop_enable_pct && s.last_trade_worth >= (so.profit_stop_enable_pct / 100)) {
             s.profit_stop_high = Math.max(s.profit_stop_high || s.period.close, s.period.close)
@@ -224,14 +193,13 @@ module.exports = function (s, conf) {
           }
           if (s.profit_stop && s.period.close < s.profit_stop && s.last_trade_worth > 0) {
             stop_signal = 'sell'
-            console.log(('\nprofit stop triggered at ' + pct(s.last_trade_worth) + ' trade worth\n').green)
+            console.log(('\nprofit stop triggered at ' + formatPercent(s.last_trade_worth) + ' trade worth\n').green)
           }
-
         }
         else {
           if (s.buy_stop && s.period.close > s.buy_stop) {
             stop_signal = 'buy'
-            console.log(('\nbuy stop triggered at ' + pct(s.last_trade_worth) + ' trade worth\n').red)
+            console.log(('\nbuy stop triggered at ' + formatPercent(s.last_trade_worth) + ' trade worth\n').red)
           }
         }
       }
@@ -308,7 +276,7 @@ module.exports = function (s, conf) {
         err.order = api_order
         return cb(err)
       }
-      msg(type + ' order placed at ' + fc(order.price))
+      msg(type + ' order placed at ' + formatCurrency(order.price, s.currency))
       order.order_id = api_order.id
       if (!order.time) {
         order.orig_time = new Date(api_order.created_at).getTime()
@@ -432,12 +400,12 @@ module.exports = function (s, conf) {
             if (s.product.max_size && Number(size) > Number(s.product.max_size)) {
               size = s.product.max_size
             }
-            msg('preparing buy order over ' + fa(size) + ' of ' + fc(tradeable_balance) + ' (' + buy_pct + '%) tradeable balance with a expected fee of ' + fc(expected_fee) + ' (' + fee + '%)')
+            msg('preparing buy order over ' + formatAsset(size, s.asset) + ' of ' + formatCurrency(tradeable_balance, s.currency) + ' (' + buy_pct + '%) tradeable balance with a expected fee of ' + formatCurrency(expected_fee, s.currency) + ' (' + fee + '%)')
             let latest_low_sell = _.chain(trades).dropRightWhile(['type','buy']).takeRightWhile(['type','sell']).sortBy(['price']).head().value() // return lowest price
             let buy_loss = latest_low_sell ? (latest_low_sell.price - Number(price)) / latest_low_sell.price * -100 : null
             if (so.max_buy_loss_pct != null && buy_loss > so.max_buy_loss_pct) {
               let err = new Error('\nloss protection')
-              err.desc = 'refusing to buy at ' + fc(price) + ', buy loss of ' + pct(buy_loss / 100)
+              err.desc = 'refusing to buy at ' + formatCurrency(price, s.currency) + ', buy loss of ' + formatPercent(buy_loss / 100)
               return cb(err)
             }
             else {
@@ -445,12 +413,12 @@ module.exports = function (s, conf) {
                 let slippage = n(price).subtract(s.buy_order.orig_price).divide(s.buy_order.orig_price).multiply(100).value()
                 if (so.max_slippage_pct != null && slippage > so.max_slippage_pct) {
                   let err = new Error('\nslippage protection')
-                  err.desc = 'refusing to buy at ' + fc(price) + ', slippage of ' + pct(slippage / 100)
+                  err.desc = 'refusing to buy at ' + formatCurrency(price, s.currency) + ', slippage of ' + formatPercent(slippage / 100)
                   return cb(err)
                 }
               }
               if (n(s.balance.currency).subtract(s.balance.currency_hold || 0).value() < n(price).multiply(size).value() && s.balance.currency_hold > 0) {
-                msg('buy delayed: ' + pct(n(s.balance.currency_hold || 0).divide(s.balance.currency).value()) + ' of funds (' + fc(s.balance.currency_hold) + ') on hold')
+                msg('buy delayed: ' + formatPercent(n(s.balance.currency_hold || 0).divide(s.balance.currency).value()) + ' of funds (' + formatCurrency(s.balance.currency_hold, s.currency) + ') on hold')
                 return setTimeout(function () {
                   if (s.last_signal === signal) {
                     executeSignal(signal, cb, size, true)
@@ -458,7 +426,7 @@ module.exports = function (s, conf) {
                 }, conf.wait_for_settlement)
               }
               else {
-                pushMessage('Buying ' + s.exchange.name.toUpperCase(), 'placing buy order at ' + fc(price) + ', ' + fc(quote.bid - Number(price)) + ' under best bid\n')
+                pushMessage('Buying ' + s.exchange.name.toUpperCase(), 'placing buy order at ' + formatCurrency(price, s.currency) + ', ' + formatCurrency(quote.bid - Number(price), s.currency) + ' under best bid\n')
                 doOrder()
               }
             }
@@ -485,7 +453,7 @@ module.exports = function (s, conf) {
             let sell_loss = latest_high_buy ? (Number(price) - latest_high_buy.price) / latest_high_buy.price * -100 : null
             if (so.max_sell_loss_pct != null && sell_loss > so.max_sell_loss_pct) {
               let err = new Error('\nloss protection')
-              err.desc = 'refusing to sell at ' + fc(price) + ', sell loss of ' + pct(sell_loss / 100)
+              err.desc = 'refusing to sell at ' + formatCurrency(price, s.currency) + ', sell loss of ' + formatPercent(sell_loss / 100)
               return cb(err)
             }
             else {
@@ -493,12 +461,12 @@ module.exports = function (s, conf) {
                 let slippage = n(s.sell_order.orig_price).subtract(price).divide(price).multiply(100).value()
                 if (slippage > so.max_slippage_pct) {
                   let err = new Error('\nslippage protection')
-                  err.desc = 'refusing to sell at ' + fc(price) + ', slippage of ' + pct(slippage / 100)
+                  err.desc = 'refusing to sell at ' + formatCurrency(price, s.currency) + ', slippage of ' + formatPercent(slippage / 100)
                   return cb(err)
                 }
               }
               if (n(s.balance.asset).subtract(s.balance.asset_hold || 0).value() < n(size).value()) {
-                msg('sell delayed: ' + pct(n(s.balance.asset_hold || 0).divide(s.balance.asset).value()) + ' of funds (' + fa(s.balance.asset_hold) + ') on hold')
+                msg('sell delayed: ' + formatPercent(n(s.balance.asset_hold || 0).divide(s.balance.asset).value()) + ' of funds (' + formatAsset(s.balance.asset_hold, s.asset) + ') on hold')
                 return setTimeout(function () {
                   if (s.last_signal === signal) {
                     executeSignal(signal, cb, size, true)
@@ -506,7 +474,7 @@ module.exports = function (s, conf) {
                 }, conf.wait_for_settlement)
               }
               else {
-                pushMessage('Selling ' + s.exchange.name.toUpperCase(), 'placing sell order at ' + fc(price) + ', ' + fc(Number(price) - quote.bid) + ' over best ask\n')
+                pushMessage('Selling ' + s.exchange.name.toUpperCase(), 'placing sell order at ' + formatCurrency(price, s.currency) + ', ' + formatCurrency(Number(price) - quote.bid, s.currency) + ' over best ask\n')
                 doOrder()
               }
             }
@@ -600,7 +568,7 @@ module.exports = function (s, conf) {
       }
       s.my_trades.push(my_trade)
       if (so.stats) {
-        let order_complete = '\nbuy order completed at ' + moment(trade.time).format('YYYY-MM-DD HH:mm:ss') + ':\n\n' + fa(my_trade.size) + ' at ' + fc(my_trade.price) + '\ntotal ' + fc(my_trade.size * my_trade.price) + '\n' + n(my_trade.slippage).format('0.0000%') + ' slippage (orig. price ' + fc(s.buy_order.orig_price) + ')\nexecution: ' + moment.duration(my_trade.execution_time).humanize() + '\n'
+        let order_complete = '\nbuy order completed at ' + moment(trade.time).format('YYYY-MM-DD HH:mm:ss') + ':\n\n' + formatAsset(my_trade.size, s.asset) + ' at ' + formatCurrency(my_trade.price, s.currency) + '\ntotal ' + formatCurrency(my_trade.size * my_trade.price, s.currency) + '\n' + n(my_trade.slippage).format('0.0000%') + ' slippage (orig. price ' + formatCurrency(s.buy_order.orig_price, s.currency) + ')\nexecution: ' + moment.duration(my_trade.execution_time).humanize() + '\n'
         console.log((order_complete).cyan)
         pushMessage('Buy ' + s.exchange.name.toUpperCase(), order_complete)
       }
@@ -648,7 +616,7 @@ module.exports = function (s, conf) {
       }
       s.my_trades.push(my_trade)
       if (so.stats) {
-        let order_complete = '\nsell order completed at ' + moment(trade.time).format('YYYY-MM-DD HH:mm:ss') + ':\n\n' + fa(my_trade.size) + ' at ' + fc(my_trade.price) + '\ntotal ' + fc(my_trade.size * my_trade.price) + '\n' + n(my_trade.slippage).format('0.0000%') + ' slippage (orig. price ' + fc(s.sell_order.orig_price) + ')\nexecution: ' + moment.duration(my_trade.execution_time).humanize() + '\n'
+        let order_complete = '\nsell order completed at ' + moment(trade.time).format('YYYY-MM-DD HH:mm:ss') + ':\n\n' + formatAsset(my_trade.size, s.asset) + ' at ' + formatCurrency(my_trade.price, s.currency) + '\ntotal ' + formatCurrency(my_trade.size * my_trade.price, s.currency) + '\n' + n(my_trade.slippage).format('0.0000%') + ' slippage (orig. price ' + formatCurrency(s.sell_order.orig_price, s.currency) + ')\nexecution: ' + moment.duration(my_trade.execution_time).humanize() + '\n'
         console.log((order_complete).cyan)
         pushMessage('Sell ' + s.exchange.name.toUpperCase(), order_complete)
       }
@@ -692,10 +660,10 @@ module.exports = function (s, conf) {
     readline.clearLine(process.stdout)
     readline.cursorTo(process.stdout, 0)
     process.stdout.write(moment(is_progress ? s.period.latest_trade_time : tb(s.period.time).resize(so.period_length).add(1).toMilliseconds()).format('YYYY-MM-DD HH:mm:ss')[is_progress && !blink_off ? 'bgBlue' : 'grey'])
-    process.stdout.write('  ' + fc(s.period.close, true, true, true) + ' ' + s.product_id.grey)
+    process.stdout.write('  ' + formatCurrency(s.period.close, s.currency, true, true, true) + ' ' + s.product_id.grey)
     if (s.lookback[0]) {
       let diff = (s.period.close - s.lookback[0].close) / s.lookback[0].close
-      process.stdout.write(z(8, pct(diff), ' ')[diff >= 0 ? 'green' : 'red'])
+      process.stdout.write(z(8, formatPercent(diff), ' ')[diff >= 0 ? 'green' : 'red'])
     }
     else {
       process.stdout.write(z(9, '', ' '))
@@ -749,7 +717,7 @@ module.exports = function (s, conf) {
       process.stdout.write(z(9, s.signal || '', ' ')[s.signal ? s.signal === 'buy' ? 'green' : 'red' : 'grey'])
     }
     else if (s.last_trade_worth && !s.buy_order && !s.sell_order) {
-      process.stdout.write(z(8, pct(s.last_trade_worth), ' ')[s.last_trade_worth > 0 ? 'green' : 'red'])
+      process.stdout.write(z(8, formatPercent(s.last_trade_worth), ' ')[s.last_trade_worth > 0 ? 'green' : 'red'])
     }
     else {
       process.stdout.write(z(9, '', ' '))
@@ -765,10 +733,10 @@ module.exports = function (s, conf) {
       process.stdout.write(z(currency_col_width, currency_col, ' ').yellow)
       let consolidated = n(s.balance.currency).add(n(s.period.close).multiply(s.balance.asset)).value()
       let profit = (consolidated - orig_capital) / orig_capital
-      process.stdout.write(z(8, pct(profit), ' ')[profit >= 0 ? 'green' : 'red'])
+      process.stdout.write(z(8, formatPercent(profit), ' ')[profit >= 0 ? 'green' : 'red'])
       let buy_hold = s.period.close * (orig_capital / orig_price)
       let over_buy_hold_pct = (consolidated - buy_hold) / buy_hold
-      process.stdout.write(z(8, pct(over_buy_hold_pct), ' ')[over_buy_hold_pct >= 0 ? 'green' : 'red'])
+      process.stdout.write(z(8, formatPercent(over_buy_hold_pct), ' ')[over_buy_hold_pct >= 0 ? 'green' : 'red'])
     }
     if (!is_progress) {
       process.stdout.write('\n')
@@ -1023,8 +991,6 @@ module.exports = function (s, conf) {
     executeSignal: executeSignal,
     writeReport: writeReport,
     syncBalance: syncBalance,
-    formatCurrency: fc,
-    formatAsset: fa
   }
 }
 

--- a/lib/format.js
+++ b/lib/format.js
@@ -1,0 +1,34 @@
+let n = require('numbro')
+
+let max_fc_width = 0
+module.exports = {
+  formatAsset: function formatAsset (amt, asset) {
+    return n(amt).format('0.00000000') + ' ' + asset
+  },
+  formatPercent: function formatPercent (ratio) {
+    return (ratio >= 0 ? '+' : '') + n(ratio).format('0.00%')
+  },
+  formatCurrency: function formatCurrency (amt, currency, omit_currency, color_trick, do_pad) {
+    let str
+    let fstr
+    amt > 999 ? fstr = '0.00' :
+      amt > 99 ? fstr = '0.000' :
+        amt > 9 ? fstr = '0.0000' :
+          amt > 0.9 ? fstr = '0.00000' :
+            amt > 0.09 ? fstr = '0.000000' :
+              amt > 0.009 ? fstr = '0.0000000' :
+                fstr = '0.00000000'
+    str = n(amt).format(fstr)
+    if (do_pad) {
+      max_fc_width = Math.max(max_fc_width, str.length)
+      str = ' '.repeat(max_fc_width - str.length) + str
+    }
+    if (color_trick) {
+      str = str
+        .replace(/^(.*\.)(.*?)(0*)$/, function (_, m1, m2, m3) {
+          return m1.cyan + m2.yellow + m3.grey
+        })
+    }
+    return str + (omit_currency ? '' : ' ' + currency)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint **/*.js",
     "lint-fix": "eslint **/*.js --fix",
     "precommit": "lint-staged",
-    "test": "jasmine test/_specs/**/**.test.js",
+    "test": "jasmine test/**/**.test.js",
     "test-one": "jasmine $PATH_TO_TEST",
     "postinstall": "node post_install.js"
   },

--- a/test/lib/engine.test.js
+++ b/test/lib/engine.test.js
@@ -1,3 +1,5 @@
+var EventEmitter = require('events')
+
 describe('Engine', function() {
   describe('executeSignal', function() {
     describe('when maker in live mode', function(){
@@ -10,12 +12,12 @@ describe('Engine', function() {
           var buy_max_amt = 0.25
           var order_type = 'maker'
           var held_asset = 0
-          var buy_spy = jasmine.createSpy()
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
-          var expected = '2.77500000'
+          var expected = '2.77500277'
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })
@@ -27,12 +29,12 @@ describe('Engine', function() {
           var buy_max_amt = 0.25
           var order_type = 'maker'
           var held_asset = 0.75
-          var buy_spy = jasmine.createSpy()
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
-          var expected = '1.85925000'
+          var expected = '1.85925185'
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })
@@ -44,7 +46,7 @@ describe('Engine', function() {
           var buy_max_amt = 0.25
           var order_type = 'maker'
           var held_asset = 2.0
-          var buy_spy = jasmine.createSpy()
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
@@ -60,16 +62,18 @@ describe('Engine', function() {
           var buy_pct = 50
           var buy_max_amt = undefined
           var order_type = 'maker'
-          var held_asset = 0				
-          var buy_spy = jasmine.createSpy()
+          var held_asset = 0
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
-          var expected = '5.55000000'
+          var expected = '5.55000555'
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })
+        // no longer taking held assets into account with no buy_max
+        /*
         it('and held assets should use adjusted buy_pct', function(){
           // arrange
           var signal_type = 'buy'
@@ -77,8 +81,8 @@ describe('Engine', function() {
           var buy_pct = 50
           var buy_max_amt = undefined
           var order_type = 'maker'
-          var held_asset = 0.5				
-          var buy_spy = jasmine.createSpy()
+          var held_asset = 0.5
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
@@ -94,14 +98,15 @@ describe('Engine', function() {
           var buy_pct = 50
           var buy_max_amt = undefined
           var order_type = 'maker'
-          var held_asset = 5.25				
-          var buy_spy = jasmine.createSpy()
+          var held_asset = 10.25				
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
           expect(buy_spy).not.toHaveBeenCalled()
         })
+        */
       })
     })
     
@@ -115,12 +120,12 @@ describe('Engine', function() {
           var buy_max_amt = 0.25
           var order_type = 'taker'
           var held_asset = 0
-          var buy_spy = jasmine.createSpy()
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
-          var expected = '2.77222222'
+          var expected = '2.77223331'
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })
@@ -133,12 +138,12 @@ describe('Engine', function() {
           var buy_max_amt = 0.25
           var order_type = 'taker'
           var held_asset = 0.75
-          var buy_spy = jasmine.createSpy()
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
-          var expected = '1.85738888'
+          var expected = '1.85739631'
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })
@@ -151,7 +156,7 @@ describe('Engine', function() {
           var buy_max_amt = 0.25
           var order_type = 'taker'
           var held_asset = 2.0
-          var buy_spy = jasmine.createSpy()
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
@@ -168,15 +173,16 @@ describe('Engine', function() {
           var buy_max_amt = undefined
           var order_type = 'taker'
           var held_asset = 0
-          var buy_spy = jasmine.createSpy()
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
-          var expected = '5.54444444'
+          var expected = '5.54446662'
           var buyArgs = buy_spy.calls.mostRecent().args[0]
           expect(buyArgs.size).toBe(expected)
         })
+        /*
         it('and held assets should use adjusted buy_pct', function(){
           // arrange
           var signal_type = 'buy'
@@ -185,7 +191,7 @@ describe('Engine', function() {
           var buy_max_amt = undefined
           var order_type = 'taker'
           var held_asset = 0.5				
-          var buy_spy = jasmine.createSpy()
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
@@ -202,13 +208,14 @@ describe('Engine', function() {
           var buy_max_amt = undefined
           var order_type = 'taker'
           var held_asset = 5.25				
-          var buy_spy = jasmine.createSpy()
+          var buy_spy = jasmine.createSpy('buy')
           var sut = createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_asset, buy_spy)
           // act
           sut.executeSignal(signal_type)
           // assert
           expect(buy_spy).not.toHaveBeenCalled()
         })
+        */
       })
     })
   })
@@ -224,13 +231,7 @@ function createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_as
   var fake_project = 'test_product'
   var fake_bid = 0.10
   var fake_ask = 0.11
-  var fake_balance = { currency: currency_amount, asset:held_asset}
-  
-  var fakes = {
-    get: function() { },
-    set: function() { },
-    clear: function() { }
-  }
+  var fake_balance = { currency: currency_amount, asset: held_asset }
   
   var fake_product = {
     'asset': fake_asset,
@@ -243,6 +244,7 @@ function createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_as
 
   var fake_return = {
     'conf': {
+      eventBus: new EventEmitter(),
       output: {
         api: {}
       }
@@ -264,10 +266,6 @@ function createEngine(currency_amount, buy_pct, buy_max_amt, order_type, held_as
   var exchange_path = path.resolve(__dirname, '../../extensions/exchanges/test_exchange/exchange')
   mock(exchange_path, fake_return['exchanges.test_exchange'])
   mock('./notify', fake_return['lib.notify'])
-  
-  spyOn(fakes,'get').and.callFake(function(param){
-    return fake_return[param]
-  })
   
   var input = {
     options: {

--- a/test/lib/format.test.js
+++ b/test/lib/format.test.js
@@ -1,0 +1,26 @@
+let { formatAsset, formatCurrency, formatPercent } = require('../../lib/format')
+
+describe('Format', () => {
+  describe('formatAsset', () => {
+    it('formats assets as expected', () => {
+      expect(formatAsset(5, 'USD')).toBe('5.00000000 USD')
+    })
+  })
+  describe('formatCurrency', () => {
+    it('formats currency as expected', () => {
+      expect(formatCurrency(1000, 'USD')).toBe('1000.00 USD')
+      expect(formatCurrency(100, 'THING')).toBe('100.000 THING')
+      expect(formatCurrency(1, 'GBP')).toBe('1.00000 GBP')
+      expect(formatCurrency(0.008, 'XRP')).toBe('0.00800000 XRP')
+      expect(formatCurrency(10, 'USD', true)).toBe('10.0000')
+      expect(formatCurrency(10, 'USD', false, false, true)).toBe('10.0000 USD')
+    })
+  })
+  describe('formatPercent', () => {
+    it('formats percentages as expected', () => {
+      expect(formatPercent(0.1)).toBe('+10.00%')
+      expect(formatPercent(-0.03)).toBe('-3.00%')
+      expect(formatPercent(0.0005)).toBe('+0.05%')
+    })
+  })
+})


### PR DESCRIPTION
Takes the formatting functions out of `engine` and puts them in their own module as part of the effort to clean up/thin out `engine`.

Also re-enables the rest of the unit tests that somehow got dropped along the way and adds unit tests for the new formatting functions. I had to modify the existing `engine` tests as the calculations for orders have changed slightly since the tests were written. 