### PR TITLE
syncBalance can return quote, no need to get it again

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -246,7 +246,7 @@ module.exports = function (s, conf) {
     s.exchange.getBalance({currency: s.currency, asset: s.asset}, function (err, balance) {
       if (err) return cb(err)
       s.balance = balance
-      s.exchange.getQuote({product_id: s.product_id}, function (err, quote) {
+      getQuote(function (err, quote) {
         if (err) return cb(err)
 
         if (!s.start_capital) {
@@ -257,7 +257,7 @@ module.exports = function (s, conf) {
         }
 
         s.asset_capital = n(s.balance.asset).multiply(quote.ask).value()
-        cb()
+        cb(null, { balance, quote })
       })
     })
   }
@@ -373,149 +373,147 @@ module.exports = function (s, conf) {
         _cb(null, order)
       }
     }
-    syncBalance(function (err) {
+    syncBalance(function (err, { quote }) {
       if (err) {
         msg('error getting balance')
       }
-      getQuote(function (err, quote) {
-        let reorder_pct, fee, trade_balance, tradeable_balance, expected_fee
-        if (err) {
-          err.desc = 'could not execute ' + signal + ': error fetching quote'
-          return cb(err)
-        }
-        if (is_reorder && s[signal + '_order']) {
-          if (signal === 'buy') {
-            reorder_pct = n(size).multiply(s.buy_order.price).add(s.buy_order.fee).divide(s.balance.currency).multiply(100)
-          } else {
-            reorder_pct = n(size).divide(s.balance.asset).multiply(100)
-          }
-          msg('price changed, resizing order, ' + reorder_pct + '% remain')
-          size = null
-        }
-        if (s.my_prev_trades.length) {
-          trades = _.concat(s.my_prev_trades, s.my_trades)
-        } else {
-          trades = _.cloneDeep(s.my_trades)
-        }
+      let reorder_pct, fee, trade_balance, tradeable_balance, expected_fee
+      if (err) {
+        err.desc = 'could not execute ' + signal + ': error fetching quote'
+        return cb(err)
+      }
+      if (is_reorder && s[signal + '_order']) {
         if (signal === 'buy') {
-          price = nextBuyForQuote(s, quote)
+          reorder_pct = n(size).multiply(s.buy_order.price).add(s.buy_order.fee).divide(s.balance.currency).multiply(100)
+        } else {
+          reorder_pct = n(size).divide(s.balance.asset).multiply(100)
+        }
+        msg('price changed, resizing order, ' + reorder_pct + '% remain')
+        size = null
+      }
+      if (s.my_prev_trades.length) {
+        trades = _.concat(s.my_prev_trades, s.my_trades)
+      } else {
+        trades = _.cloneDeep(s.my_trades)
+      }
+      if (signal === 'buy') {
+        price = nextBuyForQuote(s, quote)
 
-          if (is_reorder) {
-            buy_pct = reorder_pct
-          } else {
-            buy_pct = so.buy_pct
-          }
-          if (so.buy_max_amt) { // account for held assets as buy_max
-            let adjusted_buy_max_amt = n(so.buy_max_amt).subtract(s.asset_capital).value()
-            if(adjusted_buy_max_amt < s.balance.currency){
-              let buy_max_as_pct = n(adjusted_buy_max_amt).divide(s.balance.currency).multiply(100).value()
-              buy_pct = buy_max_as_pct
-            }
-          }
-          if (so.use_fee_asset) {
-            fee = 0
-          } else if (so.order_type === 'maker' && (buy_pct + s.exchange.takerFee < 100 || !s.exchange.makerBuy100Workaround)) {
-            fee = s.exchange.makerFee
-          } else {
-            fee = s.exchange.takerFee
-          }
-          trade_balance = n(s.balance.currency).divide(100).multiply(buy_pct)
-          tradeable_balance = n(s.balance.currency).divide(100 + fee).multiply(buy_pct)
-          expected_fee = n(trade_balance).subtract(tradeable_balance).format('0.00000000', Math.ceil) // round up as the exchange will too
-          if (buy_pct + fee < 100) {
-            size = n(tradeable_balance).divide(price).format(s.product.asset_increment ? s.product.asset_increment : '0.00000000')
-          } else {
-            size = n(trade_balance).subtract(expected_fee).divide(price).format(s.product.asset_increment ? s.product.asset_increment : '0.00000000')
-          }
-
-          if ((s.product.min_size && Number(size) >= Number(s.product.min_size)) || ('min_total' in s.product && s.product.min_total && n(size).multiply(price).value() >= Number(s.product.min_total))) {
-            if (s.product.max_size && Number(size) > Number(s.product.max_size)) {
-              size = s.product.max_size
-            }
-            msg('preparing buy order over ' + fa(size) + ' of ' + fc(tradeable_balance) + ' (' + buy_pct + '%) tradeable balance with a expected fee of ' + fc(expected_fee) + ' (' + fee + '%)')
-            let latest_low_sell = _.chain(trades).dropRightWhile(['type','buy']).takeRightWhile(['type','sell']).sortBy(['price']).head().value() // return lowest price
-            let buy_loss = latest_low_sell ? (latest_low_sell.price - Number(price)) / latest_low_sell.price * -100 : null
-            if (so.max_buy_loss_pct != null && buy_loss > so.max_buy_loss_pct) {
-              let err = new Error('\nloss protection')
-              err.desc = 'refusing to buy at ' + fc(price) + ', buy loss of ' + pct(buy_loss / 100)
-              return cb(err)
-            }
-            else {
-              if (s.buy_order && so.max_slippage_pct != null) {
-                let slippage = n(price).subtract(s.buy_order.orig_price).divide(s.buy_order.orig_price).multiply(100).value()
-                if (so.max_slippage_pct != null && slippage > so.max_slippage_pct) {
-                  let err = new Error('\nslippage protection')
-                  err.desc = 'refusing to buy at ' + fc(price) + ', slippage of ' + pct(slippage / 100)
-                  return cb(err)
-                }
-              }
-              if (n(s.balance.currency).subtract(s.balance.currency_hold || 0).value() < n(price).multiply(size).value() && s.balance.currency_hold > 0) {
-                msg('buy delayed: ' + pct(n(s.balance.currency_hold || 0).divide(s.balance.currency).value()) + ' of funds (' + fc(s.balance.currency_hold) + ') on hold')
-                return setTimeout(function () {
-                  if (s.last_signal === signal) {
-                    executeSignal(signal, cb, size, true)
-                  }
-                }, conf.wait_for_settlement)
-              }
-              else {
-                pushMessage('Buying ' + s.exchange.name.toUpperCase(), 'placing buy order at ' + fc(price) + ', ' + fc(quote.bid - Number(price)) + ' under best bid\n')
-                doOrder()
-              }
-            }
-          }
-          else {
-            cb(null, null)
+        if (is_reorder) {
+          buy_pct = reorder_pct
+        } else {
+          buy_pct = so.buy_pct
+        }
+        if (so.buy_max_amt) { // account for held assets as buy_max
+          let adjusted_buy_max_amt = n(so.buy_max_amt).subtract(s.asset_capital).value()
+          if(adjusted_buy_max_amt < s.balance.currency){
+            let buy_max_as_pct = n(adjusted_buy_max_amt).divide(s.balance.currency).multiply(100).value()
+            buy_pct = buy_max_as_pct
           }
         }
-        else if (signal === 'sell') {
-          price = nextSellForQuote(s, quote)
+        if (so.use_fee_asset) {
+          fee = 0
+        } else if (so.order_type === 'maker' && (buy_pct + s.exchange.takerFee < 100 || !s.exchange.makerBuy100Workaround)) {
+          fee = s.exchange.makerFee
+        } else {
+          fee = s.exchange.takerFee
+        }
+        trade_balance = n(s.balance.currency).divide(100).multiply(buy_pct)
+        tradeable_balance = n(s.balance.currency).divide(100 + fee).multiply(buy_pct)
+        expected_fee = n(trade_balance).subtract(tradeable_balance).format('0.00000000', Math.ceil) // round up as the exchange will too
+        if (buy_pct + fee < 100) {
+          size = n(tradeable_balance).divide(price).format(s.product.asset_increment ? s.product.asset_increment : '0.00000000')
+        } else {
+          size = n(trade_balance).subtract(expected_fee).divide(price).format(s.product.asset_increment ? s.product.asset_increment : '0.00000000')
+        }
 
-          if (is_reorder) {
-            sell_pct = reorder_pct
-          } else {
-            sell_pct = so.sell_pct
+        if ((s.product.min_size && Number(size) >= Number(s.product.min_size)) || ('min_total' in s.product && s.product.min_total && n(size).multiply(price).value() >= Number(s.product.min_total))) {
+          if (s.product.max_size && Number(size) > Number(s.product.max_size)) {
+            size = s.product.max_size
           }
-          size = n(s.balance.asset).multiply(sell_pct / 100).format(s.product.asset_increment ? s.product.asset_increment : '0.00000000')
-
-          if ((s.product.min_size && Number(size) >= Number(s.product.min_size)) || (s.product.min_total && n(size).multiply(price).value() >= Number(s.product.min_total))) {
-            if (s.product.max_size && Number(size) > Number(s.product.max_size)) {
-              size = s.product.max_size
-            }
-            let latest_high_buy = _.chain(trades).dropRightWhile(['type','sell']).takeRightWhile(['type','buy']).sortBy(['price']).reverse().head().value() // return highest price
-            let sell_loss = latest_high_buy ? (Number(price) - latest_high_buy.price) / latest_high_buy.price * -100 : null
-            if (so.max_sell_loss_pct != null && sell_loss > so.max_sell_loss_pct) {
-              let err = new Error('\nloss protection')
-              err.desc = 'refusing to sell at ' + fc(price) + ', sell loss of ' + pct(sell_loss / 100)
-              return cb(err)
-            }
-            else {
-              if (s.sell_order && so.max_slippage_pct != null) {
-                let slippage = n(s.sell_order.orig_price).subtract(price).divide(price).multiply(100).value()
-                if (slippage > so.max_slippage_pct) {
-                  let err = new Error('\nslippage protection')
-                  err.desc = 'refusing to sell at ' + fc(price) + ', slippage of ' + pct(slippage / 100)
-                  return cb(err)
-                }
-              }
-              if (n(s.balance.asset).subtract(s.balance.asset_hold || 0).value() < n(size).value()) {
-                msg('sell delayed: ' + pct(n(s.balance.asset_hold || 0).divide(s.balance.asset).value()) + ' of funds (' + fa(s.balance.asset_hold) + ') on hold')
-                return setTimeout(function () {
-                  if (s.last_signal === signal) {
-                    executeSignal(signal, cb, size, true)
-                  }
-                }, conf.wait_for_settlement)
-              }
-              else {
-                pushMessage('Selling ' + s.exchange.name.toUpperCase(), 'placing sell order at ' + fc(price) + ', ' + fc(Number(price) - quote.bid) + ' over best ask\n')
-                doOrder()
-              }
-            }
+          msg('preparing buy order over ' + fa(size) + ' of ' + fc(tradeable_balance) + ' (' + buy_pct + '%) tradeable balance with a expected fee of ' + fc(expected_fee) + ' (' + fee + '%)')
+          let latest_low_sell = _.chain(trades).dropRightWhile(['type','buy']).takeRightWhile(['type','sell']).sortBy(['price']).head().value() // return lowest price
+          let buy_loss = latest_low_sell ? (latest_low_sell.price - Number(price)) / latest_low_sell.price * -100 : null
+          if (so.max_buy_loss_pct != null && buy_loss > so.max_buy_loss_pct) {
+            let err = new Error('\nloss protection')
+            err.desc = 'refusing to buy at ' + fc(price) + ', buy loss of ' + pct(buy_loss / 100)
+            return cb(err)
           }
           else {
-            cb(null, null)
+            if (s.buy_order && so.max_slippage_pct != null) {
+              let slippage = n(price).subtract(s.buy_order.orig_price).divide(s.buy_order.orig_price).multiply(100).value()
+              if (so.max_slippage_pct != null && slippage > so.max_slippage_pct) {
+                let err = new Error('\nslippage protection')
+                err.desc = 'refusing to buy at ' + fc(price) + ', slippage of ' + pct(slippage / 100)
+                return cb(err)
+              }
+            }
+            if (n(s.balance.currency).subtract(s.balance.currency_hold || 0).value() < n(price).multiply(size).value() && s.balance.currency_hold > 0) {
+              msg('buy delayed: ' + pct(n(s.balance.currency_hold || 0).divide(s.balance.currency).value()) + ' of funds (' + fc(s.balance.currency_hold) + ') on hold')
+              return setTimeout(function () {
+                if (s.last_signal === signal) {
+                  executeSignal(signal, cb, size, true)
+                }
+              }, conf.wait_for_settlement)
+            }
+            else {
+              pushMessage('Buying ' + s.exchange.name.toUpperCase(), 'placing buy order at ' + fc(price) + ', ' + fc(quote.bid - Number(price)) + ' under best bid\n')
+              doOrder()
+            }
           }
         }
-      })
+        else {
+          cb(null, null)
+        }
+      }
+      else if (signal === 'sell') {
+        price = nextSellForQuote(s, quote)
+
+        if (is_reorder) {
+          sell_pct = reorder_pct
+        } else {
+          sell_pct = so.sell_pct
+        }
+        size = n(s.balance.asset).multiply(sell_pct / 100).format(s.product.asset_increment ? s.product.asset_increment : '0.00000000')
+
+        if ((s.product.min_size && Number(size) >= Number(s.product.min_size)) || (s.product.min_total && n(size).multiply(price).value() >= Number(s.product.min_total))) {
+          if (s.product.max_size && Number(size) > Number(s.product.max_size)) {
+            size = s.product.max_size
+          }
+          let latest_high_buy = _.chain(trades).dropRightWhile(['type','sell']).takeRightWhile(['type','buy']).sortBy(['price']).reverse().head().value() // return highest price
+          let sell_loss = latest_high_buy ? (Number(price) - latest_high_buy.price) / latest_high_buy.price * -100 : null
+          if (so.max_sell_loss_pct != null && sell_loss > so.max_sell_loss_pct) {
+            let err = new Error('\nloss protection')
+            err.desc = 'refusing to sell at ' + fc(price) + ', sell loss of ' + pct(sell_loss / 100)
+            return cb(err)
+          }
+          else {
+            if (s.sell_order && so.max_slippage_pct != null) {
+              let slippage = n(s.sell_order.orig_price).subtract(price).divide(price).multiply(100).value()
+              if (slippage > so.max_slippage_pct) {
+                let err = new Error('\nslippage protection')
+                err.desc = 'refusing to sell at ' + fc(price) + ', slippage of ' + pct(slippage / 100)
+                return cb(err)
+              }
+            }
+            if (n(s.balance.asset).subtract(s.balance.asset_hold || 0).value() < n(size).value()) {
+              msg('sell delayed: ' + pct(n(s.balance.asset_hold || 0).divide(s.balance.asset).value()) + ' of funds (' + fa(s.balance.asset_hold) + ') on hold')
+              return setTimeout(function () {
+                if (s.last_signal === signal) {
+                  executeSignal(signal, cb, size, true)
+                }
+              }, conf.wait_for_settlement)
+            }
+            else {
+              pushMessage('Selling ' + s.exchange.name.toUpperCase(), 'placing sell order at ' + fc(price) + ', ' + fc(Number(price) - quote.bid) + ' over best ask\n')
+              doOrder()
+            }
+          }
+        }
+        else {
+          cb(null, null)
+        }
+      }
     })
     function doOrder () {
       placeOrder(signal, {


### PR DESCRIPTION
Currently, as part of `executeSignal`, we run `syncBalance` and then immediately run `getQuote` when `getQuote` is actually run _inside_ `syncBalance`... So instead of running `getQuote` twice, we can just have `syncBalance` return the quote (and balance for that matter, to start moving these things away from just mutating a psudo-global) and use that quote. 

Involved removing a level of nesting for most of the **enormous** `executeSignal` function, so turning off whitespace with `?w=1` is recommended for readability. 