### PR TITLE
Workaround for issue #1629

### DIFF
--- a/extensions/strategies/Ichimoku_Score/strategy.js
+++ b/extensions/strategies/Ichimoku_Score/strategy.js
@@ -31,6 +31,7 @@ let z = require('zero-fill')
   , Phenotypes = require('../../../lib/phenotype')
   , crossover = require('../../../lib/helpers').crossover
   , crossunder = require('../../../lib/helpers').crossunder
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'ichimoku_score',
@@ -117,7 +118,7 @@ module.exports = {
   onPeriod: function (s, cb) {
 
 
-   //    == Debugging ==
+    //    == Debugging ==
 
     if (s.options.debug) {console.log('\n== Options ==')}
 
@@ -167,10 +168,12 @@ module.exports = {
     if (!s.previousScore) {s.previousScore = 0}
 
     if (s.normalizedScore > s.options.buyLevel && s.previousScore < s.options.buyLevel) {
-      s.signal = 'buy'
+      if (dupOrderWorkAround.checkForPriorBuy(s)) 
+        s.signal = 'buy'
       s.previousScore = s.normalizedScore
     } else if (s.normalizedScore < s.options.sellLevel && s.previousScore > s.options.sellLevel) {
-      s.signal = 'sell'
+      if (dupOrderWorkAround.checkForPriorSell(s)) 
+        s.signal = 'sell'
       s.previousScore = s.normalizedScore
     } else {
       s.signal = null
@@ -271,7 +274,7 @@ function valueAboveKumo(s, val, key1, key2) {
 }
 
 function valueAbove(val, target1, target2) {
-    return val > Math.max(target1, target2)
+  return val > Math.max(target1, target2)
 }
 
 function valueBelow(val, target1, target2) {

--- a/extensions/strategies/bollinger/strategy.js
+++ b/extensions/strategies/bollinger/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , bollinger = require('../../../lib/bollinger')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'bollinger',
@@ -27,9 +28,11 @@ module.exports = {
         let upperBound = s.period.bollinger.upper[s.period.bollinger.upper.length-1]
         let lowerBound = s.period.bollinger.lower[s.period.bollinger.lower.length-1]
         if (s.period.close > (upperBound / 100) * (100 - s.options.bollinger_upper_bound_pct)) {
-          s.signal = 'sell'
+          if (dupOrderWorkAround.checkForPriorSell(s)) 
+            s.signal = 'sell'
         } else if (s.period.close < (lowerBound / 100) * (100 + s.options.bollinger_lower_bound_pct)) {
-          s.signal = 'buy'
+          if (dupOrderWorkAround.checkForPriorBuy(s))
+            s.signal = 'buy'
         } else {
           s.signal = null // hold
         }

--- a/extensions/strategies/cci_srsi/strategy.js
+++ b/extensions/strategies/cci_srsi/strategy.js
@@ -4,6 +4,7 @@ let z = require('zero-fill')
   , srsi = require('../../../lib/srsi')
   , cci = require('../../../lib/cci')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'cci_srsi',
@@ -57,13 +58,15 @@ module.exports = {
         // Buy signal
         if (s.period.cci <= s.options.oversold_cci && /*s.period.srsi_K > s.period.srsi_D &&*/ s.period.srsi_K <= s.options.oversold_rsi) {
           if (!s.cci_fromAbove && !s.rsi_fromAbove) {
-            s.signal = 'buy'
+            if (dupOrderWorkAround.checkForPriorBuy(s)) 
+              s.signal = 'buy'
           }
         }
         // Sell signal
         if (s.period.cci >= s.options.overbought_cci && /*s.period.srsi_K < s.period.srsi_D &&*/ s.period.srsi_K >= s.options.overbought_rsi) {
           if (s.cci_fromAbove || s.rsi_fromAbove) {
-            s.signal = 'sell'
+            if (dupOrderWorkAround.checkForPriorSell(s)) 
+              s.signal = 'sell'
           }
         }
         //cb()
@@ -72,7 +75,8 @@ module.exports = {
       if (s.trend === 'up') {
         if (s.period.cci <= s.options.oversold_cci && /*s.period.srsi_K > s.period.srsi_D &&*/ s.period.srsi_K <= s.options.oversold_rsi) {
           if (!s.cci_fromAbove && !s.rsi_fromAbove) {
-            s.signal = 'buy'
+            if (dupOrderWorkAround.checkForPriorBuy(s)) 
+              s.signal = 'buy'
           }
         }
       }
@@ -80,7 +84,8 @@ module.exports = {
       if (s.trend === 'down') {
         if (s.period.cci >= s.options.overbought_cci && /*s.period.srsi_K < s.period.srsi_D &&*/ s.period.srsi_K >= s.options.overbought_rsi) {
           if (s.cci_fromAbove || s.rsi_fromAbove) {
-            s.signal = 'sell'
+            if (dupOrderWorkAround.checkForPriorSell(s)) 
+              s.signal = 'sell'
           }
         }
       }

--- a/extensions/strategies/crossover_vwap/strategy.js
+++ b/extensions/strategies/crossover_vwap/strategy.js
@@ -4,6 +4,7 @@ var z = require('zero-fill')
   , ema = require('../../../lib/ema')
   , sma = require('../../../lib/sma')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'crossover_vwap',
@@ -50,14 +51,14 @@ module.exports = {
           s.acted_on_trend = false
         }
         s.trend = 'up'
-        s.signal = !s.acted_on_trend ? 'buy' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorBuy(s) ? 'buy' : null : null
       },
       trendDown = function(s){
         if (s.trend !== 'down') {
           s.acted_on_trend = false
         }
         s.trend = 'down'
-        s.signal = !s.acted_on_trend ? 'sell' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorSell(s) ? 'sell' : null : null
       }
 
     if(emagreen && smared && smapurple && s.period.vwap){

--- a/extensions/strategies/dema/strategy.js
+++ b/extensions/strategies/dema/strategy.js
@@ -3,6 +3,7 @@ var z = require('zero-fill')
   , rsi = require('../../../lib/rsi')
   , ema = require('../../../lib/ema')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'dema',
@@ -53,9 +54,15 @@ module.exports = {
       if (s.options.noise_level_pct != 0 && (s.period.ema_short / s.lookback[0].ema_short * 100 < s.options.noise_level_pct)) {
         s.signal = null
       } else if ((s.period.dema_histogram - s.options.up_trend_threshold) > 0 && (s.lookback[0].dema_histogram - s.options.up_trend_threshold) <= 0) {
-        s.signal = 'buy'
+        { 
+          if (dupOrderWorkAround.checkForPriorBuy(s))
+            s.signal = 'buy'
+        }
       } else if ((s.period.dema_histogram + s.options.down_trend_threshold) < 0 && (s.lookback[0].dema_histogram + s.options.down_trend_threshold) >= 0) {
-        s.signal = 'sell'
+        { 
+          if (dupOrderWorkAround.checkForPriorSell(s))
+            s.signal = 'sell'
+        }
       } else {
         s.signal = null  // hold
       }

--- a/extensions/strategies/ehlers_ft/strategy.js
+++ b/extensions/strategies/ehlers_ft/strategy.js
@@ -37,7 +37,8 @@ https://discordapp.com/channels/316120967200112642/383023593942155274
 const z = require('zero-fill'),
   n = require('numbro'),
   Phenotypes = require('../../../lib/phenotype'),
-  tv = require('../../../lib/helpers')
+  tv = require('../../../lib/helpers'),
+  dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'ehlers_fisher_transform',
@@ -83,9 +84,11 @@ module.exports = {
     if (!s.in_preroll) {
       if (s.options.pos_length === 1) {
         if (s.eft.pos[0] === 1) {
-          s.signal = 'buy'
+          if (dupOrderWorkAround.checkForPriorBuy(s)) 
+            s.signal = 'buy'
         } else if (s.eft.pos[0] === -1) {
-          s.signal = 'sell'
+          if (dupOrderWorkAround.checkForPriorSell(s))
+            s.signal = 'sell'
         } else {
           s.signal = null
         }
@@ -96,9 +99,11 @@ module.exports = {
           posDn = s.eft.pos[0] === 1 && pos.every(pos => pos === -1)
 
         if (posUp) {
-          s.signal = 'buy'
+          if (dupOrderWorkAround.checkForPriorBuy(s)) 
+            s.signal = 'buy'
         } else if (posDn) {
-          s.signal = 'sell'
+          if (dupOrderWorkAround.checkForPriorSell(s))
+            s.signal = 'sell'
         } else
           s.signal = null
       }

--- a/extensions/strategies/ehlers_mama/strategy.js
+++ b/extensions/strategies/ehlers_mama/strategy.js
@@ -30,7 +30,8 @@ let z = require('zero-fill'),
   crossunder = require('../../../lib/helpers').crossunder,
   nz = require('../../../lib/helpers').nz,
   iff = require('../../../lib/helpers').iff,
-  tv = require('../../../lib/helpers')
+  tv = require('../../../lib/helpers'),
+  dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'Ehlers MAMA',
@@ -126,9 +127,15 @@ module.exports = {
       if (!s.in_preroll) {
         
         if (crossover(s, 'mama', 'fama'))
-          s.signal = 'buy'
+        {
+          if (dupOrderWorkAround.checkForPriorBuy(s)) 
+            s.signal = 'buy'
+        }
         else if (crossunder(s, 'mama', 'fama'))
-          s.signal = 'sell'
+        {
+          if (dupOrderWorkAround.checkForPriorSell(s))
+            s.signal = 'sell'
+        }
         else 
           s.signal = null
       }

--- a/extensions/strategies/ehlers_trend/strategy.js
+++ b/extensions/strategies/ehlers_trend/strategy.js
@@ -5,6 +5,7 @@ let z = require('zero-fill')
   , crossunder = require('../../../lib/helpers').crossunder
   , nz = require('../../../lib/helpers').nz
   , tv = require('../../../lib/helpers')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'Ehlers_Trend',
@@ -49,9 +50,15 @@ module.exports = {
 
 
     if(crossover(s, 'trend', 'trigger'))
-      s.signal = 'sell'
+    {
+      if (dupOrderWorkAround.checkForPriorSell(s))
+        s.signal = 'sell'
+    }
     else if(crossunder(s, 'trend', 'trigger'))
-      s.signal = 'buy'
+    {
+      if (dupOrderWorkAround.checkForPriorBuy(s)) 
+        s.signal = 'buy'
+    }
     else
       s.signal = null
 

--- a/extensions/strategies/forex_analytics/strategy.js
+++ b/extensions/strategies/forex_analytics/strategy.js
@@ -1,6 +1,7 @@
 var fs = require('fs')
   , path = require('path')
   , analytics = require('forex.analytics')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 var model
 module.exports =  {
@@ -69,9 +70,15 @@ module.exports =  {
 
       var result = analytics.getMarketStatus(candlesticks, {'strategy': model.strategy})
       if (result.shouldSell) {
-        s.signal = 'sell'
+        {
+          if (dupOrderWorkAround.checkForPriorSell(s)) 
+            s.signal = 'sell'
+        }
       } else if (result.shouldBuy) {
-        s.signal = 'buy'
+        {
+          if (dupOrderWorkAround.checkForPriorBuy(s))
+            s.signal = 'buy'
+        }
       }
     }
 

--- a/extensions/strategies/ichimoku/strategy.js
+++ b/extensions/strategies/ichimoku/strategy.js
@@ -1,8 +1,8 @@
-var z = require('zero-fill'),
-n = require('numbro'),
-highest = require('../../../lib/highest'),
-lowest = require('../../../lib/lowest'),
-Phenotypes = require('../../../lib/phenotype')
+var 
+  highest = require('../../../lib/highest'),
+  lowest = require('../../../lib/lowest'),
+  Phenotypes = require('../../../lib/phenotype'),
+  dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'ichimoku',
@@ -17,7 +17,7 @@ module.exports = {
     this.option('chikou','Chikou (lagging) span)', Number, 26)
   },
 
-  calculate: function (s) {
+  calculate: function () {
   },
 
   onPeriod: function (s, cb) {
@@ -44,20 +44,20 @@ module.exports = {
           s.acted_on_trend = false
         }
         s.trend = 'up'
-        s.signal = !s.acted_on_trend ? 'buy' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorBuy(s) ? 'buy' : null : null
       }
       if (s.period.close < Math.max(s.period.senkou_a, s.period.senkou_b)) {
         if (s.trend !== 'down') {
           s.acted_on_trend = false
         }
         s.trend = 'down'
-        s.signal = !s.acted_on_trend ? 'sell' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorSell(s) ? 'sell' : null : null
       }
     }
     cb()
   },
 
-  onReport: function (s) {
+  onReport: function () {
     var cols = []
     return cols
   },

--- a/extensions/strategies/ichimoku_score/strategy.js
+++ b/extensions/strategies/ichimoku_score/strategy.js
@@ -31,6 +31,7 @@ let z = require('zero-fill')
   , Phenotypes = require('../../../lib/phenotype')
   , crossover = require('../../../lib/helpers').crossover
   , crossunder = require('../../../lib/helpers').crossunder
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'ichimoku_score',
@@ -117,7 +118,7 @@ module.exports = {
   onPeriod: function (s, cb) {
 
 
-   //    == Debugging ==
+    //    == Debugging ==
 
     if (s.options.debug) {console.log('\n== Options ==')}
 
@@ -167,10 +168,12 @@ module.exports = {
     if (!s.previousScore) {s.previousScore = 0}
 
     if (s.normalizedScore > s.options.buyLevel && s.previousScore < s.options.buyLevel) {
-      s.signal = 'buy'
+      if (dupOrderWorkAround.checkForPriorBuy(s)) 
+        s.signal = 'buy'
       s.previousScore = s.normalizedScore
     } else if (s.normalizedScore < s.options.sellLevel && s.previousScore > s.options.sellLevel) {
-      s.signal = 'sell'
+      if (dupOrderWorkAround.checkForPriorSell(s))
+        s.signal = 'sell'
       s.previousScore = s.normalizedScore
     } else {
       s.signal = null
@@ -271,7 +274,7 @@ function valueAboveKumo(s, val, key1, key2) {
 }
 
 function valueAbove(val, target1, target2) {
-    return val > Math.max(target1, target2)
+  return val > Math.max(target1, target2)
 }
 
 function valueBelow(val, target1, target2) {

--- a/extensions/strategies/kc/strategy.js
+++ b/extensions/strategies/kc/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , kc = require('../../../lib/kc')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'kc',
@@ -27,9 +28,11 @@ module.exports = {
         let upperChannel = s.period.kc.upper[s.period.kc.upper.length-1]
         let lowerChannel = s.period.kc.lower[s.period.kc.lower.length-1]
         if (s.period.close > (upperChannel / 100) * (100 - s.options.kc_upper_channel_pct)) {  
-          s.signal = 'sell'
+          if (dupOrderWorkAround.checkForPriorSell(s))
+            s.signal = 'sell'
         } else if (s.period.close < (lowerChannel / 100) * (100 + s.options.kc_lower_channel_pct)) {
-          s.signal = 'buy'
+          if (dupOrderWorkAround.checkForPriorBuy(s)) 
+            s.signal = 'buy'
         } else {
           s.signal = null // hold
         }

--- a/extensions/strategies/macd/strategy.js
+++ b/extensions/strategies/macd/strategy.js
@@ -3,6 +3,7 @@ var z = require('zero-fill')
   , ema = require('../../../lib/ema')
   , rsi = require('../../../lib/rsi')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'macd',
@@ -49,7 +50,8 @@ module.exports = {
       if (s.overbought) {
         s.overbought = false
         s.trend = 'overbought'
-        s.signal = 'sell'
+        if (dupOrderWorkAround.checkForPriorSell(s)) 
+          s.signal = 'sell'
         return cb()
       }
 
@@ -57,9 +59,11 @@ module.exports = {
 
     if (typeof s.period.macd_histogram === 'number' && typeof s.lookback[0].macd_histogram === 'number') {
       if ((s.period.macd_histogram - s.options.up_trend_threshold) > 0 && (s.lookback[0].macd_histogram - s.options.up_trend_threshold) <= 0) {
-        s.signal = 'buy'
+        if (dupOrderWorkAround.checkForPriorBuy(s)) 
+          s.signal = 'buy'
       } else if ((s.period.macd_histogram + s.options.down_trend_threshold) < 0 && (s.lookback[0].macd_histogram + s.options.down_trend_threshold) >= 0) {
-        s.signal = 'sell'
+        if (dupOrderWorkAround.checkForPriorSell(s))
+          s.signal = 'sell'
       } else {
         s.signal = null  // hold
       }

--- a/extensions/strategies/momentum/strategy.js
+++ b/extensions/strategies/momentum/strategy.js
@@ -2,6 +2,7 @@ let z = require('zero-fill')
   , n = require('numbro')
   , momentum = require('../../../lib/momentum')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'momentum',
@@ -24,10 +25,12 @@ module.exports = {
     }
 
     if (s.period.mom0 > 0 && s.period.mom1 > 0) {
-      s.signal = 'buy'
+      if (dupOrderWorkAround.checkForPriorBuy(s)) 
+        s.signal = 'buy'
     }
     if (s.period.mom0 < 0 && s.period.mom1 < 0) {
-      s.signal = 'sell'
+      if (dupOrderWorkAround.checkForPriorSell(s))
+        s.signal = 'sell'
     }
     cb()
   },

--- a/extensions/strategies/neural/strategy.js
+++ b/extensions/strategies/neural/strategy.js
@@ -3,6 +3,8 @@ let convnetjs = require('convnetjs')
   , n = require('numbro')
   , ema = require('../../../lib/ema')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
+
 const cluster = require('cluster')
 
 // the below line starts you at 0 threads
@@ -109,18 +111,16 @@ module.exports = {
       global.predi = s.prediction
       //something strange is going on here
       global.sig0 = global.predi > oldmean
-      if (
-        global.sig0 === false
-      )
+      if ( global.sig0 === false )
       {
-        s.signal = 'sell'
+        if (dupOrderWorkAround.checkForPriorSell(s)) 
+          s.signal = 'sell'
       }
       else if
-      (
-        global.sig0 === true
-      )
+      ( global.sig0 === true  )
       {
-        s.signal = 'buy'
+        if (dupOrderWorkAround.checkForPriorBuy(s)) 
+          s.signal = 'buy'
       }
       oldmean = global.predi
       cb()

--- a/extensions/strategies/sar/strategy.js
+++ b/extensions/strategies/sar/strategy.js
@@ -1,6 +1,7 @@
 var z = require('zero-fill')
   , n = require('numbro')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports =  {
   name: 'sar',
@@ -51,7 +52,8 @@ module.exports =  {
       if (s.trend === 'down') {
         if (s.period.high >= s.sar && s.period.close > s.lookback[0].close) {
           s.trend = 'up'
-          s.signal = 'buy'
+          if (dupOrderWorkAround.checkForPriorBuy(s)) 
+            s.signal = 'buy'
           s.sar_ep = s.period.low
           s.sar_af = s.options.sar_af
           s.sar = Math.min(s.lookback[0].low, s.period.low, s.sar + (s.sar_af * (s.sar_ep - s.sar)))
@@ -66,7 +68,8 @@ module.exports =  {
       else if (s.trend === 'up') {
         if (s.period.low <= s.sar && s.period.close < s.lookback[0].close) {
           s.trend = 'down'
-          s.signal = 'sell'
+          if (dupOrderWorkAround.checkForPriorSell(s)) 
+            s.signal = 'sell'
           s.sar_ep = s.period.high
           s.sar_af = s.options.sar_af
           s.sar = Math.max(s.lookback[0].high, s.period.high, s.sar - (s.sar_af * (s.sar - s.sar_ep)))
@@ -79,7 +82,7 @@ module.exports =  {
         }
       }
       if (!s.my_trades.length) {
-        s.signal = s.trend === 'up' ? 'buy' : 'sell'
+        s.signal = s.trend === 'up' ? dupOrderWorkAround.checkForPriorBuy(s) ? 'buy' : null : dupOrderWorkAround.checkForPriorSell(s) ? 'sell' : null
       }
     }
     cb()

--- a/extensions/strategies/speed/strategy.js
+++ b/extensions/strategies/speed/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , ema = require('../../../lib/ema')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'speed',
@@ -32,14 +33,14 @@ module.exports = {
           s.acted_on_trend = false
         }
         s.trend = 'up'
-        s.signal = !s.acted_on_trend ? 'buy' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorBuy(s) ? 'buy' : null : null
       }
       else if (s.period.speed <= s.period.baseline * s.options.trigger_factor * -1) {
         if (s.trend !== 'down') {
           s.acted_on_trend = false
         }
         s.trend = 'down'
-        s.signal = !s.acted_on_trend ? 'sell' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorSell(s) ? 'sell' : null : null
       }
     }
     cb()

--- a/extensions/strategies/srsi_macd/strategy.js
+++ b/extensions/strategies/srsi_macd/strategy.js
@@ -3,6 +3,7 @@ let z = require('zero-fill')
   , srsi = require('../../../lib/srsi')
   , ema = require('../../../lib/ema')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'srsi_macd',
@@ -47,12 +48,14 @@ module.exports = {
       // Buy signal
         if (s.period.macd_histogram >= s.options.up_trend_threshold)
           if (s.period.srsi_K > s.period.srsi_D && s.period.srsi_K > s.lookback[0].srsi_K && s.period.srsi_K < s.options.oversold_rsi)
-            s.signal = 'buy'
+            if (dupOrderWorkAround.checkForPriorBuy(s)) 
+              s.signal = 'buy'
 
     // Sell signal
     if (s.period.macd_histogram < s.options.down_trend_threshold)
       if (s.period.srsi_K < s.period.srsi_D && s.period.srsi_K < s.lookback[0].srsi_K && s.period.srsi_K > s.options.overbought_rsi)
-        s.signal = 'sell'
+        if (dupOrderWorkAround.checkForPriorSell(s)) 
+          s.signal = 'sell'
 
     // Hold
     //s.signal = null;

--- a/extensions/strategies/stddev/strategy.js
+++ b/extensions/strategies/stddev/strategy.js
@@ -3,6 +3,7 @@ var z = require('zero-fill')
   , math = require('mathjs')
   , ema = require('../../../lib/ema')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'stddev',
@@ -31,10 +32,12 @@ module.exports = {
       s.sig1 = s.mean0 > s.mean1 ? 'Up' : 'Down'
     }
     if (s.sig1 === 'Down') {
-      s.signal = 'sell'
+      if (dupOrderWorkAround.checkForPriorSell(s))
+        s.signal = 'sell'
     }
     else if (s.sig0 === 'Up' && s.sig1 === 'Up') {
-      s.signal = 'buy'
+      if (dupOrderWorkAround.checkForPriorBuy(s)) 
+        s.signal = 'buy'
     }
     cb()
   },

--- a/extensions/strategies/ta_ema/strategy.js
+++ b/extensions/strategies/ta_ema/strategy.js
@@ -4,6 +4,7 @@ var z = require('zero-fill')
   , rsi = require('../../../lib/rsi')
   , stddev = require('../../../lib/stddev')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'ta_ema',
@@ -67,7 +68,7 @@ module.exports = {
           s.acted_on_trend = false
         }
         s.trend = 'up'
-        s.signal = !s.acted_on_trend ? 'buy' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorBuy(s) ? 'buy' : null : null
         s.cancel_down = false
       }
       else if (!s.cancel_down && s.period.trend_ema_rate < (s.period.trend_ema_stddev * -1)) {
@@ -75,7 +76,7 @@ module.exports = {
           s.acted_on_trend = false
         }
         s.trend = 'down'
-        s.signal = !s.acted_on_trend ? 'sell' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorSell(s) ? 'sell' : null : null
       }
     }
     cb()

--- a/extensions/strategies/ta_macd/strategy.js
+++ b/extensions/strategies/ta_macd/strategy.js
@@ -3,6 +3,7 @@ var z = require('zero-fill')
   , rsi = require('../../../lib/rsi')
   , ta_macd = require('../../../lib/ta_macd')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'ta_macd',
@@ -55,9 +56,11 @@ module.exports = {
 
       if (typeof s.period.macd_histogram === 'number' && typeof s.lookback[0].macd_histogram === 'number') {
         if ((s.period.macd_histogram - s.options.up_trend_threshold) > 0 && (s.lookback[0].macd_histogram - s.options.up_trend_threshold) <= 0) {
-          s.signal = 'buy'
+          if (dupOrderWorkAround.checkForPriorBuy(s)) 
+            s.signal = 'buy'
         } else if ((s.period.macd_histogram + s.options.down_trend_threshold) < 0 && (s.lookback[0].macd_histogram + s.options.down_trend_threshold) >= 0) {
-          s.signal = 'sell'
+          if (dupOrderWorkAround.checkForPriorSell(s))
+            s.signal = 'sell'
         } else {
           s.signal = null  // hold
         }

--- a/extensions/strategies/ta_macd_ext/strategy.js
+++ b/extensions/strategies/ta_macd_ext/strategy.js
@@ -3,6 +3,7 @@ var z = require('zero-fill')
   , rsi = require('../../../lib/rsi')
   , ta_macd_ext = require('../../../lib/ta_macd_ext')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'ta_macd_ext',
@@ -85,9 +86,11 @@ module.exports = {
 
       if (typeof s.period.macd_histogram === 'number' && typeof s.lookback[0].macd_histogram === 'number') {
         if ((s.period.macd_histogram - s.options.up_trend_threshold) > 0 && (s.lookback[0].macd_histogram - s.options.up_trend_threshold) <= 0) {
-          s.signal = 'buy'
+          if (dupOrderWorkAround.checkForPriorBuy(s))
+            s.signal = 'buy'
         } else if ((s.period.macd_histogram + s.options.down_trend_threshold) < 0 && (s.lookback[0].macd_histogram + s.options.down_trend_threshold) >= 0) {
-          s.signal = 'sell'
+          if (dupOrderWorkAround.checkForPriorSell(s))
+            s.signal = 'sell'
         } else {
           s.signal = null  // hold
         }

--- a/extensions/strategies/ta_ppo/strategy.js
+++ b/extensions/strategies/ta_ppo/strategy.js
@@ -3,6 +3,7 @@ var z = require('zero-fill')
   , rsi = require('../../../lib/rsi')
   , ta_ppo = require('../../../lib/ta_ppo')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'ta_ppo',
@@ -56,14 +57,14 @@ module.exports = {
         }
 
         s.trend = 'up'
-        s.signal = !s.acted_on_trend ? 'buy' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorBuy(s) ? 'buy' : null : null
       } else if (s.period.trend_ppo == 'down') {
         if (s.trend !== 'down') {
           s.acted_on_trend = false
         }
 
         s.trend = 'down'
-        s.signal = !s.acted_on_trend ? 'sell' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorSell(s) ? 'sell' : null : null
       }
 
       cb()

--- a/extensions/strategies/ta_srsi_bollinger/strategy.js
+++ b/extensions/strategies/ta_srsi_bollinger/strategy.js
@@ -3,6 +3,7 @@ let z = require('zero-fill')
   , ta_srsi = require('../../../lib/ta_stochrsi')
   , ta_bollinger = require('../../../lib/ta_bollinger')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 module.exports = {
   name: 'srsi_bollinger',
   description: 'Stochastic RSI BollingerBand Strategy',
@@ -80,12 +81,14 @@ module.exports = {
             {
               if (s.period.close > ((upperBound / 100) * (100 - s.options.bollinger_upper_bound_pct))  && nextdivergent < divergent && _switch == -1 && s.period.srsi_K > s.options.srsi_k_sell) 
               {
-                s.signal = 'sell'
+                if (dupOrderWorkAround.checkForPriorSell(s)) 
+                  s.signal = 'sell'
               } 
               else
               if (s.period.close < ((lowerBound / 100) * (100 + s.options.bollinger_lower_bound_pct))   &&  nextdivergent >= divergent  && _switch == 1    && s.period.srsi_K < s.options.srsi_k_buy) 
               {
-                s.signal = 'buy'
+                if (dupOrderWorkAround.checkForPriorBuy(s)) 
+                  s.signal = 'buy'
               } 
              
             }

--- a/extensions/strategies/ta_stoch_bollinger/strategy.js
+++ b/extensions/strategies/ta_stoch_bollinger/strategy.js
@@ -3,6 +3,8 @@ let z = require('zero-fill')
   , ta_stoch = require('../../../lib/ta_stoch')
   , ta_bollinger = require('../../../lib/ta_bollinger')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
+
 module.exports = {
   name: 'ta_stoch_bollinger',
   description: 'Stochastic BollingerBand Strategy',
@@ -71,12 +73,14 @@ module.exports = {
             {
               if (s.period.close >= midBound && s.period.close >= ((upperBound / 100) * (100 +  s.options.bollinger_upper_bound_pct)) && nextdivergent < divergent && _switch == -1 && s.period.stoch_K > s.options.stoch_k_sell) 
               {
-                s.signal = 'sell'
+                if (dupOrderWorkAround.checkForPriorSell(s))
+                  s.signal = 'sell'
               } 
               else
               if (s.period.close < (lowerBound / 100) * (100 + s.options.bollinger_lower_bound_pct)   &&  nextdivergent >= divergent  && _switch == 1    && s.period.stoch_K < s.options.stoch_k_buy) 
               {
-                s.signal = 'buy'
+                if (dupOrderWorkAround.checkForPriorBuy(s)) 
+                  s.signal = 'buy'
               } 
             }
 

--- a/extensions/strategies/ta_trix/strategy.js
+++ b/extensions/strategies/ta_trix/strategy.js
@@ -3,6 +3,7 @@ var z = require('zero-fill')
   , rsi = require('../../../lib/rsi')
   , ta_trix = require('../../../lib/ta_trix')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'ta_trix',
@@ -35,7 +36,8 @@ module.exports = {
     if (!s.in_preroll && typeof s.period.overbought_rsi === 'number') {
       if (s.overbought) {
         s.overbought = false
-        s.signal = 'sell'
+        if (dupOrderWorkAround.checkForPriorSell(s)) 
+          s.signal = 'sell'
         return cb()
       }
     }
@@ -53,14 +55,14 @@ module.exports = {
         }
 
         s.trend = 'up'
-        s.signal = !s.acted_on_trend ? 'buy' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorBuy(s) ? 'buy' : null : null
       } else if (s.period.trend_trix == 'down') {
         if (s.trend !== 'down') {
           s.acted_on_trend = false
         }
 
         s.trend = 'down'
-        s.signal = !s.acted_on_trend ? 'sell' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorSell(s) ? 'sell' : null : null
       }
 
       cb()

--- a/extensions/strategies/ta_ultosc/strategy.js
+++ b/extensions/strategies/ta_ultosc/strategy.js
@@ -3,6 +3,7 @@ var z = require('zero-fill')
   , rsi = require('../../../lib/rsi')
   , ultosc = require('../../../lib/ta_ultosc')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'ta_ultosc',
@@ -94,14 +95,14 @@ module.exports = {
         }
 
         s.trend = 'up'
-        s.signal = !s.acted_on_trend ? 'buy' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorBuy(s) ? 'buy' : null : null
       } else if (s.period.trend_ultosc == 'down') {
         if (s.trend !== 'down') {
           s.acted_on_trend = false
         }
 
         s.trend = 'down'
-        s.signal = !s.acted_on_trend ? 'sell' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorSell(s) ? 'sell' : null : null
       }
 
       cb()

--- a/extensions/strategies/ti_bollinger/strategy.js
+++ b/extensions/strategies/ti_bollinger/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , tulip_bollinger = require('../../../lib/ti_bollinger')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'ti_bollinger',
@@ -37,10 +38,13 @@ module.exports = {
           let lowerBound = (bollinger.LowerBand / 100) * (100 + s.options.bollinger_lower_bound_pct)
           s.signal = null // hold
           if (s.period.close < lowerBound ) {
-            s.signal = 'buy'
+            if (dupOrderWorkAround.checkForPriorBuy(s)) 
+              s.signal = 'buy'
+
           } 
           if (s.period.close > upperBound ) {
-            s.signal = 'sell'
+            if (dupOrderWorkAround.checkForPriorSell(s)) 
+              s.signal = 'sell'
           } 
 
 

--- a/extensions/strategies/ti_hma/strategy.js
+++ b/extensions/strategies/ti_hma/strategy.js
@@ -3,6 +3,7 @@ var z = require('zero-fill')
   , rsi = require('../../../lib/rsi')
   , ti_hma = require('../../../lib/ti_hma')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'ti_hma',
@@ -53,14 +54,14 @@ module.exports = {
           s.acted_on_trend = false
         }
         s.trend = 'up'
-        s.signal = !s.acted_on_trend ? 'buy' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorBuy(s) ?  'buy' : null : null
         s.cancel_down = false
       } else if (!s.cancel_down && s.period.trend_hma_rate < 0) {
         if (s.trend !== 'down') {
           s.acted_on_trend = false
         }
         s.trend = 'down'
-        s.signal = !s.acted_on_trend ? 'sell' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorSell(s) ? 'sell': null : null
       }
 
       cb()

--- a/extensions/strategies/ti_stoch/strategy.js
+++ b/extensions/strategies/ti_stoch/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , tulip_stoch = require('../../../lib/ti_stoch')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'ti_stoch',
@@ -46,12 +47,14 @@ module.exports = {
         {
           if (_switch == -1 && s.period.srsi_K > s.options.stoch_k_sell) 
           {
-            s.signal = 'sell'
+            if (dupOrderWorkAround.checkForPriorSell(s))
+              s.signal = 'sell'
           } 
           else
           if (  nextdivergent >= divergent  && _switch == 1    && s.period.srsi_K < s.options.stoch_k_buy) 
           {
-            s.signal = 'buy'
+            if (dupOrderWorkAround.checkForPriorBuy(s)) 
+              s.signal = 'buy'
           } 
          
         }

--- a/extensions/strategies/ti_stoch_bollinger/strategy.js
+++ b/extensions/strategies/ti_stoch_bollinger/strategy.js
@@ -3,6 +3,8 @@ let z = require('zero-fill')
   , ti_stoch = require('../../../lib/ti_stoch')
   , ti_bollinger = require('../../../lib/ti_bollinger')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
+
 module.exports = {
   name: 'ti_stoch_bollinger',
   description: 'Stochastic BollingerBand Strategy',
@@ -71,12 +73,14 @@ module.exports = {
             {
               if (s.period.close >= MiddleBand && s.period.close >= ((UpperBand / 100) * (100 +  s.options.bollinger_upper_bound_pct)) && nextdivergent < divergent && _switch == -1 && s.period.stoch_K > s.options.stoch_k_sell) 
               {
-                s.signal = 'sell'
+                if (dupOrderWorkAround.checkForPriorSell(s)) 
+                  s.signal = 'sell'
               } 
               else
               if (s.period.close < (LowerBand / 100) * (100 + s.options.bollinger_lower_bound_pct)   &&  nextdivergent >= divergent  && _switch == 1    && s.period.stoch_K < s.options.stoch_k_buy) 
               {
-                s.signal = 'buy'
+                if (dupOrderWorkAround.checkForPriorBuy(s)) 
+                  s.signal = 'buy'
               } 
              
             }

--- a/extensions/strategies/trend_bollinger/strategy.js
+++ b/extensions/strategies/trend_bollinger/strategy.js
@@ -2,6 +2,7 @@ var z = require('zero-fill')
   , n = require('numbro')
   , bollinger = require('../../../lib/bollinger')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'trend_bollinger',
@@ -53,10 +54,12 @@ module.exports = {
         s.last_hit_close = s.period.close
 
         if (s.trend === 'down') {
-          s.signal = 'sell'
+          if (dupOrderWorkAround.checkForPriorSell(s))
+            s.signal = 'sell'
           s.trend = null
         } else if (s.trend === 'up') {
-          s.signal = 'buy'
+          if (dupOrderWorkAround.checkForPriorBuy(s)) 
+            s.signal = 'buy'
           s.trend = null
         }
       }

--- a/extensions/strategies/trend_ema/strategy.js
+++ b/extensions/strategies/trend_ema/strategy.js
@@ -4,6 +4,7 @@ var z = require('zero-fill')
   , rsi = require('../../../lib/rsi')
   , stddev = require('../../../lib/stddev')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround')
 
 module.exports = {
   name: 'trend_ema',
@@ -57,14 +58,14 @@ module.exports = {
           s.acted_on_trend = false
         }
         s.trend = 'up'
-        s.signal = !s.acted_on_trend ? 'buy' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorBuy(s) ? 'buy' : null : null
         s.cancel_down = false
       } else if (!s.cancel_down && s.period.trend_ema_rate < (s.period.trend_ema_stddev * -1)) {
         if (s.trend !== 'down') {
           s.acted_on_trend = false
         }
         s.trend = 'down'
-        s.signal = !s.acted_on_trend ? 'sell' : null
+        s.signal = !s.acted_on_trend ? dupOrderWorkAround.checkForPriorSell(s) ? 'sell' : null : null
       }
     }
     cb()

--- a/extensions/strategies/trendline/strategy.js
+++ b/extensions/strategies/trendline/strategy.js
@@ -5,6 +5,7 @@ let math = require('mathjs')
   , stats = require('stats-lite')
   , ema = require('../../../lib/ema')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 var oldgrowth = 1
 
 module.exports = {
@@ -73,7 +74,8 @@ module.exports = {
          s.growth2 === true
     )
     {
-      s.signal = 'buy'
+      if (dupOrderWorkAround.checkForPriorBuy(s)) 
+        s.signal = 'buy'
     }
     else if (
       s.growth === false |
@@ -81,7 +83,10 @@ module.exports = {
          s.accel === false
     )
     {
-      //s.signal = 'sell'
+      //This is commented still even though I added the sell check, not sure why it is commented as the stratagy would never sell only buy.  
+      //may be a typo but I havn't checked the function of this stratagy for find out.  --Station
+      //if (dupOrderWorkAround.checkForPriorSell(s)) 
+      //  s.signal = 'sell'
     }
     cb()
   },

--- a/extensions/strategies/trust_distrust/strategy.js
+++ b/extensions/strategies/trust_distrust/strategy.js
@@ -1,6 +1,7 @@
 var z = require('zero-fill')
   , n = require('numbro')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'trust_distrust',
@@ -59,7 +60,9 @@ module.exports = {
     if (s.trust_distrust_last_action !== 'sell') {
       if ( s.period.high > (s.trust_distrust_start + (s.trust_distrust_start / 100 * s.options.sell_min))) { // we are above minimum we want to sell for, or going so low we should "panic sell"
         if (s.period.high < (s.trust_distrust_highest - (s.trust_distrust_highest / 100 * s.options.sell_threshold))) { // we lost sell_threshold from highest point
-          s.signal = 'sell'
+         
+          if (dupOrderWorkAround.checkForPriorSell(s))
+            s.signal = 'sell'
 
           s.trust_distrust_last_action = 'sell'
           s.trust_distrust_start = s.period.high
@@ -71,7 +74,8 @@ module.exports = {
       }
 
       if (s.options.sell_threshold_max > 0 && s.period.high < (s.trust_distrust_highest - (s.trust_distrust_highest / 100 * s.options.sell_threshold_max))) { // we panic sell
-        s.signal = 'sell'
+        if (dupOrderWorkAround.checkForPriorSell(s))
+          s.signal = 'sell'
 
         s.trust_distrust_last_action = 'sell'
         s.trust_distrust_start = s.period.high
@@ -83,7 +87,8 @@ module.exports = {
     }
 
     if (s.options.greed > 0 && s.period.high > (s.trust_distrust_start_greed + (s.trust_distrust_start_greed / 100 * s.options.greed))) { // we are not greedy, sell if this profit is reached
-      s.signal = 'sell'
+      if (dupOrderWorkAround.checkForPriorSell(s))
+        s.signal = 'sell'
 
       s.trust_distrust_last_action = 'sell'
       s.trust_distrust_start = s.period.high
@@ -102,7 +107,8 @@ module.exports = {
           return cb()
         }
         s.trust_distrust_buy_threshold_max = 0
-        s.signal = 'buy'
+        if (dupOrderWorkAround.checkForPriorBuy(s))
+          s.signal = 'buy'
 
         s.trust_distrust_last_action = 'buy'
         s.trust_distrust_start = s.period.high

--- a/extensions/strategies/wavetrend/strategy.js
+++ b/extensions/strategies/wavetrend/strategy.js
@@ -3,6 +3,7 @@ var z = require('zero-fill')
   , wto = require('../../../lib/wto')
   , ema = require('../../../lib/ema')
   , Phenotypes = require('../../../lib/phenotype')
+  , dupOrderWorkAround = require('../../../lib/duporderworkaround') 
 
 module.exports = {
   name: 'wavetrend',
@@ -54,7 +55,8 @@ module.exports = {
             //console.log('\n')
             //console.log(s.period.hcl3, s.period.wto, s.lookback[0].wto, s.buy_signal_close)
             //console.log('trend reversal, we should sell')
-            s.signal = 'sell'
+            if (dupOrderWorkAround.checkForPriorSell(s)) 
+              s.signal = 'sell'
             s.sell_signal_close = s.period.close
           }
           s.trend = 'up'
@@ -64,7 +66,8 @@ module.exports = {
             //console.log('\n')
             //console.log(s.period.hcl3, s.period.wto, s.lookback[0].wto, s.sell_signal_close)
             //console.log('trend reversal, we should buy')
-            s.signal = 'buy'
+            if (dupOrderWorkAround.checkForPriorBuy(s)) 
+              s.signal = 'buy'
             s.buy_signal_close = s.period.close
           }
           s.trend = 'down'
@@ -78,7 +81,8 @@ module.exports = {
           //console.log('trend reversal, we should sell')
           if (prev_wto > wto && prev_hcl3 > hcl3 && prev_ema > ema) {
             if (s.trend === 'down' && s.buy_signal_close < s.period.close) {
-              s.signal = 'sell'
+              if (dupOrderWorkAround.checkForPriorSell(s)) 
+                s.signal = 'sell'
               s.sell_signal_close = s.period.close
             }
             s.trend = 'up'
@@ -91,7 +95,8 @@ module.exports = {
           //console.log('trend reversal, we should buy')
           if (prev_wto < wto && prev_hcl3 < hcl3 && prev_ema < ema) {
             if (s.trend === 'up' && s.sell_signal_close > s.period.close) {
-              s.signal = 'buy'
+              if (dupOrderWorkAround.checkForPriorBuy(s)) 
+                s.signal = 'buy'
               s.buy_signal_close = s.period.close
             }
             s.trend = 'down'
@@ -104,7 +109,8 @@ module.exports = {
           //console.log('trend reversal, we should sell')
           if (prev_wto > wto && prev_hcl3 > hcl3 && prev_ema > ema) {
             if (s.trend === 'down' && s.buy_signal_close < s.period.close) {
-              s.signal = 'sell'
+              if (dupOrderWorkAround.checkForPriorSell(s)) 
+                s.signal = 'sell'
               s.sell_signal_close = s.period.close
             }
             s.trend = 'up'
@@ -117,7 +123,8 @@ module.exports = {
           //console.log('trend reversal, we should buy')
           if (prev_wto < wto && prev_hcl3 < hcl3 && prev_ema < ema) {
             if (s.trend === 'up' && s.sell_signal_close > s.period.close) {
-              s.signal = 'buy'
+              if (dupOrderWorkAround.checkForPriorBuy(s)) 
+                s.signal = 'buy'
               s.buy_signal_close = s.period.close
             }
             s.trend = 'down'
@@ -131,7 +138,8 @@ module.exports = {
               //console.log('\n')
               //console.log(s.period.hcl3, s.period.wto, s.lookback[0].wto, s.buy_signal_close)
               //console.log('trend reversal, we should sell')
-              s.signal = 'sell'
+              if (dupOrderWorkAround.checkForPriorSell(s)) 
+                s.signal = 'sell'
               s.sell_signal_close = s.period.close
             }
             s.trend = 'up'
@@ -141,7 +149,8 @@ module.exports = {
               //console.log('\n')
               //console.log(s.period.hcl3, s.period.wto, s.lookback[0].wto, s.sell_signal_close)
               //console.log('trend reversal, we should buy')
-              s.signal = 'buy'
+              if (dupOrderWorkAround.checkForPriorBuy(s)) 
+                s.signal = 'buy'
               s.buy_signal_close = s.period.close
             }
             s.trend = 'down'

--- a/lib/duporderworkaround.js
+++ b/lib/duporderworkaround.js
@@ -1,0 +1,8 @@
+module.exports = {
+  checkForPriorSell: function (s) {
+    return !s.api_order || (s.api_order && s.api_order.tradetype != 'sell' && s.api_order.status != 'open') || (s.api_order && s.api_order.tradetype == 'sell' && s.api_order.status == 'done')
+  },
+  checkForPriorBuy:  function (s) {
+    return !s.api_order || (s.api_order && s.api_order.tradetype != 'buy' && s.api_order.status != 'open') || (s.api_order && s.api_order.tradetype == 'buy' && s.api_order.status == 'done')
+  }
+}


### PR DESCRIPTION
There is currently a bug in the engine that allows for a buy to occur when a buy is already active or a sell to occur when  a sell is already active causing 2 orders to be be active on the exchange these functions check for this condition and return true or false if this condition exists.  see #1629

This doesn't correct the core problem in the engine, but will stop any strategy from triggering the possibility of the condition.