### PR TITLE
Add minimum trades and fitnessCalcType options

### DIFF
--- a/commands/sim.js
+++ b/commands/sim.js
@@ -158,6 +158,10 @@ module.exports = function (program, conf) {
           output_lines.push('error rate: ' + (sells ? n(losses).divide(sells).format('0.00%') : '0.00%').yellow)
         }
         options_output.simresults.start_capital = s.start_capital
+        options_output.simresults.last_buy_price = s.last_buy_price
+        options_output.simresults.last_assest_value = s.trades[s.trades.length-1].price
+        options_output.net_currency = s.net_currency
+        options_output.simresults.asset_capital = s.asset_capital
         options_output.simresults.currency = n(s.balance.currency).value()
         options_output.simresults.profit = profit.value()
         options_output.simresults.buy_hold = buy_hold.value()

--- a/lib/backtester.js
+++ b/lib/backtester.js
@@ -24,6 +24,11 @@ let processOutput = function (output, taskStrategyName, pheno) {
 
   let outputArray
   let params
+  let assetPriceLastBuy
+  let lastAssestValue
+  let assetCapital
+  let profit
+  let startCapital
   let endBalance
   let buyHold
   let vsBuyHold
@@ -63,6 +68,13 @@ let processOutput = function (output, taskStrategyName, pheno) {
   if (typeof (simulationResults) === 'object' && typeof simulationResults.simresults !== typeof undefined) {
     params = simulationResults
     endBalance = simulationResults.simresults.currency
+    assetPriceLastBuy = simulationResults.simresults.last_buy_price
+    lastAssestValue = simulationResults.simresults.last_assest_value
+    assetCapital = simulationResults.simresults.asset_capital
+    startCapital = simulationResults.simresults.start_capital
+    profit = simulationResults.simresults.profit
+
+
     buyHold = simulationResults.simresults.buy_hold
     vsBuyHold = simulationResults.simresults.vs_buy_hold
     //wlMatch = (simulationResults.simresults.total_sells - simulationResults.simresults.total_losses) +'/'+ simulationResults.simresults.total_losses
@@ -75,6 +87,7 @@ let processOutput = function (output, taskStrategyName, pheno) {
   }
   else {
     console.log(`Couldn't find simulationResults for ${pheno.backtester_generation}`)
+    console.log(pheno.command.commandString)
     // this should return a general bad result but not throw an error
     // our job here is to use the result.  not diagnose an error at this point so a failing sim should just be ignored.
     // idea here is to make the fitness of this calculation as bad as possible so darwin won't use the combonation of parameters again.
@@ -84,6 +97,8 @@ let processOutput = function (output, taskStrategyName, pheno) {
       endBalance: 0,
       buyHold: 0,
       vsBuyHold: 0,
+      lastAssestValue: 0,
+      assetPriceLastBuy:0,
       wins: 0,
       losses: -1,
       errorRate: 100,
@@ -97,7 +112,11 @@ let processOutput = function (output, taskStrategyName, pheno) {
       roi: -1000,
       selector: selector,
       strategy: taskStrategyName,
-      frequency: 0
+      frequency: 0,
+      assetCapital:0,
+      startCapital:0,
+      profit:0
+
     }
   }
 
@@ -132,6 +151,15 @@ let processOutput = function (output, taskStrategyName, pheno) {
   delete r.use_strategies
   delete r.verbose
   delete r.simresults
+  delete r.silent
+  delete r.generateLaunch
+  delete r.ignoreLaunchFitness
+  delete r.maxCores
+  delete r.minTrades
+  delete r.noStatSave
+  delete r.filename
+  //delete r.fitnessCalcType
+   
   r.selector = r.selector.normalized
 
   if (start) {
@@ -150,6 +178,11 @@ let processOutput = function (output, taskStrategyName, pheno) {
 
   let results = {
     params: 'module.exports = ' + JSON.stringify(r),
+    assetPriceLastBuy: assetPriceLastBuy,
+    lastAssestValue: lastAssestValue,
+    profit: profit,
+    assetCapital: assetCapital,
+    startCapital: startCapital,
     endBalance: parseFloat(endBalance),
     buyHold: parseFloat(buyHold),
     vsBuyHold: parseFloat(vsBuyHold) || vsBuyHold,

--- a/lib/phenotype.js
+++ b/lib/phenotype.js
@@ -4,8 +4,10 @@
  * 07/01/2017
  */
 
-let PROPERTY_MUTATION_CHANCE = 0.30
-let PROPERTY_CROSSOVER_CHANCE = 0.50
+let PROPERTY_RANDOM_CHANCE = 0.30 // Chance of a Mutation to spawn a new species -- Try and prevent some stagnation
+let PROPERTY_MUTATION_CHANCE = 0.30 // Chance of a Mutation in an aspect of the species
+let PROPERTY_CROSSOVER_CHANCE = 0.50 // Chance of a aspect being inherited by another species
+
 
 module.exports = {
   create: function(strategy) {
@@ -73,11 +75,13 @@ module.exports = {
 
   mutation: function(oldPhenotype, strategy) {
     var r = module.exports.create(strategy)
-    for (var k in oldPhenotype) {
-      if (k === 'sim') continue
+    if(Math.random() > PROPERTY_RANDOM_CHANCE) {
+      for (var k in oldPhenotype) {
+        if (k === 'sim') continue
 
-      var v = oldPhenotype[k]
-      r[k] = (Math.random() < PROPERTY_MUTATION_CHANCE) ? r[k] : v
+        var v = oldPhenotype[k]
+        r[k] = (Math.random() < PROPERTY_MUTATION_CHANCE) ? r[k] : v
+      }
     }
     return r
   },
@@ -88,9 +92,11 @@ module.exports = {
 
     for (var k in strategy) {
       if (k === 'sim') continue
+      if (k === 'minTrades') continue
+      if (k === 'fitnessCalcType') continue
 
-      p1[k] = Math.random() >= PROPERTY_CROSSOVER_CHANCE ? phenotypeA[k] : phenotypeB[k]
-      p2[k] = Math.random() >= PROPERTY_CROSSOVER_CHANCE ? phenotypeA[k] : phenotypeB[k]
+      p1[k] = Math.random() <= PROPERTY_CROSSOVER_CHANCE ? phenotypeA[k] : phenotypeB[k]
+      p2[k] = Math.random() <= PROPERTY_CROSSOVER_CHANCE ? phenotypeA[k] : phenotypeB[k]
     }
 
     return [p1, p2]
@@ -98,16 +104,78 @@ module.exports = {
 
   fitness: function(phenotype) {
     if (typeof phenotype.sim === 'undefined') return 0
+    let rate = 0
+    if (phenotype.fitnessCalcType == 'profitwl')
+    {
+      let profit = phenotype.sim.profit + (phenotype.sim.assetCapital * phenotype.sim.lastAssestValue)
+      // if minTrades is set use an alternate fitness calculation to hone in on a trade stratagy that has the minimum trade count
+      // once found use the normal fitness strsategy to find the best parameters.
+      if (phenotype.minTrades > 0) 
+      {
+        if (phenotype.sim.wins < phenotype.minTrades && phenotype.sim.wins == 0) return 0.0
+        if (phenotype.sim.wins < phenotype.minTrades) return ((phenotype.sim.wins/phenotype.minTrades)+profit)/100
+      }
+      let wlRatio = phenotype.sim.wins / phenotype.sim.losses
+      if (isNaN(wlRatio)) { // zero trades will result in 0/0 which is NaN
+        wlRatio = 0
+      }
+      let wlRatioRate = 1.0 / (1.0 + Math.pow(Math.E,-wlRatio))
+      rate = (profit * wlRatioRate )
 
-    var vsBuyHoldRate = ((phenotype.sim.vsBuyHold + 100) / 50)
-    var wlRatio = phenotype.sim.wins / phenotype.sim.losses
-    if (isNaN(wlRatio)) { // zero trades will result in 0/0 which is NaN
-      wlRatio = 1
     }
-    var wlRatioRate = 1.0 / (1.0 + Math.pow(Math.E, -wlRatio))
-    var rate = vsBuyHoldRate * wlRatioRate
+    else  if (phenotype.fitnessCalcType == 'profit')
+    {
+      //let profit = phenotype.sim.profit
+      let profit = phenotype.sim.profit + (phenotype.sim.assetCapital * phenotype.sim.lastAssestValue)
+      // if minTrades is set use an alternate fitness calculation to hone in on a trade stratagy that has the minimum trade count
+      // once found use the normal fitness strsategy to find the best parameters.
+      if (phenotype.minTrades > 0) 
+      {
+        if (phenotype.sim.wins < phenotype.minTrades && phenotype.sim.wins == 0) return 0.0
+        if (phenotype.sim.wins < phenotype.minTrades) return ((phenotype.minTrades)+profit)/1000
+      }
+
+      rate = profit
+    }  
+    if (phenotype.fitnessCalcType == 'wl')
+    {
+      //let vsBuyHoldRate = phenotype.sim.profit 
+      // if minTrades is set use an alternate fitness calculation to hone in on a trade stratagy that has the minimum trade count
+      // once found use the normal fitness strsategy to find the best parameters.
+      if (phenotype.minTrades > 0) 
+      {
+        if (phenotype.sim.wins < phenotype.minTrades && phenotype.sim.wins == 0) return 0.0
+        if (phenotype.sim.wins < phenotype.minTrades) return (phenotype.sim.wins/phenotype.minTrades)/100
+      }
+      let wlRatio = phenotype.sim.wins / phenotype.sim.losses
+      if (isNaN(wlRatio)) { // zero trades will result in 0/0 which is NaN
+        wlRatio = 0
+      }
+      let wlRatioRate = 1.0 / (1.0 + Math.pow(Math.E,-wlRatio))
+      rate = ( wlRatioRate )
+    }
+    else
+    {
+
+      let vsBuyHoldRate = ((phenotype.sim.vsBuyHold + 100) / 50)
+      if (phenotype.minTrades > 0) 
+      {
+        if (phenotype.sim.wins < phenotype.minTrades && phenotype.sim.wins == 0) return 0.0
+        if (phenotype.sim.wins < phenotype.minTrades) return ((phenotype.sim.wins/phenotype.minTrades)+vsBuyHoldRate)/100
+      }
+      let wlRatio = phenotype.sim.wins / phenotype.sim.losses
+      if (isNaN(wlRatio)) { // zero trades will result in 0/0 which is NaN
+        wlRatio = 1
+      }
+      let wlRatioRate = 1.0 / (1.0 + Math.pow(Math.E, -wlRatio))
+      rate = vsBuyHoldRate * wlRatioRate
+   
+    }
+
     return rate
+    
   },
+  
 
   competition: function(phenotypeA, phenotypeB) {
     // TODO: Refer to geneticalgorithm documentation on how to improve this with diverstiy

--- a/scripts/genetic_backtester/darwin.js
+++ b/scripts/genetic_backtester/darwin.js
@@ -20,6 +20,8 @@
  * --noStatSave=<true>|<false>            true:no statistics are saved to the simulation folder
  * --silent=<true>|<false>                true:can improve performance
  * --runGenerations=<int>                 if used run this number of generations, will be shown 1 less due to generations starts at 0
+ * --minTrades=<int>                      Minimum wins before generation is considured fit to evolve
+ * --fitnessCalcType=<wl / profit / classic / profitwl> Default: Classic. wl will score the highes for wins and losses, profit doesn't care about wins and losses only the higest end balance, classic uses original claculation / profitwl tries to get the highest profit using the lowest win/loss ratio
  *
  *
  * any parameters for sim and or strategy can be passed in and will override the genetic test generated parameter
@@ -40,7 +42,7 @@ let Backtester = require('../../lib/backtester')
 let argv = require('yargs').argv
 let z = require('zero-fill')
 let n = require('numbro')
-let _ = require('lodash')
+
 
 let VERSION = 'Zenbot 4 Genetic Backtester v0.2.3'
 
@@ -57,8 +59,10 @@ let runGenerations = undefined
 let generationProcessing = false
 let population_data = ''
 let noStatSave = false
-let floatScanWindow = false
+//let floatScanWindow = false
 let ignoreLaunchFitness = false
+let minimumTrades = 0
+let fitnessCalcType = 'classic'
 
 let readSimDataFile = (iteration) => {
   let jsonFileName = `simulations/${population_data}/gen_${generationCount}/sim_${iteration}.json`
@@ -258,6 +262,8 @@ function simulateGeneration(generateLaunchFile) {
       }
 
       iterationCount++
+      phenotype.minTrades = minimumTrades
+      phenotype.fitnessCalcType = fitnessCalcType
       Backtester.runCommand(v, phenotype, command, cb)
     }
   })).reduce((a, b) => a.concat(b))
@@ -325,9 +331,9 @@ function simulateGeneration(generateLaunchFile) {
           (a.fitness < b.fitness) ? 1 :
             (b.fitness < a.fitness) ? -1 : 0)
 
-    let bestOverallCommand = generateCommandParams(bestOverallResult[0])
-    bestOverallCommand = prefix + bestOverallCommand
-    bestOverallCommand = bestOverallCommand + ' --asset_capital=' + argv.asset_capital + ' --currency_capital=' + argv.currency_capital
+    // let bestOverallCommand = generateCommandParams(bestOverallResult[0])
+    // bestOverallCommand = prefix + bestOverallCommand
+    // bestOverallCommand = bestOverallCommand + ' --asset_capital=' + argv.asset_capital + ' --currency_capital=' + argv.currency_capital
 
     saveLaunchFiles(generateLaunchFile, bestOverallResult[0])
 
@@ -371,6 +377,7 @@ if (simArgs.help || !(simArgs.use_strategies)) {
   console.log('--days=<int>  amount of days to use when backfilling')
   console.log('--noStatSave=<true>|<false>')
   console.log('--runGenerations=<int>  if used run this number of generations, will be shown 1 less due to generations starts at 0')
+  console.log('--minTrades=<int>  Minimum wins before generation is considured fit to evolve')
   process.exit(0)
 }
 
@@ -384,6 +391,17 @@ if (simArgs.maxCores) {
   if (simArgs.maxCores < 1) PARALLEL_LIMIT = 1
   else PARALLEL_LIMIT = simArgs.maxCores
 }
+fitnessCalcType = 'classic'
+if (simArgs.fitnessCalcType) {
+
+  if (simArgs.fitnessCalcType == 'classic') fitnessCalcType = 'classic'
+  if (simArgs.fitnessCalcType == 'wl') fitnessCalcType = 'wl'
+  if (simArgs.fitnessCalcType == 'profit') fitnessCalcType = 'profit'
+  if (simArgs.fitnessCalcType == 'profitwl') fitnessCalcType = 'profitwl'
+
+
+}
+
 
 if (!isUndefined(simArgs.runGenerations)) {
   if (simArgs.runGenerations) {
@@ -396,7 +414,8 @@ noStatSave = (simArgs.noStatSave) ? true : false
 
 let strategyName = (argv.use_strategies) ? argv.use_strategies : 'all'
 populationSize = (argv.population) ? argv.population : 100
-floatScanWindow = (argv.floatScanWindow) ? argv.floatScanWindow : false
+minimumTrades = (argv.minTrades) ? argv.minTrades : 0
+//floatScanWindow = (argv.floatScanWindow) ? argv.floatScanWindow : false
 ignoreLaunchFitness = (argv.ignoreLaunchFitness) ? argv.ignoreLaunchFitness : false
 
 population_data = argv.population_data || `backtest.${simArgs.selector.toLowerCase()}.${moment().format('YYYYMMDDHHmmss')}`
@@ -419,7 +438,8 @@ for (var i = 0; i < selectedStrategies.length; i++) {
     let population = []
 
     for (var i2 = population.length; i2 < populationSize; ++i2) {
-      population.push(Phenotypes.create(strategyPhenotypes))
+      var lPheno = Phenotypes.create(strategyPhenotypes)
+      population.push(lPheno)
       evolve = false
     }
 


### PR DESCRIPTION
--minTrades will try and achieve the minimum x amount of trades before using normal fitness calculations
--fitnessCalcType allows for different fitness priorities.  i.e. profit does not care how many wins or losses occur.  it only looks at how much of a return is occurring.   wl does not care about profit, only more wins than losses, profitwl tries to get the best profit, while taking into consideration wins and losses, but rates profit higher.  classic uses the legacy calculation and is the default.

Addition modifications
Add PROPERTY_RANDOM_CHANCE to phenotype process to allow for injection of entirely new species. this helps prevent stagnation during a long run.

At some point floatScanWindow was removed from backtester.  Commented out code in darwin.js that applies to this change
