### PR TITLE
Add option to set number of prev trades to load

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ zenbot trade --help
     --exact_buy_orders                instead of only adjusting maker buy when the price goes up, adjust it if price has changed at all
     --exact_sell_orders               instead of only adjusting maker sell when the price goes down, adjust it if price has changed at all
     --use_prev_trades                 load and use previous trades for stop-order triggers and loss protection
+    --min_prev_trades                 minimum number of previous trades to load if use_prev_trades is enabled, set to 0 to disable and use trade time instead
     --disable_stats                   disable printing order stats
     --reset_profit                    start new profit calculation from 0
     --use_fee_asset                   Using separated asset to pay for fees. Such as binance's BNB or Huobi's HT

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -50,6 +50,7 @@ module.exports = function (program, conf) {
     .option('--exact_buy_orders', 'instead of only adjusting maker buy when the price goes up, adjust it if price has changed at all')
     .option('--exact_sell_orders', 'instead of only adjusting maker sell when the price goes down, adjust it if price has changed at all')
     .option('--use_prev_trades', 'load and use previous trades for stop-order triggers and loss protection')
+    .option('--min_prev_trades', 'minimum number of previous trades to load if use_prev_trades is enabled, set to 0 to disable and use trade time instead')
     .option('--disable_stats', 'disable printing order stats')
     .option('--reset_profit', 'start new profit calculation from 0')
     .option('--use_fee_asset', 'Using separated asset to pay for fees. Such as binance\'s BNB or Huobi\'s HT', Boolean, false)
@@ -77,6 +78,7 @@ module.exports = function (program, conf) {
       so.currency_increment = cmd.currency_increment
       so.keep_lookback_periods = cmd.keep_lookback_periods
       so.use_prev_trades = (cmd.use_prev_trades||conf.use_prev_trades)
+      so.min_prev_trades = parseInt(cmd.min_prev_trades||conf.min_prev_trades)
       so.debug = cmd.debug
       so.stats = !cmd.disable_stats
       so.mode = so.paper ? 'paper' : 'live'
@@ -407,10 +409,19 @@ module.exports = function (program, conf) {
           trades.find(opts.query).limit(opts.limit).sort(opts.sort).toArray(function (err, trades) {
             if (err) throw err
             if (trades.length && so.use_prev_trades) {
-              my_trades.find({selector: so.selector.normalized, time : {$gte : trades[0].time}}).limit(0).toArray(function (err, my_prev_trades) {
+              let prevOpts = {
+                query: {
+                  selector: so.selector.normalized
+                },
+                limit: so.min_prev_trades
+              }
+              if (!so.min_prev_trades) {
+                prevOpts.query.time = {$gte : trades[0].time}
+              }
+              my_trades.find(prevOpts.query).sort({$natural:-1}).limit(prevOpts.limit).toArray(function (err, my_prev_trades) {
                 if (err) throw err
                 if (my_prev_trades.length) {
-                  s.my_prev_trades = my_prev_trades.slice(0).sort(function(a,b){return a.time + a.execution_time < b.time + b.execution_time ? -1 : 1}) // simple copy, less recent executed first
+                  s.my_prev_trades = my_prev_trades.reverse().slice(0) // simple copy, less recent executed first
                 }
               })
             }

--- a/conf-sample.js
+++ b/conf-sample.js
@@ -170,6 +170,8 @@ c.avg_slippage_pct = 0.045
 c.cancel_after = 'day'
 // load and use previous trades for stop-order triggers and loss protection (live/paper mode only)
 c.use_prev_trades = false
+// minimum number of previous trades to load if use_prev_trades is enabled, set to 0 to disable and use trade time instead
+c.min_prev_trades = 0
 
 // Notifiers:
 c.notifiers = {}


### PR DESCRIPTION
By default use_prev_trades will only load previous trades within the last 1000 trades lookback, which can be a problem if e.g. the bot hasn't traded for a extended period of time for whatever reason (didn't run, not profitable, etc...)

To overcome this "limitation" set min_prev_trades to the number of previous trades you want to load.

Set to zero (0) to use the default behavior.