### PR TITLE
Fix issue #1664: Error 'Invalid end time.' on Poloniex

### DIFF
--- a/extensions/exchanges/poloniex/exchange.js
+++ b/extensions/exchanges/poloniex/exchange.js
@@ -60,11 +60,11 @@ module.exports = function container (conf) {
       }
       if (args.start && !args.end) {
         // add 12 hours
-        args.end = args.start + opts.offset
+        args.end = args.start + (opts.offset || this.offset)
       }
       else if (args.end && !args.start) {
         // subtract 12 hours
-        args.start = args.end - opts.offset
+        args.start = args.end - (opts.offset || this.offset)
       }
 
       client._public('returnTradeHistory', args, function (err, body) {


### PR DESCRIPTION
For some reason the opts.offset is void, so I patched the code to use the default value in these cases.