### PR TITLE
notifiers - slack - fix exception when running in docker

### DIFF
--- a/extensions/notifiers/slack.js
+++ b/extensions/notifiers/slack.js
@@ -3,8 +3,7 @@ var IncomingWebhook = require('@slack/client').IncomingWebhook
 module.exports = function slack (config) {
   var slack = {
     pushMessage: function(title, message) {
-      var slackWebhook = new IncomingWebhook(config.webhook_url || '')
-
+      var slackWebhook = new IncomingWebhook(config.webhook_url || '', {})
       slackWebhook.send(title + ': ' + message, function (err) {
         if (err) {
           console.error('\nerror: slack webhook')


### PR DESCRIPTION
/app/node_modules/@slack/client/dist/IncomingWebhook.js:26
            payload.text = message;
                         ^

TypeError: Cannot set property 'text' of undefined
    at IncomingWebhook.send (/app/node_modules/@slack/client/dist/IncomingWebhook.js:26:26)
    at Object.pushMessage (/app/extensions/notifiers/slack.js:11:20)
    at active_notifiers.forEach (/app/lib/notify.js:19:18)
    at Array.forEach (<anonymous>)
    at Object.pushMessage (/app/lib/notify.js:15:24)
    at pushMessage (/app/lib/engine.js:121:16)
    at /app/lib/engine.js:256:11
    at /app/extensions/exchanges/gdax/exchange.js:311:11
    at Request._callback (/app/node_modules/gdax/lib/clients/public.js:81:11)
    at Request.self.callback (/app/node_modules/request/request.js:186:22)