### PR TITLE
Edit max_sell/buy_loss_pct defaults in conf-sample.js

### DIFF
--- a/conf-sample.js
+++ b/conf-sample.js
@@ -129,9 +129,9 @@ c.sell_pct = 99
 // ms to adjust non-filled order after
 c.order_adjust_time = 5000
 // avoid selling at a loss below this pct set to 0 to ensure selling at a higher price...
-c.max_sell_loss_pct = 25
+c.max_sell_loss_pct = 99
 // avoid buying at a loss above this pct set to 0 to ensure buying at a lower price...
-c.max_buy_loss_pct = 25
+c.max_buy_loss_pct = 99
 // ms to poll order status
 c.order_poll_time = 5000
 // ms to wait for settlement (after an order cancel)


### PR DESCRIPTION
* Changed default c.max_sell_loss_pct and c.max_buy_loss_pct to 99. With a value of 25, once the current price is 25% under the bought price the bot would refuse to sell unless the current price goes back above the 25% loss, however, this doesn't always happen and can cause the bot to refuse sells and end up with a huge loss. Also the descriptions for these options are very vague and confusing and I don't think most users know what they even are or would want them to use them. If my interpretation of what the option actually does is incorrect let me know.