### PR TITLE
Added database to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ gen.*.bat
 gen.*.sh
 .env
 scripts/auto_backtester/backtesting_*.csv
+database/*


### PR DESCRIPTION
The directory `app/database` should not be included in the git repo. This commit adds it to the `.gitignore` file.