### PR TITLE
Improved Docker + auth in database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.env
 *.tar.gz
 *.log.*
 t.js
@@ -9,10 +10,10 @@ dump
 conf/secret.json
 github.pub
 github
+conf.js
 config.js
 config.patch
 data/*
-conf.js
 conf-*
 conf_*
 !conf-sample.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,3 @@ RUN ln -s /app/zenbot.sh /usr/local/bin/zenbot
 
 ENV NODE_ENV production
 
-ENTRYPOINT ["/usr/local/bin/node", "zenbot.js"]
-CMD [ "trade", "--paper" ]

--- a/boot.js
+++ b/boot.js
@@ -53,7 +53,7 @@ module.exports = function (cb) {
   } else {
     connectionString = 'mongodb://' + authStr + zenbot.conf.mongo.host + ':' + zenbot.conf.mongo.port + '/' + zenbot.conf.mongo.db + '?' +
       (zenbot.conf.mongo.replicaSet ? '&replicaSet=' + zenbot.conf.mongo.replicaSet : '' ) +
-      (authMechanism ? '&authMechanism=' + authMechanism : '' )
+      (zenbot.conf.mongo.authMechanism ? '&authMechanism=' + authMechanism : '' )
   }
 
   require('mongodb').MongoClient.connect(connectionString, function (err, client) {

--- a/conf-sample.js
+++ b/conf-sample.js
@@ -14,6 +14,7 @@ c.mongo.username = null
 c.mongo.password = null
 // when using mongodb replication, i.e. when running a mongodb cluster, you can define your replication set here; when you are not using replication (most of the users), just set it to `null` (default).
 c.mongo.replicaSet = null
+c.mongo.authMechanism  = null
 
 // default selector. only used if omitting [selector] argument from a command.
 c.selector = 'gdax.BTC-USD'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,43 +1,36 @@
 version: '3.1'
-
 services:
-
   server:
-    image: deviavir/zenbot:unstable
+    image: 'deviavir/zenbot:unstable'
     volumes:
-      - ./conf.js:/app/conf.js
-      - ./extensions:/app/extensions
-      - ./simulations:/app/simulations
-      - ./models:/app/models
+      - './conf.js:/app/conf.js'
+      - './extensions:/app/extensions'
+      - './simulations:/app/simulations'
+      - './models:/app/models'
     links:
-      - mongodb
-    command: [ "trade", "--paper" ]
+      - mongodb1
     restart: always
     tty: true
     depends_on:
-      - mongodb
+      - mongodb1
     environment:
-      - MONGODB_PORT_27017_TCP_ADDR=mongodb
-
-  mongodb:
-    image: mongo:latest
-    volumes:
-      - ./data/db:/data/db
-    command: mongod --smallfiles --bind_ip=0.0.0.0 --logpath=/dev/null
+      - MONGODB_PORT_27017_TCP_ADDR=mongodb1
+    entrypoint: /usr/local/bin/node
     ports:
-      - 27017:27017
-
-  # Remove below comments to use this container. "adminMongo is a Web based user interface (GUI) to handle all your MongoDB connections/databases needs."
-  #
-  #adminmongo:
-  #  image: mrvautin/adminmongo
-  #  links:
-  #    - mongodb
-  #  tty: true
-  #  ports:
-  #    - "1234:1234"
-  #  environment:
-  #    - CONN_NAME=zenbot_mongodb
-  #    - DB_HOST=mongodb
-  #    - DB_PORT=27017
-  #  command: "npm start"
+      # added 8080 mapped to 80 for my own usage (defined port on conf.js), remove if you want or update your conf.js to show results on port 80 instead of a random port
+      - '8080:80'
+  mongodb1:
+    #Using tutum mongodb because it allows to easily set user&password directly from docker-compose
+    image: tutum/mongodb
+    volumes:
+      - './data:/data'
+    ports:
+      - '27017:27017'
+    environment:
+      - MONGODB_USER = YOUR-OWN-DATA # FAKE DATA JUST FOR COMMIT PURPOSES, DONT USE ("") just write them like - ENV = mydata
+      - MONGODB_PASS = YOUR-OWN-DATA # FAKE DATA JUST FOR COMMIT PURPOSES, DONT USE ("") just write them like - ENV = mydata
+      - MONGODB_DATABASE = YOUR-OWN-DATA # FAKE DATA JUST FOR COMMIT PURPOSES, DONT USE ("") just write them like - ENV = mydata
+  adminmongo:
+    image: mrvautin/adminmongo
+    ports:
+      - '1234:1234'


### PR DESCRIPTION
- Previous configuration returned a lot of errors when using docker.
- Added comments on docker-compose.
- Removed entrypoint/command from Dockerfile, it caused an error, and it was not worth it.
- Switched to tutum/mongodb instead of official mongodb because it allows to set user&password from docker-compose instead of going to the command line
- Added adminmongo to visualize the db related things
- Added support for authMechanism (db related) and modified conf-sample.js to support that change (previous configuration led to an error while connecting to the database if someone did not use the connectionString but used the parameters listed in conf-sample)