### PR TITLE
Update strategy.js

### DIFF
--- a/extensions/strategies/rsi/strategy.js
+++ b/extensions/strategies/rsi/strategy.js
@@ -38,6 +38,10 @@ module.exports = {
           s.rsi_high = s.period.rsi
         }
       }
+      if (s.trend !== 'oversold' && s.trend !== 'long' && s.period.rsi >= s.options.overbought_rsi) {
+        s.rsi_high = s.period.rsi
+        s.trend = 'long'
+      }
       if (s.trend === 'long') {
         s.rsi_high = Math.max(s.rsi_high, s.period.rsi)
         if (s.period.rsi <= s.rsi_high / s.options.rsi_divisor) {
@@ -66,6 +70,9 @@ module.exports = {
       var color = 'grey'
       if (s.period.rsi <= s.options.oversold_rsi) {
         color = 'green'
+      }
+      if (s.period.rsi >= s.options.overbought_rsi) {
+        color = 'red'
       }
       cols.push(z(4, n(s.period.rsi).format('0'), ' ')[color])
     }

--- a/extensions/strategies/rsi/strategy.js
+++ b/extensions/strategies/rsi/strategy.js
@@ -38,7 +38,7 @@ module.exports = {
           s.rsi_high = s.period.rsi
         }
       }
-      if (s.trend !== 'oversold' && s.trend !== 'long' && s.period.rsi >= s.options.overbought_rsi) {
+      if (s.trend !== 'overbought' && s.trend !== 'short' && s.period.rsi >= s.options.overbought_rsi) {
         s.rsi_high = s.period.rsi
         s.trend = 'long'
       }


### PR DESCRIPTION
Added overbought parameters to trade with crypto assets directly (the original code works fine if starts with FIAT, but not with asset) and use red color to mark RSI with red (sell signal). Tested and works fine.