### PR TITLE
Replaced fs.existsSync(Deprecated) with fs.accessSync

### DIFF
--- a/lib/backtester.js
+++ b/lib/backtester.js
@@ -39,7 +39,7 @@ let processOutput = function (output, taskStrategyName, pheno) {
   // but if no file is found it will fall back to the older metheod of scraping the output of the sim process
   // stdio scraping to be removed after full verification of functionality.
   // todo: see above comment
-  if (fs.existsSync(tFileName)) {
+  if (fs.accessSync(tFileName)) {
     let jsonBuffer
     jsonBuffer = fs.readFileSync(tFileName, { encoding: 'utf8' })
     simulationResults = JSON.parse(jsonBuffer)
@@ -188,7 +188,7 @@ let runUpdate = function (days, selector) {
 
 let ensureDirectoryExistence = function (filePath) {
   var dirname = path.dirname(filePath)
-  if (fs.existsSync(dirname)) {
+  if (fs.accessSync(dirname)) {
     return true
   }
   ensureDirectoryExistence(dirname)


### PR DESCRIPTION
https://iojs.org/api/fs.html#fs_fs_existssync_path

fs.existsSync(path)
Stability: 0 - Deprecated: Use fs.statSync or fs.accessSync instead.